### PR TITLE
Add Mu-An and Arash

### DIFF
--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -49,6 +49,16 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
+<DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" signupLink="https://www.gebruikercentraal.nl/agenda/design-system-laten-meegroeien-met-je-organisatie#event-booking">
+
+Een design system is altijd in beweging, maar de manier waarop we eraan werken verandert naarmate het groeit. Sinds PostNL het design system Stamp introduceerde, heeft het zich ontwikkeld tot een belangrijk onderdeel van de digitale productontwikkeling. En met de volwassenheid komen er ook weer nieuwe vragen naar boven.
+
+In deze sessie neemt Arash Azizi, product owner bij PostNL, je mee door de ontwikkeling van het design system. Hij laat zien welke beslissingen hij en zijn team hebben genomen en hoe ze het hebben uitgerold binnen de organisatie.
+
+Een design system is namelijk niet alleen een ontwerp- of technische aangelegenheid, maar vraagt ook andere keuzes en prioriteiten van een organisatie. Arash laat je zien wat de impact is van een design system binnen een grote organisatie en hoe hij daar als product owner mee omgaat.
+
+</DSWSession>
+
 <DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" signupLink="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk#event-booking">
 
 In deze sessie krijg je alles te horen over Trinity, het design system van de Kamer van Koophandel (KVK) dat wordt onderhouden door Team Matrix. Tooling, context en impact komt aan de orde, maar er wordt vooral dieper in gegaan op hoe KVK omgaat met de uitdagingen rondom de adoptie van het design system door de gebruikers. Ben jij erbij? Red pill or blue pill?
@@ -60,6 +70,12 @@ In deze sessie krijg je alles te horen over Trinity, het design system van de Ka
 Ze zijn essentieel voor vrijwel alle digitale overheidsdiensten: formulieren. Zeker nu de Wet modernisering elektronisch bestuurlijk verkeer (WMEBV) burgers en bedrijven het recht gaat geven om elektronisch zaken te doen met de overheid. Logisch dus dat steeds meer organisaties NL Design System gebruiken voor formulieren.
 
 In deze sessie vertellen ontwikkelaars Robbert Broersma en Hidde de Vries je over hoe je de beste formulieren maakt. Ze laten daarbij zien hoe digitale toegankelijkheid is ingebouwd in de componenten en richtlijnen van NL Design System, en nemen je mee in de do’s en don’ts.
+
+</DSWSession>
+
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation=" Public Digital Innovation Space, Cabinet Office, Taiwan" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure#event-booking">
+
+(Omschrijving volgt)
 
 </DSWSession>
 

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -20,21 +20,21 @@ import { Link } from '@utrecht/component-library-react';
 
 ## dinsdag 3 oktober
 
-| Tijd  | Spreker                            | Onderwerp                                                                                                                                                  | Taal                               |
-| :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| 11:00 | Nog aan te kondigen                | -                                                                                                                                                          | -                                  |
-| 11:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                        | <abbr title="Nederlands">NL</abbr> |
-| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                       | <abbr title="Nederlands">NL</abbr> |
-| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link> | <abbr title="Nederlands">NL</abbr> |
+| Tijd  | Spreker                            | Onderwerp                                                                                                                                                        | Taal                               |
+| :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Arash Azizi                        | <Link href="https://www.gebruikercentraal.nl/agenda/design-system-laten-meegroeien-met-je-organisatie/">Design system laten meegroeien met je organisatie</Link> | <abbr title="Nederlands">NL</abbr> |
+| 13:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                              | <abbr title="Nederlands">NL</abbr> |
+| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                             | <abbr title="Nederlands">NL</abbr> |
+| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link>       | <abbr title="Nederlands">NL</abbr> |
 
 ## woensdag 4 oktober
 
-| Tijd  | Spreker             | Onderwerp                                                                                                  | Taal                            |
-| :---- | :------------------ | :--------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| 11:00 | Nog aan te kondigen | -                                                                                                          | -                               |
-| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link> | <abbr title="English">EN</abbr> |
-| 15:00 | Aleksandr Beliaev   | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/">Estonia Design System</Link>   | <abbr title="English">EN</abbr> |
-| 16:30 | Nog aan te kondigen | -                                                                                                          | -                               |
+| Tijd  | Spreker             | Onderwerp                                                                                                                                   | Taal                            |
+| :---- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| 11:00 | Mu-An Chiou         | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure">Design systems as public infrastructure</Link> | <abbr title="English">EN</abbr> |
+| 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link>                                  | <abbr title="English">EN</abbr> |
+| 15:00 | Aleksandr Beliaev   | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/">Estonia Design System</Link>                                    | <abbr title="English">EN</abbr> |
+| 16:30 | Nog aan te kondigen | -                                                                                                                                           | -                               |
 
 ## donderdag 5 oktober
 
@@ -42,7 +42,7 @@ import { Link } from '@utrecht/component-library-react';
 | :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | <abbr title="Nederlands">NL</abbr> |
 | 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | <abbr title="English">EN</abbr>    |
-| 15:00 | Inayaili Léon - GitHub            | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/">DesignOps: designing the API of design teams</Link>                        | <abbr title="English">EN</abbr>s   |
+| 15:00 | Inayaili Léon - GitHub            | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/">DesignOps: designing the API of design teams</Link>                        | <abbr title="English">EN</abbr>    |
 | 16:30 | Nog aan te kondigen               | -                                                                                                                                                                            | -                                  |
 
 ## Organisatie

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -20,6 +20,12 @@ From **2 to 5 October**, NL Design System organises the third edition of Design 
 
 This event is partially in Dutch, partially in English. On this page, you can find all sessions that will be in English, with sign up links to each.
 
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure#event-booking">
+
+(Description to be announced)
+
+</DSWSession>
+
 <DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" signupLink="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit#event-booking">
 
 A set of components is one thing, but the true magic comes when they are put in use together. At GOV.UK they make it easier to prototype realistic digital services in HTML, with the GOV.UK Prototype Kit.

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -21,11 +21,11 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 
 ## Wednesday October 4rd
 
-| Time (CEST) | Speaker           | Topic                                                                                                              |
-| :---------- | :---------------- | :----------------------------------------------------------------------------------------------------------------- |
-| 11:00       | To be announced   | -                                                                                                                  |
-| 13:00       | Joe Lanman        | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link> |
-| 15:00       | Aleksandr Beliaev | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/#english">Estonia Design System</Link>   |
+| Time (CEST) | Speaker           | Topic                                                                                                                                               |
+| :---------- | :---------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 11:00       | Mu-An Chiou       | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure#english">Design systems as public infrastructure</Link> |
+| 13:00       | Joe Lanman        | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link>                                  |
+| 15:00       | Aleksandr Beliaev | <Link href="https://www.gebruikercentraal.nl/agenda/estland-design-system/#english">Estonia Design System</Link>                                    |
 
 ## Thursday October 5th
 

--- a/docs/project/events/design-systems-week-2023/speakers.json
+++ b/docs/project/events/design-systems-week-2023/speakers.json
@@ -146,6 +146,31 @@
         "nl": "Aleksandr Beliaev is UI Development Lead bij Nortal, gespecialiseerd in UI engineering en design systems. Aleksandr heeft al meer dan 15 jaar ervaring met werken met UI en code. Hij houdt ervan als dingen mooi, opgeruimd maar werkbaar zijn.",
         "en": " Aleksandr Beliaev is a UI Development Lead at Nortal. His main expertise revolves around UI engineering and design systems.  Aleksandr has been working with UI code for a bit more than 15 years. He likes his things shiny, tidied-up but liveable."
       }
+    },
+    "MuAnChiou": {
+      "name": "Mu-An Chiou",
+      "organisation": "Public Digital Innovation Space, Cabinet Office, Taiwan",
+      "image": {
+        "src": "https://www.gebruikercentraal.nl/wp-content/uploads/sites/4/2023/09/mu-an-chiou-150x150.png",
+        "alt": "Mu-An Chiou"
+      },
+      "description": {
+        "nl": "Mu-An Chiou is hoofd design systems bij de Public Digital Innovation Space, dat valt onder het Taiwanese Cabinet Office. Ze werkte eerder bij GitHub, waar ze werkte aan hun design system en initiatieven leidde rondom toegankelijkheid, front-end architectuur en Web Components.",
+        "en": "Mu-An Chiou is Head of Design Systems at Public Digital Innovation Space, under Taiwan's Cabinet Office. She used to work at GitHub, where she worked on their design system and led efforts on accessibility and Web Components."
+      },
+      "language": "en"
+    },
+    "ArashAzizi": {
+      "name": "Arash Azizi",
+      "organisation": "PostNL",
+      "image": {
+        "src": "https://www.gebruikercentraal.nl/wp-content/uploads/sites/4/2023/09/arash-azizi-300x300.jpeg",
+        "alt": "Arash Azizi"
+      },
+      "description": {
+        "nl": "Arash Azizi is product owner van het design system van PostNL. Daarnaast is hij channel manager van de PostNL-webshop. Arash was ook betrokken bij de ontwikkeling van de nieuwe website van PostNL."
+      },
+      "language": "nl"
     }
   }
 }


### PR DESCRIPTION
Dit voegt Mu-An en Arash toe aan de docs site. 

Dit was eerder onvolledig gedaan in https://github.com/nl-design-system/documentatie/commit/34348d457989e0d899c47a0ea889302b17dae4c0, en daarna ongedaan gemaakt in https://github.com/nl-design-system/documentatie/commit/7d390d5a4095f2a52b95233c141499ab0257a263. 