### PR TITLE
docs: videos Design Systems Week day 1

### DIFF
--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -22,12 +22,7 @@ Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren on
 
 Dit jaar hebben we nationale én internationale sprekers. We laten ons inspireren door andere design systems en horen waarom organisaties in een design system investeren. Vanuit verschillende perspectieven leren we hoe design systems bijdragen aan toegankelijkheid en gaan we technisch de diepte in met design tokens en web components.
 
-<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system#event-booking">
-
-<VimeoPlayer
-  url="https://vimeo.com/870255529"
-  controls
-/>
+<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" vimeoUrl="https://vimeo.com/870255529">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
 
@@ -41,12 +36,7 @@ Tijd om nu ook de meerwaarde ervan te laten zien aan managers, beslissers en adv
 
 </DSWSession>
 
-<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
-
-<VimeoPlayer
-  url="https://vimeo.com/870273121"
-  controls
-/>
+<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" vimeoUrl="https://vimeo.com/870273121">
 
 Heeft het NL Design System toegevoegde waarde voor leveranciers van overheden? En zijn er al leerzame voorbeelden van bijdragen van leveranciers die gebruikmaken van het NL Design System? Het antwoord op beide vragen: jazeker!
 
@@ -54,12 +44,7 @@ Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Desig
 
 </DSWSession>
 
-<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
-
-<VimeoPlayer
-  url="https://vimeo.com/870319489"
-  controls
-/>
+<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" vimeoUrl="https://vimeo.com/870319489">
 
 NL Design System wil de beste componenten uit de community herbruikbaar maken voor de hele overheid. Daarom hebben de componenten van het NL Design System van zichzelf geen huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘design tokens’.
 
@@ -67,12 +52,7 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
-<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" signupLink="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions/#event-booking">
-
-<VimeoPlayer
-  url="https://vimeo.com/870340269"
-  controls
-/>
+<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" vimeoUrl="https://vimeo.com/870340269">
 
 Marco-Christian Krenn en Jan Six presenteren samen The future of design decisions. Verdiep je in de overgang van design tokens naar dynamisch design. Deze overgang heeft gevolgen voor bijvoorbeeld toegankelijkheid en laat zien hoeveel impact designkeuzes hebben. Deze boeiende sessie onderstreept het essentiële verband tussen interne beslissingen en een single source of truth.
 

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -24,7 +24,6 @@ Dit jaar hebben we nationale én internationale sprekers. We laten ons inspirere
 
 <DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system#event-booking">
 
-
 <VimeoPlayer
   url="https://vimeo.com/870255529"
   controls

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -10,6 +10,7 @@ slug: /events/design-systems-week-2023/programma
 import DSWSession from "../../../../src/components/DSWSession";
 import speakers from "./speakers.json";
 import { Link } from '@utrecht/component-library-react/dist/css-module';
+import VimeoPlayer from "react-player";
 
 # Design Systems Week 2023
 
@@ -22,6 +23,12 @@ Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren on
 Dit jaar hebben we nationale én internationale sprekers. We laten ons inspireren door andere design systems en horen waarom organisaties in een design system investeren. Vanuit verschillende perspectieven leren we hoe design systems bijdragen aan toegankelijkheid en gaan we technisch de diepte in met design tokens en web components.
 
 <DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/toegankelijkheid-verzekeren-met-nl-design-system#event-booking">
+
+
+<VimeoPlayer
+  url="https://vimeo.com/870255529"
+  controls
+/>
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
 
@@ -37,6 +44,11 @@ Tijd om nu ook de meerwaarde ervan te laten zien aan managers, beslissers en adv
 
 <DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
 
+<VimeoPlayer
+  url="https://vimeo.com/870273121"
+  controls
+/>
+
 Heeft het NL Design System toegevoegde waarde voor leveranciers van overheden? En zijn er al leerzame voorbeelden van bijdragen van leveranciers die gebruikmaken van het NL Design System? Het antwoord op beide vragen: jazeker!
 
 Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Design System voor hem als designer en voor OpenGemeenten als leverancier betekent. Zodat jij als designer, developer, product owner, leverancier of andere geïnteresseerde voortaan óók aanhaakt bij NL Design System-meetings, zoals het design open hour en de heartbeats.
@@ -45,6 +57,11 @@ Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Desig
 
 <DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" signupLink="https://www.gebruikercentraal.nl/agenda/waarom-wij-als-leverancier-werken-met-nl-design-system#event-booking">
 
+<VimeoPlayer
+  url="https://vimeo.com/870319489"
+  controls
+/>
+
 NL Design System wil de beste componenten uit de community herbruikbaar maken voor de hele overheid. Daarom hebben de componenten van het NL Design System van zichzelf geen huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘design tokens’.
 
 Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zien hoe je ze kunt gebruiken in Figma. Je leert hoe je gebruik kunt maken van componenten uit de community van NL Design System, om deze vervolgens te voorzien van de huisstijl van jouw organisatie. En hoe je deze designkeuzes vanuit Figma kunt laten aansluiten op code.
@@ -52,6 +69,11 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 </DSWSession>
 
 <DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" signupLink="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions/#event-booking">
+
+<VimeoPlayer
+  url="https://vimeo.com/870340269"
+  controls
+/>
 
 Marco-Christian Krenn en Jan Six presenteren samen The future of design decisions. Verdiep je in de overgang van design tokens naar dynamisch design. Deze overgang heeft gevolgen voor bijvoorbeeld toegankelijkheid en laat zien hoeveel impact designkeuzes hebben. Deze boeiende sessie onderstreept het essentiële verband tussen interne beslissingen en een single source of truth.
 

--- a/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/project/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -259,7 +259,7 @@ organisation: "NL Design System",
 ],
 subject: "Management-panel: ervaringen met NL Design System uit de praktijk",
 singupLink:
-"https://https://www.gebruikercentraal.nl/agenda/management-panel-ervaringen-met-nl-design-system-uit-de-praktijk/",
+"https://www.gebruikercentraal.nl/agenda/management-panel-ervaringen-met-nl-design-system-uit-de-praktijk/",
 icalLink: "/dsweek-2023/management-panel.ics",
 language: { abbr: "NL", description: "Nederlands" },
 },

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -11,6 +11,7 @@ slug: /events/design-systems-week-2023/en/program
 import DSWSession from '../../../../../src/components/DSWSession'
 import speakers from '../speakers.json'
 import { Link } from '@utrecht/component-library-react/dist/css-module';
+import VimeoPlayer from "react-player";
 
 <div lang="en">
 
@@ -27,6 +28,11 @@ These are all sessions that will be in English, with sign up links to each. You 
 All sessions can be joined online for free. You will receive a link after sign-up. This link is valid for all talks during the week. Each talk will take about 30 minutes, including time for questions.
 
 <DSWSession title="The future of design decisions" speakers={[speakers.MarcoChristianKrenn, speakers.JanSix]} organisation="Token Studio" lang="en" signupLink="https://www.gebruikercentraal.nl/agenda/the-future-of-design-decisions/#event-booking">
+
+<VimeoPlayer
+  url="https://vimeo.com/870340269"
+  controls
+/>
 
 Marco-Christian Krenn and Jan Six team up to present The future of design decisions. Delve into the transition from design tokens to dynamic design, impacting areas like accessibility, and revealing the profound implications of choices. This engaging discussion underscores the essential connection between internal decisions and the source of truth.
 

--- a/src/components/DSWSession.module.css
+++ b/src/components/DSWSession.module.css
@@ -46,3 +46,8 @@
   height: 100%;
   margin-block-start: 0.4em;
 }
+
+.dsw-session__video {
+  margin-block-start: 24px;
+  margin-block-end: 32px;
+}

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -4,6 +4,7 @@ import Link from '@docusaurus/Link';
 import style from './DSWSession.module.css';
 import { IconChevronRight } from '@tabler/icons-react';
 import { Heading, Paragraph } from '@utrecht/component-library-react/dist/css-module';
+import VimeoPlayer from 'react-player';
 
 interface DSWSessionProps {
   headingLevel: 2 | 3 | 4 | 5 | 6;
@@ -14,6 +15,7 @@ interface DSWSessionProps {
   signupLink: string;
   lang?: 'en' | 'nl';
   organisation: string;
+  vimeoUrl?: string;
 }
 
 interface DSWSpeaker {
@@ -33,15 +35,20 @@ export const DSWSession = ({
   speakers,
   signupLink,
   organisation,
+  vimeoUrl,
   children,
 }: PropsWithChildren<DSWSessionProps>) => (
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
       {title}
     </Heading>
-    <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
-      {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}
-    </Paragraph>
+    {vimeoUrl ? (
+      <VimeoPlayer url={vimeoUrl} className={clsx(style['dsw-session__video'])} controls />
+    ) : (
+      <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
+        {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}
+      </Paragraph>
+    )}
     {children}
     {lang === 'nl' && speakers.find(({ language }) => language !== 'nl') && (
       <Paragraph>
@@ -56,15 +63,17 @@ export const DSWSession = ({
         </div>
       ))}
     </aside>
-    <Paragraph className={clsx(style['homepage-hero__call-to-action'])}>
-      <Link className={clsx('utrecht-link', style['homepage-hero__call-to-action-link'])} to={signupLink}>
-        {lang === 'en' ? 'Sign up for' : 'Aanmelden voor'} “{title}”
-        <IconChevronRight
-          className={clsx('utrecht-icon', style['homepage-hero__call-to-action-icon'])}
-          style={{ verticalAlign: 'middle' }}
-        />
-      </Link>
-    </Paragraph>
+    {signupLink && (
+      <Paragraph className={clsx(style['homepage-hero__call-to-action'])}>
+        <Link className={clsx('utrecht-link', style['homepage-hero__call-to-action-link'])} to={signupLink}>
+          {lang === 'en' ? 'Sign up for' : 'Aanmelden voor'} “{title}”
+          <IconChevronRight
+            className={clsx('utrecht-icon', style['homepage-hero__call-to-action-icon'])}
+            style={{ verticalAlign: 'middle' }}
+          />
+        </Link>
+      </Paragraph>
+    )}
     <div className={clsx(style['homepage-hero__linear-gradient'])} />
   </article>
 );


### PR DESCRIPTION
also fixes `https://https://` typo in one session.

@Yolijn ik vind de videos trouwens _net_ iets mooier staan als ik de naam van de spreker weghaal onder de sessietitel; thoughts? En ik denk dat het goed kan want we noemen die naam vrijwel altijd in de content _en_ altijd in de bio.

<img width="1516" alt="screenshots van sessie, twee naast elkaar, bij de linker staat naam spreker onder de video, bij de rechter niet, er staat een pijltje bij met de vraag 'mooier?'" src="https://github.com/nl-design-system/documentatie/assets/178782/7ef0f75e-a035-4cb9-8ec9-6e64fd72dce8">
