### PR TITLE
feat: Add Token Studio talk

### DIFF
--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -49,6 +49,14 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
+<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="GitHub / freelance" signupLink="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions#event-booking">
+
+Marco-Christian Krenn en Jan Six presenteren samen _The future of design decisions_. Verdiep je in de overgang van design tokens naar dynamisch design. Deze overgang heeft gevolgen voor bijvoorbeeld toegankelijkheid en laat zien hoeveel impact designkeuzes hebben. Deze boeiende sessie onderstreept het essentiële verband tussen interne beslissingen en een single source of truth.
+
+Je krijgt een kijkje in de toekomst van design tokens en leert over alle mogelijkheden ervan.
+
+</DSWSession>
+
 <DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" signupLink="https://www.gebruikercentraal.nl/agenda/design-system-laten-meegroeien-met-je-organisatie#event-booking">
 
 Een design system is altijd in beweging, maar de manier waarop we eraan werken verandert naarmate het groeit. Sinds PostNL het design system Stamp introduceerde, heeft het zich ontwikkeld tot een belangrijk onderdeel van de digitale productontwikkeling. En met de volwassenheid komen er ook weer nieuwe vragen naar boven.

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -11,25 +11,25 @@ import { Link } from '@utrecht/component-library-react';
 
 ## maandag 2 oktober
 
-| Tijd  | Spreker                            | Onderwerp                                                                                                                                                                  | Taal                               |
-| :---- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| 11:00 | Olaf Schoelink en Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | <abbr title="Nederlands">NL</abbr> |
-| 13:00 | Martijn Rietveld - OpenGemeenten   | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | <abbr title="Nederlands">NL</abbr> |
-| 15:00 | Jeffrey Lauwers                    | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | <abbr title="Nederlands">NL</abbr> |
-| 16:30 | Nog aan te kondigen                | -                                                                                                                                                                          | -                                  |
+| Tijd  | Spreker(s)                        | Onderwerp                                                                                                                                                                  | Taal                               |
+| :---- | :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Olaf Schoelink & Peter Berrevoets | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system/">Toegankelijkheid verzekeren met NL Design System</Link>             | <abbr title="Nederlands">NL</abbr> |
+| 13:00 | Martijn Rietveld - OpenGemeenten  | <Link href="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system/">Waarom wij als leverancier werken met NL Design System</Link> | <abbr title="Nederlands">NL</abbr> |
+| 15:00 | Jeffrey Lauwers                   | <Link href="https://www.gebruikercentraal.nl/agenda/onze-componenten-jouw-huisstijl-over-design-tokens/">Design Tokens - onze componenten jouw huisstijl</Link>            | <abbr title="Nederlands">NL</abbr> |
+| 16:30 | Jan Six & Marco-Christian Krenn   | <Link href="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions/">The future of design decisions</Link>                                                 | <abbr title="Nederlands">EN</abbr> |
 
 ## dinsdag 3 oktober
 
-| Tijd  | Spreker                            | Onderwerp                                                                                                                                                        | Taal                               |
-| :---- | :--------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| 11:00 | Arash Azizi                        | <Link href="https://www.gebruikercentraal.nl/agenda/design-system-laten-meegroeien-met-je-organisatie/">Design system laten meegroeien met je organisatie</Link> | <abbr title="Nederlands">NL</abbr> |
-| 13:00 | NL Design System community         | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                              | <abbr title="Nederlands">NL</abbr> |
-| 15:00 | Hülya Bozkurt & Joshua Grootveld   | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                             | <abbr title="Nederlands">NL</abbr> |
-| 16:30 | Hidde de Vries en Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link>       | <abbr title="Nederlands">NL</abbr> |
+| Tijd  | Spreker(s)                        | Onderwerp                                                                                                                                                        | Taal                               |
+| :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| 11:00 | Arash Azizi                       | <Link href="https://www.gebruikercentraal.nl/agenda/design-system-laten-meegroeien-met-je-organisatie/">Design system laten meegroeien met je organisatie</Link> | <abbr title="Nederlands">NL</abbr> |
+| 13:00 | NL Design System community        | <Link href="https://www.gebruikercentraal.nl/agenda/update-heartbeat-van-het-nl-design-system-3/">Heartbeat NL Design System</Link>                              | <abbr title="Nederlands">NL</abbr> |
+| 15:00 | Hülya Bozkurt & Joshua Grootveld  | <Link href="https://www.gebruikercentraal.nl/agenda/trinity-het-design-system-van-de-kvk/">Trinity: het design system van KvK</Link>                             | <abbr title="Nederlands">NL</abbr> |
+| 16:30 | Hidde de Vries & Robbert Broersma | <Link href="https://www.gebruikercentraal.nl/agenda/toegankelijke-formulieren-met-nl-design-system/">Toegankelijke formulieren met NL Design System</Link>       | <abbr title="Nederlands">NL</abbr> |
 
 ## woensdag 4 oktober
 
-| Tijd  | Spreker             | Onderwerp                                                                                                                                   | Taal                            |
+| Tijd  | Spreker(s)          | Onderwerp                                                                                                                                   | Taal                            |
 | :---- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
 | 11:00 | Mu-An Chiou         | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure">Design systems as public infrastructure</Link> | <abbr title="English">EN</abbr> |
 | 13:00 | Joe Lanman          | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/">GOV.UK Prototype Kit</Link>                                  | <abbr title="English">EN</abbr> |
@@ -38,7 +38,7 @@ import { Link } from '@utrecht/component-library-react';
 
 ## donderdag 5 oktober
 
-| Tijd  | Spreker                           | Onderwerp                                                                                                                                                                    | Taal                               |
+| Tijd  | Spreker(s)                        | Onderwerp                                                                                                                                                                    | Taal                               |
 | :---- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | 11:00 | Daniëlle Rameau - Sanoma Learning | <Link href="https://www.gebruikercentraal.nl/agenda/betere-toegankelijkheid-met-een-design-system/">Betere toegankelijkheid met een design system</Link>                     | <abbr title="Nederlands">NL</abbr> |
 | 13:00 | David Darnes - Nord Health        | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/">Design Systems & Web Components: what works & what doesn’t</Link> | <abbr title="English">EN</abbr>    |

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -20,6 +20,14 @@ From **2 to 5 October**, NL Design System organises the third edition of Design 
 
 This event is partially in Dutch, partially in English. On this page, you can find all sessions that will be in English, with sign up links to each.
 
+<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="GitHub / freelance" lang="en" signupLink="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions#event-booking">
+
+Marco-Christian Krenn and Jan Six team up to present _The future of design decisions_. Delve into the transition from design tokens to dynamic design, impacting areas like accessibility, and revealing the profound implications of choices. This engaging discussion underscores the essential connection between internal decisions and the source of truth.
+
+You get a glimpse into the future around design tokens and learn about all the possibilities.
+
+</DSWSession>
+
 <DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" signupLink="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure#event-booking">
 
 Government digital services should be treated as public infrastructure in this day and age. Taiwan is in a rare position where there is an urgency to ensure digital resilience for all government services.

--- a/docs/project/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/project/events/design-systems-week-2023/english/2-timetable.md
@@ -15,13 +15,13 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 
 ## Monday October 2th
 
-| Time (CEST) | Speaker         | Topic |
-| :---------- | :-------------- | :---- |
-| 16:30       | To be announced | -     |
+| Time (CEST) | Speaker(s)                      | Topic                                                                                                                             |
+| :---------- | :------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
+| 16:30       | Jan Six & Marco-Christian Krenn | <Link href="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions#english">The future of design decisions</Link> |
 
 ## Wednesday October 4rd
 
-| Time (CEST) | Speaker           | Topic                                                                                                                                               |
+| Time (CEST) | Speaker(s)        | Topic                                                                                                                                               |
 | :---------- | :---------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 11:00       | Mu-An Chiou       | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-as-public-infrastructure#english">Design systems as public infrastructure</Link> |
 | 13:00       | Joe Lanman        | <Link href="https://www.gebruikercentraal.nl/agenda/the-gov-uk-prototype-kit/#english">GOV.UK Prototype Kit</Link>                                  |
@@ -29,7 +29,7 @@ These are all timeslots with talks in English, <Link href="/events/design-system
 
 ## Thursday October 5th
 
-| Time (CEST) | Speaker         | Topic                                                                                                                                                                |
+| Time (CEST) | Speaker(s)      | Topic                                                                                                                                                                |
 | :---------- | :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 13:00       | David Darnes    | <Link href="https://www.gebruikercentraal.nl/agenda/design-systems-web-components-what-works-what-doesnt/#english">Web Components at Nordhealth design system</Link> |
 | 15:00       | Inayaili Léon   | <Link href="https://www.gebruikercentraal.nl/agenda/designops-designing-the-api-of-design-teams/#english">DesignOps at GitHub design system</Link>                   |

--- a/docs/project/events/design-systems-week-2023/speakers.json
+++ b/docs/project/events/design-systems-week-2023/speakers.json
@@ -171,6 +171,32 @@
         "nl": "Arash Azizi is product owner van het design system van PostNL. Daarnaast is hij channel manager van de PostNL-webshop. Arash was ook betrokken bij de ontwikkeling van de nieuwe website van PostNL."
       },
       "language": "nl"
+    },
+    "MarcoChristianKrenn": {
+      "name": "Marco-Christian Krenn",
+      "organisation": "Freelance",
+      "image": {
+        "src": "https://www.gebruikercentraal.nl/wp-content/uploads/sites/4/2023/09/marco-christian-krenn-300x300.png",
+        "alt": "Marco-Christian Krenn"
+      },
+      "description": {
+        "nl": "Marco-Christian Krenn is een design system architect uit Oostenrijk. Hij houdt zich graag bezig met het oplossen van ontwerpen met logische beslissingen, headless architecture en design tokens. Als onderdeel van Tokens Studio werkt hij intensief aan Generators en Resolvers en streeft hij naar innovatie en verbetering op het gebied van design systems.",
+        "en": "Marco-Christian Krenn is a Design System Architect from Austria who is passionate about solving design with logical decisions, headless architecture, and design tokens. As part of Tokens Studio, he’s deeply involved in working on Generators and Resolvers, striving to innovate and enhance the field of design systems."
+      },
+      "language": "en"
+    },
+    "JanSix": {
+      "name": "Jan Six",
+      "organisation": "GitHub",
+      "image": {
+        "src": "https://www.gebruikercentraal.nl/wp-content/uploads/sites/4/2023/09/jan-six-300x300.png",
+        "alt": "Jan Six"
+      },
+      "description": {
+        "nl": "Jan Six is een product designer bij GitHub. Hij heeft opensourcetools en plugins gebouwd die ontwerpers helpen om de vervelende en repetitieve onderdelen van hun werk te automatiseren. Met zijn opensourceproject Tokens Studio bouwt hij aan een open ecosysteem rond ontwerpbeslissingen, inclusief een Figma-plugin en een platform om ontwerpsystemen op schaal en geautomatiseerd te laten werken.",
+        "en": "Jan Six is a product designer at GitHub who has been building open-source tools and plugins that help designers automate the tedious and repetitive parts. With his open source project Tokens Studio he’s building an open ecosystem around design decisions, including a Figma plugin and a platform to help make design systems work at scale and in automated ways."
+      },
+      "language": "en"
     }
   }
 }

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -36,7 +36,7 @@ export const DSWSession = ({
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
     <Heading2 className={clsx(style['dsw-session__title'])}>{title}</Heading2>
     <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
-      {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}
+      {speakers.map((speaker) => speaker.name).join(' & ')} ({organisation})
     </Paragraph>
     {children}
     {lang === 'nl' && speakers.find(({ language }) => language !== 'nl') && (


### PR DESCRIPTION
Behalve de Token Studio talk toevoegen doet dit ook:

- “of [organisatie]” / “van [organisatie]” is nu “([organisatie])” zodat het ook werkt met “GitHub / freelance” (Jan Six is van GitHub, Marco-Christian is freelance, vandaar)
- waar we twee sprekers hebben staat er nu consistent overal `&` en niet `en`. 