### PR TITLE
fix: Typo in blog post

### DIFF
--- a/blog/2023/20231109-spacing-tokens.md
+++ b/blog/2023/20231109-spacing-tokens.md
@@ -42,7 +42,7 @@ In deze eerste sessie is al veel denkwerk verricht, liet Jeroen zien. In een spr
 
 Er zijn ook nog wel wat open vragen:
 
-- Hoeveel relaties is voldoende om de meeste scenario's af te dekken? Is er nog een relatie nodig na 'Onbekenden'?
+- Hoeveel relaties zijn voldoende om de meeste scenario's af te dekken? Is er nog een relatie nodig na 'Onbekenden'?
 - Hoe kan dit worden uitgewerkt in de front-end? (Er waren al wat eerste ideeën, door aanwezigheid van developers Yolijn en Robbert)
 - Hoe zit het met verticale ruimte binnen componenten?
 - Er zijn allerlei componenten waar de waarden op elkaar lijken, zoals buttons en links; kunnen we hier een groepering in aanbrengen?

--- a/blog/2023/20231109-spacing-tokens.md
+++ b/blog/2023/20231109-spacing-tokens.md
@@ -16,7 +16,7 @@ Vorige week kwamen designers van Gemeente Utrecht, Gemeente Den Haag en OpenGeme
 
 De belangrijkste reden voor deze samenkomst: op dit moment zijn er nog geen afspraken over de verticale ruimte tussen componenten. Dat zit gebruikersvriendelijkheid in de weg, doordat er onvoldoende relatie en hiërarchie tussen componenten bestaat.
 
-Tijdens een workshop kwamen designers bij elkaar om samen te werken aan twee doelen:
+De designers + enkele leden uit het kernteam (Rozerin, René, Martijn, Jeroen, Jeffrey, Yolijn en Robbert) kwamen bij elkaar om samen te werken aan twee doelen:
 
 - een systeem voor verticale paddings en/of margins dat intuïtief en logisch is (met design tokens voor implementatie en documentatie)
 - richtlijnen voor het gebruik van paddings en margins (waarin redeneringen en werking worden uitgelegd)


### PR DESCRIPTION
Typo gefixed (thanks @Rozerinay! <3). En merge van eerdere aanpassing lijkt niet goed te zijn gegaan, die zit hier weer in.