### PR TITLE
docs: update coreteam details

### DIFF
--- a/docs/project/contact.mdx
+++ b/docs/project/contact.mdx
@@ -27,8 +27,9 @@ Je kunt ook je vraag stellen in het [#nl-design-system Slack kanaal](https://pra
 Je kunt natuurlijk ook contact opnemen een of meerdere kernteam leden:
 
 - Projectleider Peter Berrevoets: [peter.berrevoets@ictu.nl](mailto:peter.berrevoets@ictu.nl) of [@Peter Berrevoets op Slack](https://praatmee.codefor.nl)
-- Lead developer Robbert Broersma: [robbert.broersma@ictu.nl](mailto:robbert.broersma@ictu.nl) of [@Robbert op Slack](https://praatmee.codefor.nl)
-- Front-end developer Yolijn van der Kolk: [yolijn.vanderkolk@ictu.nl](mailto:yolijn.vanderkolk@ictu.nl) of [@Yolijn op Slack](https://praatmee.codefor.nl)
+- Tech lead Robbert Broersma: [robbert.broersma@ictu.nl](mailto:robbert.broersma@ictu.nl) of [@Robbert op Slack](https://praatmee.codefor.nl)
+- Developer Yolijn van der Kolk: [yolijn.vanderkolk@ictu.nl](mailto:yolijn.vanderkolk@ictu.nl) of [@Yolijn op Slack](https://praatmee.codefor.nl)
 - UX designer Jeffrey Lauwers: [jeffrey.lauwers@ictu.nl](mailto:jeffrey.lauwers@ictu.nl) of [@Jeffrey op Slack](https://praatmee.codefor.nl)
+- Developer Andrea Busse: [andrea.busse@ictu.nl](mailto:andrea.busse@ictu.nl) of [@Andrea Busse op Slack](https://praatmee.codefor.nl)
 
 <CoreTeam />

--- a/src/components/CoreTeam.tsx
+++ b/src/components/CoreTeam.tsx
@@ -55,7 +55,6 @@ export const CoreTeam = () => {
       <Robbert />
       <Yolijn />
       <Jeffrey />
-      <Andrea />
     </div>
   );
 };

--- a/src/components/CoreTeam.tsx
+++ b/src/components/CoreTeam.tsx
@@ -6,9 +6,8 @@ export const Peter = () => (
   <img
     alt="Avatar van Peter"
     className={clsx(style['core-team__avatar'])}
-    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam-peter-mvp.svg"
+    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam-peter.png"
     title="Peter - Projectleider"
-    style={{ maxHeight: '210px', height: '210px' }}
   />
 );
 
@@ -39,6 +38,15 @@ export const Jeffrey = () => (
   />
 );
 
+export const Andrea = () => (
+  <img
+    alt="Avatar van Andrea"
+    className={clsx(style['core-team__avatar'])}
+    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_andrea-mvp.svg"
+    title="Andrea - Developer"
+  />
+);
+
 export const CoreTeam = () => {
   return (
     <div className={clsx(style['core-team'])}>
@@ -46,6 +54,7 @@ export const CoreTeam = () => {
       <Robbert />
       <Yolijn />
       <Jeffrey />
+      <Andrea />
     </div>
   );
 };

--- a/src/components/CoreTeam.tsx
+++ b/src/components/CoreTeam.tsx
@@ -15,7 +15,7 @@ export const Robbert = () => (
   <img
     alt="Avatar van Robbert"
     className={clsx(style['core-team__avatar'])}
-    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_robbert.png"
+    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_robbert.svg"
     title="Robbert - Techlead"
   />
 );
@@ -24,8 +24,9 @@ export const Yolijn = () => (
   <img
     alt="Avatar van Yolijn"
     className={clsx(style['core-team__avatar'])}
-    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_yolijn.png"
+    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_yolijn.svg"
     title="Yolijn - Developer"
+    style={{ maxHeight: '190px' }}
   />
 );
 
@@ -33,7 +34,7 @@ export const Jeffrey = () => (
   <img
     alt="Avatar van Jeffrey"
     className={clsx(style['core-team__avatar'])}
-    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_jeffrey.png"
+    src="https://raw.githubusercontent.com/nl-design-system/documentatie/assets/kernteam_jeffrey.svg"
     title="Jeffrey - UX Designer"
   />
 );


### PR DESCRIPTION
Met gebruik van de `svg` bestanden huidskleur en maat van de avatars wat aangepast. Voor Andrea een MVP avatar toegevoegd en voor Peter alleen nog een png. 

<img width="682" alt="Screenshot 2023-02-19 at 11 03 47" src="https://user-images.githubusercontent.com/877246/219941373-eba4c1a8-4268-4ebe-8aa5-3d87aea67a75.png">
⬇

<img width="720" alt="Screenshot 2023-02-20 at 00 01 32" src="https://user-images.githubusercontent.com/877246/219980566-cdbef404-eaab-4c05-9d63-ed0778857129.png">
