### PR TITLE
feat: add utrecht-html to blog

### DIFF
--- a/src/theme/BlogLayout/index.tsx
+++ b/src/theme/BlogLayout/index.tsx
@@ -21,7 +21,7 @@ export default function BlogLayout(props: BlogLayoutProps): JSX.Element {
             <BreadcrumbNav breadcrumbs={breadcrumbs} />
           </div>
           <main
-            className={clsx('col', {
+            className={clsx('utrecht-document', 'utrecht-html', 'col', {
               'col--7': hasSidebar,
               'col--9 col--offset-1': !hasSidebar,
             })}


### PR DESCRIPTION
As somehow the custom Markdown components are not used for the Blogposts I've added `utrecht-html` for now as that component adds utrecht styles directly to the html components.

This solves the issues:

- Spacing of the headings inconsistent, which puts h1 especially close to the breadcrumbs.
- Focus-visible styles inconsistent