### PR TITLE
fix: Remove Dutch text and fix link

### DIFF
--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -10,6 +10,7 @@ slug: /events/design-systems-week-2023/en/program
 
 import DSWSession from '../../../../../src/components/DSWSession'
 import { speakers } from '../speakers.json'
+import { Link } from '@utrecht/component-library-react';
 
 <div lang="en">
 
@@ -25,9 +26,6 @@ A set of components is one thing, but the true magic comes when they are put in 
 Designer Joe Lanman is involved in this project as a designer and tells you more about it!
 
 Joe Lanman is a Design Lead at the UK Government Digital Service, based in London. He’s worked on projects including Register to Vote, Petition Parliament and the GOV.UK Prototype Kit – a way to rapidly prototype realistic services in HTML.
-Een verzameling losse componenten is 1 ding, maar het wordt pas écht interessant als ze bij elkaar komen. Zodat er een volwaardige, digitale overheidsdienst of -product ontstaat. Bij GOV.UK maken ze het makkelijker om te zien hoe zo’n dienst of product eruitziet. Daarvoor gebruiken ze de [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/).
-
-Joe Lanman is als ontwerper betrokken bij dit project en vertelt je er meer over!
 </DSWSession>
 
 <DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth">

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -54,7 +54,7 @@ In this talk, you will learn:
 
 ## Organisation
 
-Design Systems Week is organised by the NL Design System core team, thanks to the support of the Ministry of the Interior and Kingdom Relations (BZK) and <Link href="international.gebruikercentraal.nl">User Needs First</Link>. All sessions can also be found there <Link href="https://international.gebruikercentraal.nl/design-systems-week-2023/">Design Systems Week 2023</Link>
+Design Systems Week is organised by the NL Design System core team, thanks to the support of the Ministry of the Interior and Kingdom Relations (BZK) and <Link href="https://international.gebruikercentraal.nl">User Needs First</Link>. All sessions can also be found there <Link href="https://international.gebruikercentraal.nl/design-systems-week-2023/">Design Systems Week 2023</Link>
 
 ## Code of Conduct
 

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -39,7 +39,7 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 
 ## Organisation
 
-Design Systems Week is organised by the NL Design System core team, thanks to the support of the Ministry of the Interior and Kingdom Relations (BZK) and <Link href="international.gebruikercentraal.nl">User Needs First</Link>. All sessions can also be found there <Link href="https://international.gebruikercentraal.nl/design-systems-week-2023/">Design Systems Week 2023</Link>
+Design Systems Week is organised by the NL Design System core team, thanks to the support of the Ministry of the Interior and Kingdom Relations (BZK) and <Link href="https://international.gebruikercentraal.nl">User Needs First</Link>. All sessions can also be found there <Link href="https://international.gebruikercentraal.nl/design-systems-week-2023/">Design Systems Week 2023</Link>
 
 ## Code of Conduct
 


### PR DESCRIPTION
Er stond nog een stukje Nederlandse tekst, die heb ik eruit gehaald.

De link onderin renderde als `div`, heb het `Link` component geïmporteerd om het op te lossen.