### PR TITLE
Kondig Design Systems Week aan en link naar aanmeldformulier

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -75,6 +75,14 @@ const config = {
       searchPagePath: 'search',
       //... other Algolia params
     },
+    announcementBar: {
+      id: 'dsw_announcement',
+      content:
+        'Design Systems Week 2023 komt eraan! <a target="_blank" rel="noopener noreferrer" href="https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking">Meld je aan</a> of <a href="https://gebruikercentraal.nl/design-systems-week">bekijk de sessies tot nu toe</a>',
+      backgroundColor: '#DEFF00',
+      textColor: '#000',
+      isCloseable: false,
+    },
   },
   i18n: {
     defaultLocale: 'nl',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,9 +78,9 @@ const config = {
     announcementBar: {
       id: 'dsw_announcement',
       content:
-        'Design Systems Week 2023 komt eraan! <a target="_blank" rel="noopener noreferrer" href="https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking">Meld je aan</a> of <a href="https://gebruikercentraal.nl/design-systems-week">bekijk de sessies tot nu toe</a>',
-      backgroundColor: '#DEFF00',
-      textColor: '#000',
+        'Design Systems Week 2023 komt eraan! <a class="utrecht-link" target="_blank" rel="noopener noreferrer" href="https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking">Meld je aan</a> of <a class="utrecht-link" href="https://gebruikercentraal.nl/design-systems-week">bekijk de sessies tot nu toe</a>',
+      backgroundColor: '#148839',
+      textColor: '#fff',
       isCloseable: false,
     },
   },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,6 +19,13 @@
   -moz-osx-font-smoothing: auto !important;
   --ifm-container-width: 1030px;
   --ifm-container-width-xl: 1080px;
+  /* --docusaurus-announcement-bar-height: 50px; */
+}
+
+@media (min-width: 997px) {
+  .nlds-theme {
+    --docusaurus-announcement-bar-height: 40px;
+  }
 }
 
 .marketing-page {

--- a/src/theme/AnnouncementBar/CloseButton/index.tsx
+++ b/src/theme/AnnouncementBar/CloseButton/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import clsx from 'clsx';
+import { translate } from '@docusaurus/Translate';
+import IconClose from '@theme/Icon/Close';
+import type { Props } from '@theme/AnnouncementBar/CloseButton';
+import styles from './styles.module.css';
+
+export default function AnnouncementBarCloseButton(props: Props): JSX.Element | null {
+  return (
+    <button
+      type="button"
+      aria-label={translate({
+        id: 'theme.AnnouncementBar.closeButtonAriaLabel',
+        message: 'Close',
+        description: 'The ARIA label for close button of announcement bar',
+      })}
+      {...props}
+      className={clsx('clean-btn close', styles.closeButton, props.className)}
+    >
+      <IconClose width={14} height={14} strokeWidth={3.1} />
+    </button>
+  );
+}

--- a/src/theme/AnnouncementBar/CloseButton/styles.module.css
+++ b/src/theme/AnnouncementBar/CloseButton/styles.module.css
@@ -1,0 +1,4 @@
+.closeButton {
+  padding: 0;
+  line-height: 0;
+}

--- a/src/theme/AnnouncementBar/Content/index.tsx
+++ b/src/theme/AnnouncementBar/Content/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useThemeConfig } from '@docusaurus/theme-common';
+import type { Props } from '@theme/AnnouncementBar/Content';
+import styles from './styles.module.css';
+
+export default function AnnouncementBarContent(props: Props): JSX.Element | null {
+  const { announcementBar } = useThemeConfig();
+  const { content } = announcementBar!;
+  return (
+    <div
+      {...props}
+      className={clsx(styles.content, props.className)}
+      // Developer provided the HTML, so assume it's safe.
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  );
+}

--- a/src/theme/AnnouncementBar/Content/styles.module.css
+++ b/src/theme/AnnouncementBar/Content/styles.module.css
@@ -1,0 +1,11 @@
+.content {
+  font-size: 16px;
+  text-align: center;
+  padding: 8px 10px;
+  --utrecht-link-color: auto;
+}
+
+.content a {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/src/theme/AnnouncementBar/index.tsx
+++ b/src/theme/AnnouncementBar/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useThemeConfig } from '@docusaurus/theme-common';
+import { useAnnouncementBar } from '@docusaurus/theme-common/internal';
+import AnnouncementBarCloseButton from '@theme/AnnouncementBar/CloseButton';
+import AnnouncementBarContent from '@theme/AnnouncementBar/Content';
+
+import styles from './styles.module.css';
+
+export default function AnnouncementBar(): JSX.Element | null {
+  const { announcementBar } = useThemeConfig();
+  const { isActive, close } = useAnnouncementBar();
+  if (!isActive) {
+    return null;
+  }
+  const { backgroundColor, textColor, isCloseable } = announcementBar!;
+  return (
+    <div className={styles.announcementBar} style={{ backgroundColor, color: textColor }} role="banner">
+      {isCloseable && <div className={styles.announcementBarPlaceholder} />}
+      <AnnouncementBarContent className={styles.announcementBarContent} />
+      {isCloseable && <AnnouncementBarCloseButton onClick={close} className={styles.announcementBarClose} />}
+    </div>
+  );
+}

--- a/src/theme/AnnouncementBar/styles.module.css
+++ b/src/theme/AnnouncementBar/styles.module.css
@@ -1,0 +1,55 @@
+:root {
+  --docusaurus-announcement-bar-height: auto;
+}
+
+.announcementBar {
+  display: flex;
+  align-items: center;
+  height: var(--docusaurus-announcement-bar-height);
+  background-color: var(--ifm-color-white);
+  color: var(--ifm-color-black);
+
+  /*
+  Unfortunately we can't make announcement bar render above the navbar
+  IE need to use border-bottom instead of shadow
+  See https://github.com/facebookincubator/infima/issues/275
+
+  box-shadow: var(--ifm-global-shadow-lw);
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
+  */
+  border-bottom: 1px solid var(--ifm-color-emphasis-100);
+}
+
+html[data-announcement-bar-initially-dismissed="true"] .announcementBar {
+  display: none;
+}
+
+.announcementBarPlaceholder {
+  flex: 0 0 10px;
+}
+
+.announcementBarClose {
+  flex: 0 0 30px;
+  align-self: stretch;
+}
+
+.announcementBarContent {
+  flex: 1 1 auto;
+}
+
+@media print {
+  .announcementBar {
+    display: none;
+  }
+}
+
+@media (min-width: 997px) {
+  :root {
+    --docusaurus-announcement-bar-height: 30px;
+  }
+
+  .announcementBarPlaceholder,
+  .announcementBarClose {
+    flex-basis: 50px;
+  }
+}


### PR DESCRIPTION
Dit voegt de in Docusaurus ingebouwde Announcement Bar toe aan de site, met links naar Gebruiker Centraal voor overzicht van de sessies en aanmeldformulier.

**Q: Hoe zit dat er uit?**

**A: zo:**
<img width="998" alt="website met bovenin een markerkleurige bar waar in staat “Design Systems Week 2023 komt eraan! Meld je aan (link) of bekijk de sessies tot nu toe (link)" src="https://github.com/nl-design-system/documentatie/assets/178782/7052100d-298b-4232-a98d-321f453c6080">
