### PR TITLE
chore: Make videos responsive

### DIFF
--- a/src/components/DSWSession.module.css
+++ b/src/components/DSWSession.module.css
@@ -50,4 +50,15 @@
 .dsw-session__video {
   margin-block-start: 24px;
   margin-block-end: 32px;
+  aspect-ratio: 16 / 9;
+  position: relative;
+}
+.dsw-session__video > div {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+.dsw-session__video iframe {
+  max-width: 100%;
 }

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -43,7 +43,7 @@ export const DSWSession = ({
       {title}
     </Heading>
     {vimeoUrl ? (
-      <VimeoPlayer url={vimeoUrl} className={clsx(style['dsw-session__video'])} controls />
+      <VimeoPlayer url={vimeoUrl} width="100%" height="100%" className={clsx(style['dsw-session__video'])} controls />
     ) : (
       <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
         {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}


### PR DESCRIPTION
Video's hadden een vaste breedte waardoor ze op kleine schermen de lay-out stukmaakten, dit lost dat lop.

De `width` en `height` van 100% op de `VimeoPlayer` is wat [de `react-player` docs aanraden](https://www.npmjs.com/package/react-player) (onder “responsive player”) en voorkomt in ieder geval dat dat component vaste afmetingen op het element plaatst.