### PR TITLE
Paar aanpassingen

### DIFF
--- a/docs/meedoen/als-designer/community.md
+++ b/docs/meedoen/als-designer/community.md
@@ -15,9 +15,9 @@ keywords:
 
 # Community voor designers
 
-Je kunt als designer meekijken met andere projecten, onderzoek lezen, meepraten op Slack en inzichten uitwisselen in de periodieke designer meeting.
+Je kunt als designer meekijken met andere projecten, onderzoek lezen en meepraten op Slack. Registreer je bij de [Code for NL Slack](https://praatmee.codefor.nl) en 'join' de kanalen: `#nl-design-system` en `#nl-design-system-designers`.
 
-Registreer je bij de [Code for NL Slack](https://praatmee.codefor.nl) en join de volgende kanalen: `#nl-design-system` en `#nl-design-system-designers`.
+Daarnaast ben je van harte welkom bij de 'Design open hour' meeting. Hier wisselen designers informatie en inzichten met elkaar uit. De meeting is om de week op dinsdag om 13:00. [Neem contact op met het kernteam](../../project/contact.mdx) en we nodigen je uit.
 
 ## Design system projecten
 
@@ -26,14 +26,27 @@ Neem eens een kijkje in de keuken bij andere teams:
 - [Amsterdam Design System in Figma](https://www.figma.com/file/ORa7CBIooPgZj6HsEPBxNR/)
 - [Buren in Figma](https://www.figma.com/file/dBzv9dd3GRFLtxzCKWq9uU/)
 - [Den Haag Design System in Figma](https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/)
+- [Gemeente Haarlem / Gemeente Zandvoort in Figma](https://www.figma.com/file/yNP20OJZKRG3dW5dmDtyM9/)
 - [Provincie Zuid-Holland](https://www.figma.com/file/pWIiNmzPDwYtPbYOQevpm1/)
 - [Rijksdienst voor Ondernemend Nederland (RVO) in Figma](https://www.figma.com/file/NHV1JYxJ28vKZInSI9u200/)
 - [Rotterdam Design System in Figma](https://www.figma.com/file/ZWSC4gCrOXRUR9UX3aoZ8x/)
 - [Utrecht Design System in Figma](https://www.figma.com/file/msb3CfQBefPoruqNQ968Zh/)
 
-De volgende Figma projecten hebben wel mooi spul, maar zijn nog niet publiek. Neem contact met de auteurs als je toegang nodig hebt.
 
-- [Gemeente Haarlem / Gemeente Zandvoort om Figma](https://www.figma.com/file/yNP20OJZKRG3dW5dmDtyM9/)
+De volgende Figma projecten zijn nog niet openbaar. Neem contact met de auteurs als je toegang nodig hebt.
+
 - Mijn Overheid in Figma
 
-We krijgen vaak de vraag of [Rijkshuisstijl](https://www.rijkshuisstijl.nl) ook een Figma-bibliotheek heeft. Begin 2023 was er nog Figma bibliotheek voor Rijkshuisstijl. We willen op veler verzoek wel mogelijk maken dat de Figma library van NL Design System gebruikt kan worden met design tokens van Rijkshuisstijl, maar daar heeft het kernteam op dit moment nog geen tijd voor. Wil je helpen om dit mogelijk te maken, neem dan contact op!
+## Rijkshuisstijl in Figma
+
+We krijgen vaak de vraag of [Rijkshuisstijl](https://www.rijkshuisstijl.nl) ook een Figma-bibliotheek heeft. Momenteel is deze er nog niet. We willen het wel mogelijk maken dat de [NL Design System Figma bibliotheek](figma-structuur.mdx#nl-design-system-bibliotheek) gebruikt kan worden met design tokens van Rijkshuisstijl. Maar daar heeft het kernteam op dit moment nog geen tijd voor. Wil je helpen om dit mogelijk te maken, [neem contact op met het kernteam](../../project/contact.mdx).
+
+---
+
+## Help deze documentatie te verbeteren
+
+Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun je een wijziging voorstellen via Github.
+
+## Vragen
+
+Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/contact.mdx).


### PR DESCRIPTION
- Slack info direct achter Slack aankondiging
- Design open hour meeting apart met wat extra info
- Gemeente Haarlem en Zandvoort blijkt wel openbaar dus opgenomen in de lijst
- 'Mooi spul' weggelaten
- Rijkshuisstijl als aparte sectie met linkje naar Figma structuur
- Herbruikbare content-footer toegevoegd