### PR TITLE
docs: improve homepage pitch

### DIFF
--- a/docs/videos/heartbeat.mdx
+++ b/docs/videos/heartbeat.mdx
@@ -15,6 +15,18 @@ Sinds kort nemen we elke sessie op. Hieronder maken we deze sessies beschikbaar 
 
 Wil je er (online) bij zijn, heb je vragen of wil je zelf iets vertellen of presenteren tijdens een van de heartbeats? Stuur ons dan een mailtje op <a href="mailto:NLDesignSystem@gebruikercentraal.nl">NLDesignSystem@gebruikercentraal.nl</a>
 
+## 27 juni 2023
+
+Jeroen Visser vertelt over hoe 1Overheid met Figma direct verbinding heeft gemaakt met de front-end, via een NL Design System thema. Experiment geslaagd!
+
+Rida el Mazouji vertelt over zijn stageopdracht bij Frameless, waarin hij met een team van stagairs (ook Nova, Rowan en Britt) de open source website OpenCatalogi.nl (ontwikkeld door Conduction) heeft gemigreerd naar NL Design System en het Rotterdam Design System heeft aangesloten op NL Design System door een thema te maken.
+
+<VimeoPlayer
+  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230627
+"
+  controls
+/>
+
 ## 16 mei 2023
 
 Nico Druif laat zien hoe de gemeente Amsterdam het zakelijk erfpacht-portaal ontwerpt, op basis van de Figma-ontwerpen van de MijnOmgeving van de gemeente Den Haag. Binnenkort worden zelfs de herbruikbare Figma componenten van het NL Design System gebruikt, in combinatie met de design tokens van de huisstijl de gemeente Amsterdam.

--- a/packages/nlds-design-tokens/src/tokens.json
+++ b/packages/nlds-design-tokens/src/tokens.json
@@ -303,7 +303,7 @@
       "color": { "value": "{utrecht.page-footer.color}" },
       "link": {
         "hover": {
-          "color": { "value": "{ifm.footer.color}" }
+          "color": { "value": "{utrecht.link.color}" }
         }
       }
     },
@@ -315,7 +315,8 @@
       "base": { "value": "{utrecht.document.font-family}" }
     },
     "link": {
-      "color": { "value": "{ifm.color.primary}" }
+      "color": { "value": "{ifm.color.primary}" },
+      "decoration": { "value": "underline" }
     },
     "button": {
       "color": { "value": "{utrecht.button.color}" },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,16 +25,20 @@ export default function Home() {
       wrapperClassName="marketing-page"
     >
       <main>
-        <HomepageHero title="NL Design System" ctaLink="meedoen/introductie" cta="Lees alles over het NL Design System">
+        <HomepageHero title="NL Design System" ctaLink="meedoen/introductie" cta="Lees meer over het NL Design System">
           <Paragraph lead>
-            Dienstverlening vanuit de overheid moet toegankelijk en begrijpelijk zijn voor iedereen.
+            Samen maken we de digitale dienstverlening van de overheid toegankelijk, inclusief en gebruiksvriendelijk.
           </Paragraph>
           <Paragraph>
-            NL Design System architectuur zorgt ervoor dat verschillende organisaties samenwerken aan toegankelijkheid
-            en gebruiksvriendelijkheid. Terwijl iedereen vrijheid heeft voor een eigen huisstijl en eigen technologieën.
+            Een design system lijkt op basis van de naam vooral over ontwerp te gaan, maar het is eigenlijk een brede
+            aanpak om makkelijker consistente, toegankelijke en gebruiksvriendelijke websites en applicaties te maken.
+          </Paragraph>
+          <Paragraph>
+            Dat doet het kernteam niet alleen, maar samen met ontwerpers, ontwikkelaars, content schrijvers en andere
+            experts uit verschillende organisaties.
           </Paragraph>
           <UnorderedList>
-            <UnorderedListItem>Gevoed met kennis vanuit de community</UnorderedListItem>
+            <UnorderedListItem>Gebouwd en gebruikt door de community</UnorderedListItem>
             <UnorderedListItem>Platform en huisstijl onafhankelijk</UnorderedListItem>
             <UnorderedListItem>Uitbreidbaar en publiek beschikbaar</UnorderedListItem>
           </UnorderedList>


### PR DESCRIPTION
Op basis van de tekst zoals gebruikt voor CX-community een versie van de homepage pitch die duidelijker uitlegt wat een design system (en NL Design System) is.

Van
<img width="903" alt="Screenshot 2023-06-27 at 00 15 12" src="https://github.com/nl-design-system/documentatie/assets/877246/a3c834f4-33d1-4220-bad0-cd68af0a49c8">

**Naar**

De lead paragraph is hetzelfde als op de NL Design System banner, de tekst zoals naar de CX community (behalve het aantal deelnemers in de community)

<img width="842" alt="Screenshot 2023-06-27 at 00 38 54" src="https://github.com/nl-design-system/documentatie/assets/877246/bb5c4618-fe03-4ead-8984-cd0559181e14">
