### PR TITLE
fix: Use consistent name for the week

### DIFF
--- a/docs/project/blijf-op-de-hoogte.mdx
+++ b/docs/project/blijf-op-de-hoogte.mdx
@@ -23,7 +23,7 @@ De activiteiten en voortgang van het kernteam zijn voor iedereen te volgen door 
 - [Wordt lid van het #nl-design-system Slack kanaal](https://praatmee.codefor.nl) op CodeForNL
 - [Lees ons blog voor uitgebreidere interviews en artikelen](https://designsystem.gebruikercentraal.nl/blogs-nieuws)
 
-## NL Design System week
+## NL Design Systems week
 
 Van maandag 2 tot en met donderdag 5 oktober is de [Design Systems Week van 2023](/events/design-systems-week-2023/overzicht).
 Dit is in de week van ['Uit het doolhof!'](https://www.gebruikercentraal.nl/agenda/gebruiker-centraal-conferentie-2023-uit-het-doolhof/), de conferentie van Gebruiker Centraal. Je kunt dan allerlei online sessies volgen over design systems in het algemeen en NL Design System in het bijzonder. Vol met interessante praktijkvoorbeelden en inzichten. En natuurlijk kun je aan het einde van de sessies al je vragen stellen.
@@ -32,4 +32,4 @@ Dit is in de week van ['Uit het doolhof!'](https://www.gebruikercentraal.nl/agen
 
 ### 2022
 
-We hebben alle Design System week 2022 sessies opgenomen en deze kun je op de [design system week 2022 pagina](/events/design-systems-week-2022) vinden en op je gemak terug kijken.
+We hebben alle Design Systems week 2022 sessies opgenomen en deze kun je op de [Design Systems Week 2022 pagina](/events/design-systems-week-2022) vinden en op je gemak terug kijken.

--- a/docs/project/events/design-systems-week-2022.mdx
+++ b/docs/project/events/design-systems-week-2022.mdx
@@ -17,7 +17,7 @@ Alle sessies worden opgenomen en op deze pagina beschikbaar gemaakt. Om ze zo sn
 
 ## Wat is NL Design System?
 
-In deze eerste sessie openen we de Design System week en leggen Angela Imhof en Robbert Broersma uit waarom NL Design System er is, wat NL Design System is en wat jij ermee kunt.
+In deze eerste sessie openen we de Design Systems week en leggen Angela Imhof en Robbert Broersma uit waarom NL Design System er is, wat NL Design System is en wat jij ermee kunt.
 
 <VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-intro" controls />
 

--- a/docs/project/events/design-systems-week-2023/english/_category_.json
+++ b/docs/project/events/design-systems-week-2023/english/_category_.json
@@ -4,7 +4,7 @@
   "className": "red",
   "link": {
     "type": "generated-index",
-    "title": "Design System Week 2023",
+    "title": "Design Systems Week 2023",
     "description": "From 2 to 5 October, NL Design System organises the third edition of Design Systems Week. Speakers from various organisations will join us for short talks about the how and why of design systems. This year there will be talks both in Dutch and English. This event is partially in Dutch, partially in English. On this page, you can find all sessions that will be in English, with sign up links to each.",
     "slug": "/events/design-systems-week-2023/en/overview"
   }


### PR DESCRIPTION
Ik zag dat we op een paar plekken nog Design System Week zeiden, zonder s, dit maakt 'm consistent.