### PR TITLE
refactor: Tweak URLs of footer links

### DIFF
--- a/docs/footer/colofon.mdx
+++ b/docs/footer/colofon.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 sidebar_label: Colofon
 pagination_label: Colofon
 description: Colofon - opsomming van de manier waarop deze website tot stand is gekomen
+slug: /colofon
 ---
 
 # Colofon

--- a/docs/footer/toegankelijkheidsverklaring.md
+++ b/docs/footer/toegankelijkheidsverklaring.md
@@ -3,6 +3,7 @@ title: Toegankelijkheid
 hide_title: true
 hide_table_of_contents: false
 pagination_label: Toegankelijkheid
+slug: /toegankelijkheidsverklaring
 ---
 
 # Toegankelijkheid

--- a/footerConfig.js
+++ b/footerConfig.js
@@ -9,11 +9,11 @@ module.exports = {
         },
         {
           label: 'Toegankelijkheid',
-          to: '/footer/toegankelijkheidsverklaring',
+          to: '/toegankelijkheidsverklaring',
         },
         {
           label: 'Colofon',
-          to: '/footer/colofon',
+          to: '/colofon',
         },
         {
           label: 'GitHub',

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,2 +1,0 @@
-Redirect 301 /footer/toegankelijkheidsverklaring /toegankelijkheidsverklaring
-Redirect 301 /footer/colofon /colofon

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,2 @@
+Redirect 301 /footer/toegankelijkheidsverklaring /toegankelijkheidsverklaring
+Redirect 301 /footer/colofon /colofon


### PR DESCRIPTION
Hoi! Dit is meer “Hidde wil wat meer familiar met de codebase van deze site worden” dan strikt noodzakelijk (dus voel vrij te rejecten), maar zag 'footer' in de URLs van footerlinkjes en heb die eruit gehaald. 

De htaccess voor doorsturen lijkt niets te doen (lokaal niet, maar ook niet in de Vercel preview); is er een go-to manier voor dit soort sites die ik heb gemist?