### PR TITLE
Voeg Estland toe 🇪🇪

### DIFF
--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -18,7 +18,7 @@ Dit jaar hebben we nationale én internationale sprekers. We laten ons inspirere
 
 Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren ongeveer 30 minuten. [Meld je aan](https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking) voor de hele week en volg zo veel of zo weinig sessies als je wil!
 
-<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal">
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
 
 Veera is een codenaam voor een design system gebruikt door vele Estlandse overheids organisaties, als een gemeenschappelijke UI taal voor de hele Estlandse staat. Aleksandr zal het hebben over zijn eigen ervaringen en die van zijn collega's bij het opzetten, onderhouden en ondersteunen van een componenten bibliotheek als levend onderdeel van het design system.
 
@@ -26,7 +26,7 @@ Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verha
 
 </DSWSession>
 
-<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System">
+<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system#event-booking">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
 
@@ -40,7 +40,7 @@ Tijd om nu ook de meerwaarde ervan te laten zien aan managers, beslissers en adv
 
 </DSWSession>
 
-<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten">
+<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
 
 Heeft het NL Design System toegevoegde waarde voor leveranciers van overheden? En zijn er al leerzame voorbeelden van bijdragen van leveranciers die gebruikmaken van het NL Design System? Het antwoord op beide vragen: jazeker!
 
@@ -48,7 +48,7 @@ Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Desig
 
 </DSWSession>
 
-<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System">
+<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
 
 NL Design System wil de beste componenten uit de community herbruikbaar maken voor de hele overheid. Daarom hebben de componenten van het NL Design System van zichzelf geen huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘design tokens’.
 
@@ -56,13 +56,13 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
-<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel">
+<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" signupLink="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk#event-booking">
 
 In deze sessie krijg je alles te horen over Trinity, het design system van de Kamer van Koophandel (KVK) dat wordt onderhouden door Team Matrix. Tooling, context en impact komt aan de orde, maar er wordt vooral dieper in gegaan op hoe KVK omgaat met de uitdagingen rondom de adoptie van het design system door de gebruikers. Ben jij erbij? Red pill or blue pill?
 
 </DSWSession>
 
-<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System">
+<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system#event-booking">
 
 Ze zijn essentieel voor vrijwel alle digitale overheidsdiensten: formulieren. Zeker nu de Wet modernisering elektronisch bestuurlijk verkeer (WMEBV) burgers en bedrijven het recht gaat geven om elektronisch zaken te doen met de overheid. Logisch dus dat steeds meer organisaties NL Design System gebruiken voor formulieren.
 
@@ -70,7 +70,7 @@ In deze sessie vertellen ontwikkelaars Robbert Broersma en Hidde de Vries je ove
 
 </DSWSession>
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK" signupLink="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit#event-booking">
 
 Een verzameling losse componenten is 1 ding, maar het wordt pas écht interessant als ze bij elkaar komen. Zodat er een volwaardige, digitale overheidsdienst of -product ontstaat. Bij GOV.UK maken ze het makkelijker om te zien hoe zo’n dienst of product eruitziet. Daarvoor gebruiken ze de [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/).
 
@@ -78,13 +78,13 @@ Joe Lanman is als ontwerper betrokken bij dit project en vertelt je er meer over
 
 </DSWSession>
 
-<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning">
+<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning" signupLink="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system#event-booking">
 
 Hoe kan een design system helpen bij het verbeteren van toegankelijkheid, in 12 educatieve producten, die dagelijks worden gebruikt door 25 miljoen leerlingen over heel Europa? Dat is 1 van de vragen die Sanoma Learning de afgelopen tijd bezig hield. Design systems lead Daniëlle Rameau gaat je meer vertellen over hun aanpak.
 
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt#event-booking">
 
 Nord is het design system van Nordhealth, een bedrijf dat software maakt voor de gezondheidszorg. Design system lead David Darnes vertelt je in deze sessie over hoe het hen vergaat met Web Components, en hoe die ervoor zorgen dat ze Nord-componenten heel flexibel kunnen gebruiken, met allerlei verschillende technologieën.
 
@@ -94,7 +94,7 @@ Natuurlijk zijn er allerlei nuances en subtiliteiten rondom het gebruik van Web 
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub" signupLink="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams#event-booking">
 
 DesignOps (design operations) is het bindmiddel dat een designteam bij elkaar houdt. Daarnaast verbindt het design met andere disciplines binnen én buiten de eigen organisatie. Zelfs als je organisatie geen formeel DesignOps-team heeft, wordt design operations waarschijnlijk wel al door iemand bij jullie gedaan.
 

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -19,14 +19,6 @@ Dit jaar hebben we nationale én internationale sprekers. We laten ons inspirere
 
 Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren ongeveer 30 minuten. [Meld je aan](https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking) voor de hele week en volg zo veel of zo weinig sessies als je wil!
 
-<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
-
-Veera is een codenaam voor een design system gebruikt door vele Estlandse overheids organisaties, als een gemeenschappelijke UI taal voor de hele Estlandse staat. Aleksandr zal het hebben over zijn eigen ervaringen en die van zijn collega's bij het opzetten, onderhouden en ondersteunen van een componenten bibliotheek als levend onderdeel van het design system.
-
-Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verhaal van het land dat zich met trots de eerste digitale samenleving noemt over het managen van verwachtingen, het belang van DX, zelfbeheersing en naamgeving van dingen.
-
-</DSWSession>
-
 <DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system#event-booking">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
@@ -76,6 +68,14 @@ In deze sessie vertellen ontwikkelaars Robbert Broersma en Hidde de Vries je ove
 Een verzameling losse componenten is 1 ding, maar het wordt pas écht interessant als ze bij elkaar komen. Zodat er een volwaardige, digitale overheidsdienst of -product ontstaat. Bij GOV.UK maken ze het makkelijker om te zien hoe zo’n dienst of product eruitziet. Daarvoor gebruiken ze de [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/).
 
 Joe Lanman is als ontwerper betrokken bij dit project en vertelt je er meer over!
+
+</DSWSession>
+
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
+
+Veera is een codenaam voor een design system gebruikt door vele Estlandse overheids organisaties, als een gemeenschappelijke UI taal voor de hele Estlandse staat. Aleksandr zal het hebben over zijn eigen ervaringen en die van zijn collega's bij het opzetten, onderhouden en ondersteunen van een componenten bibliotheek als levend onderdeel van het design system.
+
+Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verhaal van het land dat zich met trots de eerste digitale samenleving noemt over het managen van verwachtingen, het belang van DX, zelfbeheersing en naamgeving van dingen.
 
 </DSWSession>
 

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -9,6 +9,7 @@ slug: /events/design-systems-week-2023/programma
 
 import DSWSession from "../../../../src/components/DSWSession";
 import { speakers } from "./speakers.json";
+import { Link } from '@utrecht/component-library-react';
 
 # Design Systems Week 2023
 

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -18,6 +18,14 @@ Dit jaar hebben we nationale én internationale sprekers. We laten ons inspirere
 
 Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren ongeveer 30 minuten. [Meld je aan](https://www.gebruikercentraal.nl/agenda/design-systems-week-2023/#event-booking) voor de hele week en volg zo veel of zo weinig sessies als je wil!
 
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal">
+
+Veera is een codenaam voor een design system gebruikt door vele Estlandse overheids organisaties, als een gemeenschappelijke UI taal voor de hele Estlandse staat. Aleksandr zal het hebben over zijn eigen ervaringen en die van zijn collega's bij het opzetten, onderhouden en ondersteunen van een componenten bibliotheek als levend onderdeel van het design system.
+
+Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verhaal van het land dat zich met trots de eerste digitale samenleving noemt over het managen van verwachtingen, het belang van DX, zelfbeheersing en naamgeving van dingen.
+
+</DSWSession>
+
 <DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -11,39 +11,39 @@ import { Link } from '@utrecht/component-library-react';
 
 ## maandag 2 oktober
 
-| Tijd  | Spreker                            | Onderwerp                                                                                                                                                                  | Taal |
-| :---- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Olaf Schoelink en Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | <abbr title="Nederlands">NL</abbr>   |
-| 13:00 | Martijn Rietveld - OpenGemeenten   | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | <abbr title="Nederlands">NL</abbr>   |
-| 15:00 | Jeffrey Lauwers                    | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | <abbr title="Nederlands">NL</abbr>   |
-| 16:30 | Nog aan te kondigen                | -                                                                                                                                                                          | -    |
+| Tijd  | Spreker                            | Onderwerp                                                                                                                                                                  | Taal                               |
+| :---- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Olaf Schoelink en Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | <abbr title="Nederlands">NL</abbr> |
+| 13:00 | Martijn Rietveld - OpenGemeenten   | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | <abbr title="Nederlands">NL</abbr> |
+| 15:00 | Jeffrey Lauwers                    | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | <abbr title="Nederlands">NL</abbr> |
+| 16:30 | Nog aan te kondigen                | -                                                                                                                                                                          | -                                  |
 
 ## dinsdag 3 oktober
 
-| Tijd  | Spreker                            | Onderwerp                                                                                                                                                  | Taal |
-| :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Nog aan te kondigen                | -                                                                                                                                                          | -    |
-| 11:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                        | <abbr title="Nederlands">NL</abbr>   |
-| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                       | <abbr title="Nederlands">NL</abbr>   |
-| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link> | <abbr title="Nederlands">NL</abbr>   |
+| Tijd  | Spreker                            | Onderwerp                                                                                                                                                  | Taal                               |
+| :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Nog aan te kondigen                | -                                                                                                                                                          | -                                  |
+| 11:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                        | <abbr title="Nederlands">NL</abbr> |
+| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                       | <abbr title="Nederlands">NL</abbr> |
+| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link> | <abbr title="Nederlands">NL</abbr> |
 
 ## woensdag 4 oktober
 
-| Tijd  | Spreker             | Onderwerp                                                                                                  | Taal |
-| :---- | :------------------ | :--------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Nog aan te kondigen | -                                                                                                          | -    |
-| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | <abbr title="English">EN</abbr>   |
-| 15:00 | Aleksandr Beliaev  | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/">Estonia Design System</Link> | <abbr title="English">EN</abbr> |
-| 16:30 | Nog aan te kondigen | -                                                                                                          | -    |
+| Tijd  | Spreker             | Onderwerp                                                                                                  | Taal                            |
+| :---- | :------------------ | :--------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| 11:00 | Nog aan te kondigen | -                                                                                                          | -                               |
+| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | <abbr title="English">EN</abbr> |
+| 15:00 | Aleksandr Beliaev   | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/">Estonia Design System</Link>   | <abbr title="English">EN</abbr> |
+| 16:30 | Nog aan te kondigen | -                                                                                                          | -                               |
 
 ## donderdag 5 oktober
 
-| Tijd  | Spreker                           | Onderwerp                                                                                                                                                                    | Taal |
-| :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | <abbr title="Nederlands">NL</abbr>   |
-| 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | <abbr title="English">EN</abbr>   |
+| Tijd  | Spreker                           | Onderwerp                                                                                                                                                                    | Taal                               |
+| :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | <abbr title="Nederlands">NL</abbr> |
+| 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | <abbr title="English">EN</abbr>    |
 | 15:00 | Inayaili Léon - GitHub            | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/">DesignOps: designing the API of design teams</Link>                        | <abbr title="English">EN</abbr>s   |
-| 16:30 | Nog aan te kondigen               | -                                                                                                                                                                            | -    |
+| 16:30 | Nog aan te kondigen               | -                                                                                                                                                                            | -                                  |
 
 ## Organisatie
 

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -13,9 +13,9 @@ import { Link } from '@utrecht/component-library-react';
 
 | Tijd  | Spreker                            | Onderwerp                                                                                                                                                                  | Taal |
 | :---- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Olaf Schoelink en Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | NL   |
-| 13:00 | Martijn Rietveld - OpenGemeenten   | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | NL   |
-| 15:00 | Jeffrey Lauwers                    | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | NL   |
+| 11:00 | Olaf Schoelink en Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | <abbr title="Nederlands">NL</abbr>   |
+| 13:00 | Martijn Rietveld - OpenGemeenten   | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | <abbr title="Nederlands">NL</abbr>   |
+| 15:00 | Jeffrey Lauwers                    | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | <abbr title="Nederlands">NL</abbr>   |
 | 16:30 | Nog aan te kondigen                | -                                                                                                                                                                          | -    |
 
 ## dinsdag 3 oktober
@@ -23,26 +23,26 @@ import { Link } from '@utrecht/component-library-react';
 | Tijd  | Spreker                            | Onderwerp                                                                                                                                                  | Taal |
 | :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
 | 11:00 | Nog aan te kondigen                | -                                                                                                                                                          | -    |
-| 11:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                        | NL   |
-| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                       | NL   |
-| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link> | NL   |
+| 11:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                        | <abbr title="Nederlands">NL</abbr>   |
+| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                       | <abbr title="Nederlands">NL</abbr>   |
+| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link> | <abbr title="Nederlands">NL</abbr>   |
 
 ## woensdag 4 oktober
 
 | Tijd  | Spreker             | Onderwerp                                                                                                  | Taal |
 | :---- | :------------------ | :--------------------------------------------------------------------------------------------------------- | ---- |
 | 11:00 | Nog aan te kondigen | -                                                                                                          | -    |
-| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | EN   |
-| 15:00 | Nog aan te kondigen | -                                                                                                          | -    |
+| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | <abbr title="English">EN</abbr>   |
+| 15:00 | Aleksandr Beliaev  | Estonia Design System | <abbr title="English">EN</abbr> |
 | 16:30 | Nog aan te kondigen | -                                                                                                          | -    |
 
 ## donderdag 5 oktober
 
 | Tijd  | Spreker                           | Onderwerp                                                                                                                                                                    | Taal |
 | :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
-| 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | NL   |
-| 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | EN   |
-| 15:00 | Inayaili Léon - GitHub            | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/">DesignOps: designing the API of design teams</Link>                        | EN   |
+| 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | <abbr title="Nederlands">NL</abbr>   |
+| 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | <abbr title="English">EN</abbr>   |
+| 15:00 | Inayaili Léon - GitHub            | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/">DesignOps: designing the API of design teams</Link>                        | <abbr title="English">EN</abbr>s   |
 | 16:30 | Nog aan te kondigen               | -                                                                                                                                                                            | -    |
 
 ## Organisatie

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -33,7 +33,7 @@ import { Link } from '@utrecht/component-library-react';
 | :---- | :------------------ | :--------------------------------------------------------------------------------------------------------- | ---- |
 | 11:00 | Nog aan te kondigen | -                                                                                                          | -    |
 | 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | <abbr title="English">EN</abbr>   |
-| 15:00 | Aleksandr Beliaev  | Estonia Design System | <abbr title="English">EN</abbr> |
+| 15:00 | Aleksandr Beliaev  | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/">Estonia Design System</Link> | <abbr title="English">EN</abbr> |
 | 16:30 | Nog aan te kondigen | -                                                                                                          | -    |
 
 ## donderdag 5 oktober

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -28,7 +28,7 @@ Designer Joe Lanman is involved in this project as a designer and tells you more
 Joe Lanman is a Design Lead at the UK Government Digital Service, based in London. He’s worked on projects including Register to Vote, Petition Parliament and the GOV.UK Prototype Kit – a way to rapidly prototype realistic services in HTML.
 </DSWSession>
 
-<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
+<DSWSession lang="en" title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
 
 Veera is a codename for a design system employed by many Estonian governmental agencies as a common UI language for the state of Estonia. Aleksandr will be talking about his and his colleagues' experiences setting up, maintaining, and supporting a component library that makes this design system breathe.
 

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -20,7 +20,7 @@ From **2 to 5 October**, NL Design System organises the third edition of Design 
 
 This event is partially in Dutch, partially in English. On this page, you can find all sessions that will be in English, with sign up links to each.
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" signupLink="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit#event-booking">
 
 A set of components is one thing, but the true magic comes when they are put in use together. At GOV.UK they make it easier to prototype realistic digital services in HTML, with the GOV.UK Prototype Kit.
 Designer Joe Lanman is involved in this project as a designer and tells you more about it!
@@ -28,7 +28,7 @@ Designer Joe Lanman is involved in this project as a designer and tells you more
 Joe Lanman is a Design Lead at the UK Government Digital Service, based in London. He’s worked on projects including Register to Vote, Petition Parliament and the GOV.UK Prototype Kit – a way to rapidly prototype realistic services in HTML.
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt#event-booking">
 
 Nord is the design system of Nordhealth, a company that makes software for healthcare professionals. Design system lead David Darnes will tell you about their experience with Web Components and how they enable reuse of Nord components across a wide variety of contexts and technologies.
 
@@ -38,7 +38,7 @@ Of course, there is lots of nuance and there are some caveats and challenges. In
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub" signupLink="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams#event-booking">
 
 DesignOps is the glue that keeps a design org together, and the connective tissue that links design to other disciplines across the company, and beyond. Even if your company doesn’t have a formal DesignOps team, this work is likely being done by someone.
 
@@ -52,7 +52,7 @@ In this talk, you will learn:
 
 </DSWSession>
 
-<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal">
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
 
 Veera is a codename for a design system employed by many Estonian governmental agencies as a common UI language for the state of Estonia. Aleksandr will be talking about his and his colleagues' experiences setting up, maintaining, and supporting a component library that makes this design system breathe.
 

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -52,6 +52,13 @@ In this talk, you will learn:
 
 </DSWSession>
 
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal">
+
+Veera is a codename for a design system employed by many Estonian governmental agencies as a common UI language for the state of Estonia. Aleksandr will be talking about his and his colleagues' experiences setting up, maintaining, and supporting a component library that makes this design system breathe.
+
+Attend if you are interested in learning from a complex real-life case study. This is a story from a country which is proud to be called the first digital society. It is also a story about managing expectations, importance of DX, self-restraint, and naming things.
+</DSWSession>
+
 ## Organisation
 
 Design Systems Week is organised by the NL Design System core team, thanks to the support of the Ministry of the Interior and Kingdom Relations (BZK) and <Link href="https://international.gebruikercentraal.nl">User Needs First</Link>. All sessions can also be found there <Link href="https://international.gebruikercentraal.nl/design-systems-week-2023/">Design Systems Week 2023</Link>

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -28,6 +28,13 @@ Designer Joe Lanman is involved in this project as a designer and tells you more
 Joe Lanman is a Design Lead at the UK Government Digital Service, based in London. He’s worked on projects including Register to Vote, Petition Parliament and the GOV.UK Prototype Kit – a way to rapidly prototype realistic services in HTML.
 </DSWSession>
 
+<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
+
+Veera is a codename for a design system employed by many Estonian governmental agencies as a common UI language for the state of Estonia. Aleksandr will be talking about his and his colleagues' experiences setting up, maintaining, and supporting a component library that makes this design system breathe.
+
+Attend if you are interested in learning from a complex real-life case study. This is a story from a country which is proud to be called the first digital society. It is also a story about managing expectations, importance of DX, self-restraint, and naming things.
+</DSWSession>
+
 <DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt#event-booking">
 
 Nord is the design system of Nordhealth, a company that makes software for healthcare professionals. Design system lead David Darnes will tell you about their experience with Web Components and how they enable reuse of Nord components across a wide variety of contexts and technologies.
@@ -50,13 +57,6 @@ In this talk, you will learn:
 - How to see DesignOps as an opportunity to connect not just designers, but design to other disciplines, and design to the community
 - Some things we’ve tried at GitHub that didn’t work so well — and some that did
 
-</DSWSession>
-
-<DSWSession title="Estonia Design System" speakers={[speakers.AleksandrBeliaev]} organisation="Nortal" signupLink="https://www.gebruikercentraal.nl/agenda/estland-design-system#event-booking">
-
-Veera is a codename for a design system employed by many Estonian governmental agencies as a common UI language for the state of Estonia. Aleksandr will be talking about his and his colleagues' experiences setting up, maintaining, and supporting a component library that makes this design system breathe.
-
-Attend if you are interested in learning from a complex real-life case study. This is a story from a country which is proud to be called the first digital society. It is also a story about managing expectations, importance of DX, self-restraint, and naming things.
 </DSWSession>
 
 ## Organisation

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -25,7 +25,8 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 | :---------- | :-------------- | :----------------------------------------------------------------------------------------------------------------- |
 | 11:00       | To be announced | -                                                                                                                  |
 | 13:00       | Joe Lanman      | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link> |
-| 15:00       | To be announced | -                                                                                                                  |
+| 15:00 | Aleksandr Beliaev  | Estonia Design System |
+
 
 ## Thursday October 5th
 

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -21,12 +21,11 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 
 ## Wednesday October 4rd
 
-| Time (CEST) | Speaker         | Topic                                                                                                              |
-| :---------- | :-------------- | :----------------------------------------------------------------------------------------------------------------- |
-| 11:00       | To be announced | -                                                                                                                  |
-| 13:00       | Joe Lanman      | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link> |
-| 15:00 | Aleksandr Beliaev  | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/#english">Estonia Design System</Link> |
-
+| Time (CEST) | Speaker           | Topic                                                                                                              |
+| :---------- | :---------------- | :----------------------------------------------------------------------------------------------------------------- |
+| 11:00       | To be announced   | -                                                                                                                  |
+| 13:00       | Joe Lanman        | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link> |
+| 15:00       | Aleksandr Beliaev | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/#english">Estonia Design System</Link>   |
 
 ## Thursday October 5th
 

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -25,7 +25,7 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 | :---------- | :-------------- | :----------------------------------------------------------------------------------------------------------------- |
 | 11:00       | To be announced | -                                                                                                                  |
 | 13:00       | Joe Lanman      | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link> |
-| 15:00 | Aleksandr Beliaev  | Estonia Design System |
+| 15:00 | Aleksandr Beliaev  | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/#english">Estonia Design System</Link> |
 
 
 ## Thursday October 5th

--- a/docs/project/events/design-systems-week-2023/speakers.json
+++ b/docs/project/events/design-systems-week-2023/speakers.json
@@ -134,6 +134,18 @@
         "en": "Inayaili León is a Staff Design Program Manager at GitHub, where she focuses on design operations, documentation, and more. Previously, she was as a Senior Designer at Microsoft, working on design systems and design ops, and she led the team creating Canonical's Vanilla design system"
       },
       "language": "en"
+    },
+    "AleksandrBeliaev": {
+      "name": "Aleksandr Beliaev",
+      "organisation": "Nortal",
+      "image": {
+        "src": "",
+        "alt": "Aleksandr Beliaev"
+      },
+      "description": {
+        "nl": "Aleksandr Beliaev is UI Development Lead bij Nortal, gespecialiseerd in UI engineering en design systems. Aleksandr heeft al meer dan 15 jaar ervaring met werken met UI en code. Hij houdt ervan als dingen mooi, opgeruimd maar werkbaar zijn.",
+        "en": " Aleksandr Beliaev is a UI Development Lead at Nortal. His main expertise revolves around UI engineering and design systems."
+      }
     }
   }
 }

--- a/docs/project/events/design-systems-week-2023/speakers.json
+++ b/docs/project/events/design-systems-week-2023/speakers.json
@@ -144,7 +144,7 @@
       },
       "description": {
         "nl": "Aleksandr Beliaev is UI Development Lead bij Nortal, gespecialiseerd in UI engineering en design systems. Aleksandr heeft al meer dan 15 jaar ervaring met werken met UI en code. Hij houdt ervan als dingen mooi, opgeruimd maar werkbaar zijn.",
-        "en": " Aleksandr Beliaev is a UI Development Lead at Nortal. His main expertise revolves around UI engineering and design systems."
+        "en": " Aleksandr Beliaev is a UI Development Lead at Nortal. His main expertise revolves around UI engineering and design systems.  Aleksandr has been working with UI code for a bit more than 15 years. He likes his things shiny, tidied-up but liveable."
       }
     }
   }

--- a/docs/project/events/design-systems-week-2023/speakers.json
+++ b/docs/project/events/design-systems-week-2023/speakers.json
@@ -139,7 +139,7 @@
       "name": "Aleksandr Beliaev",
       "organisation": "Nortal",
       "image": {
-        "src": "",
+        "src": "https://www.gebruikercentraal.nl/wp-content/uploads/sites/4/2023/09/aleksandr-beliaev-300x300.png",
         "alt": "Aleksandr Beliaev"
       },
       "description": {


### PR DESCRIPTION
toegevoegd: 

- de Estonia Design System sessie

gefixed: 

- `<abbr>` tags om 'EN' en 'NL' gezet voor stukje extra toegankelijkheid 
- de `signupLink` prop ingevuld bij alle sessies zodat aanmeld-call-to-actions werken
- op Nederlandse versie miste nog een `import { Link }` waardoor de `<Link>` niet werkte, heb die toegevoegd