### PR TITLE
chore: Use generic video player, use YT for some vids

### DIFF
--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -10,7 +10,6 @@ slug: /events/design-systems-week-2023/programma
 import DSWSession from "../../../../src/components/DSWSession";
 import speakers from "./speakers.json";
 import { Link } from '@utrecht/component-library-react/dist/css-module';
-import VimeoPlayer from "react-player";
 
 # Design Systems Week 2023
 
@@ -22,7 +21,7 @@ Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren on
 
 Dit jaar hebben we nationale én internationale sprekers. We laten ons inspireren door andere design systems en horen waarom organisaties in een design system investeren. Vanuit verschillende perspectieven leren we hoe design systems bijdragen aan toegankelijkheid en gaan we technisch de diepte in met design tokens en web components.
 
-<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" vimeoUrl="https://vimeo.com/870255529">
+<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" videoUrl="https://youtu.be/0w8DVyc9Mos">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
 
@@ -36,7 +35,7 @@ Tijd om nu ook de meerwaarde ervan te laten zien aan managers, beslissers en adv
 
 </DSWSession>
 
-<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" vimeoUrl="https://vimeo.com/870273121">
+<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" videoUrl="https://youtu.be/H2KVlMSKOmc">
 
 Heeft het NL Design System toegevoegde waarde voor leveranciers van overheden? En zijn er al leerzame voorbeelden van bijdragen van leveranciers die gebruikmaken van het NL Design System? Het antwoord op beide vragen: jazeker!
 
@@ -44,7 +43,7 @@ Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Desig
 
 </DSWSession>
 
-<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" vimeoUrl="https://vimeo.com/870319489">
+<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" videoUrl="https://youtu.be/n9m2TtD1esE">
 
 NL Design System wil de beste componenten uit de community herbruikbaar maken voor de hele overheid. Daarom hebben de componenten van het NL Design System van zichzelf geen huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘design tokens’.
 
@@ -52,7 +51,7 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
-<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" vimeoUrl="https://vimeo.com/870340269">
+<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" videoUrl="https://youtu.be/TFQbp2yNABk">
 
 Marco-Christian Krenn en Jan Six presenteren samen The future of design decisions. Verdiep je in de overgang van design tokens naar dynamisch design. Deze overgang heeft gevolgen voor bijvoorbeeld toegankelijkheid en laat zien hoeveel impact designkeuzes hebben. Deze boeiende sessie onderstreept het essentiële verband tussen interne beslissingen en een single source of truth.
 
@@ -60,7 +59,7 @@ Je krijgt een kijkje in de toekomst van design tokens en leert over alle mogelij
 
 </DSWSession>
 
-<DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-post-nl">
+<DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" videoUrl="https://youtu.be/rVCWIX0tmdM">
 
 Een design system is altijd in beweging, maar de manier waarop we eraan werken verandert naarmate het groeit. Sinds PostNL het design system Stamp introduceerde, heeft het zich ontwikkeld tot een belangrijk onderdeel van de digitale productontwikkeling. En met de volwassenheid komen er ook weer nieuwe vragen naar boven.
 
@@ -69,13 +68,13 @@ Een design system is namelijk niet alleen een ontwerp- of technische aangelegenh
 
 </DSWSession>
 
-<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-kvk">
+<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" videoUrl="https://youtu.be/51B8OHE9nJ4">
 
 In deze sessie krijg je alles te horen over Trinity, het design system van de Kamer van Koophandel (KVK) dat wordt onderhouden door Team Matrix. Tooling, context en impact komt aan de orde, maar er wordt vooral dieper in gegaan op hoe KVK omgaat met de uitdagingen rondom de adoptie van het design system door de gebruikers. Ben jij erbij? Red pill or blue pill?
 
 </DSWSession>
 
-<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-formulieren">
+<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System" videoUrl="https://youtu.be/OUegy1OKtvs">
 
 Ze zijn essentieel voor vrijwel alle digitale overheidsdiensten: formulieren. Zeker nu de Wet modernisering elektronisch bestuurlijk verkeer (WMEBV) burgers en bedrijven het recht gaat geven om elektronisch zaken te doen met de overheid. Logisch dus dat steeds meer organisaties NL Design System gebruiken voor formulieren.
 
@@ -83,7 +82,7 @@ In deze sessie vertellen ontwikkelaars Robbert Broersma en Hidde de Vries je ove
 
 </DSWSession>
 
-<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation=" Public Digital Innovation Space, Cabinet Office, Taiwan" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-public-infrastructure">
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation=" Public Digital Innovation Space, Cabinet Office, Taiwan" videoUrl="https://youtu.be/_X2zQoL5okw">
 
 Digitale overheidsdiensten zouden vandaag de dag als publieke infrastructuur moeten worden gezien. Taiwan is in de ongebruikelijke positie dat digitale weerstand essentieel is voor alle overheidsdiensten.
 
@@ -91,7 +90,7 @@ Het design system, met name hoe het gebouwd wordt, speelt een belangrijke rol in
 
 </DSWSession>
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-govuk">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK" videoUrl="https://youtu.be/PuxojwJ2OEE">
 
 Een verzameling losse componenten is 1 ding, maar het wordt pas écht interessant als ze bij elkaar komen. Zodat er een volwaardige, digitale overheidsdienst of -product ontstaat. Bij GOV.UK maken ze het makkelijker om te zien hoe zo’n dienst of product eruitziet. Daarvoor gebruiken ze de [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/).
 
@@ -107,13 +106,13 @@ Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verha
 
 </DSWSession>
 
-<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-sanoma">
+<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning" videoUrl="https://youtu.be/kPbIbf1lM_Y">
 
 Hoe kan een design system helpen bij het verbeteren van toegankelijkheid, in 12 educatieve producten, die dagelijks worden gebruikt door 25 miljoen leerlingen over heel Europa? Dat is 1 van de vragen die Sanoma Learning de afgelopen tijd bezig hield. Design systems lead Daniëlle Rameau gaat je meer vertellen over hun aanpak.
 
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-web-components">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth" videoUrl="https://youtu.be/QXHLivD5Y_Q">
 
 Nord is het design system van Nordhealth, een bedrijf dat software maakt voor de gezondheidszorg. Design system lead David Darnes vertelt je in deze sessie over hoe het hen vergaat met Web Components, en hoe die ervoor zorgen dat ze Nord-componenten heel flexibel kunnen gebruiken, met allerlei verschillende technologieën.
 
@@ -123,7 +122,7 @@ Natuurlijk zijn er allerlei nuances en subtiliteiten rondom het gebruik van Web 
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-designops">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub" videoUrl="https://youtu.be/GYUcd17cLJM">
 
 DesignOps (design operations) is het bindmiddel dat een designteam bij elkaar houdt. Daarnaast verbindt het design met andere disciplines binnen én buiten de eigen organisatie. Zelfs als je organisatie geen formeel DesignOps-team heeft, wordt design operations waarschijnlijk wel al door iemand bij jullie gedaan.
 
@@ -133,7 +132,7 @@ Het resultaat: DesignOps waarmee GitHub verder kan. Reden genoeg dus om de gelee
 
 </DSWSession>
 
-<DSWSession title="Management-panel: ervaringen met NL Design System uit de praktijk" speakers={[speakers.JeffreyKlardie, speakers.RoelDerksen, speakers.VincentVanBeek, speakers.PeterBerrevoets]} organisation="NL Design System" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-mgmt">
+<DSWSession title="Management-panel: ervaringen met NL Design System uit de praktijk" speakers={[speakers.JeffreyKlardie, speakers.RoelDerksen, speakers.VincentVanBeek, speakers.PeterBerrevoets]} organisation="NL Design System" videoUrl="https://youtu.be/AfDlY1g2OTo">
 
 Er is tussen overheidsorganisaties enorm veel overlap in de online diensten die we bouwen. Van formulieren (van eenvoudig tot complex) tot zaaksystemen tot digitale processen voor burgers en ambtenaren. Al dit soort websites en apps willen we natuurlijk toegankelijk, inclusief en gebruiksvriendelijk opleveren.
 

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -11,7 +11,6 @@ slug: /events/design-systems-week-2023/en/program
 import DSWSession from '../../../../../src/components/DSWSession'
 import speakers from '../speakers.json'
 import { Link } from '@utrecht/component-library-react/dist/css-module';
-import VimeoPlayer from "react-player";
 
 <div lang="en">
 
@@ -27,7 +26,7 @@ These are all sessions that will be in English, with sign up links to each. You 
 
 All sessions can be joined online for free. You will receive a link after sign-up. This link is valid for all talks during the week. Each talk will take about 30 minutes, including time for questions.
 
-<DSWSession title="The future of design decisions" speakers={[speakers.MarcoChristianKrenn, speakers.JanSix]} organisation="Token Studio" lang="en" vimeoUrl="https://vimeo.com/870340269">
+<DSWSession title="The future of design decisions" speakers={[speakers.MarcoChristianKrenn, speakers.JanSix]} organisation="Token Studio" lang="en" videoUrl="https://youtu.be/TFQbp2yNABk">
 
 Marco-Christian Krenn and Jan Six team up to present The future of design decisions. Delve into the transition from design tokens to dynamic design, impacting areas like accessibility, and revealing the profound implications of choices. This engaging discussion underscores the essential connection between internal decisions and the source of truth.
 
@@ -35,7 +34,7 @@ You get a glimpse into the future around design tokens and learn about all the p
 
 </DSWSession>
 
-<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-public-infrastructure">
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" videoUrl="https://youtu.be/_X2zQoL5okw">
 
 Government digital services should be treated as public infrastructure in this day and age. Taiwan is in a rare position where there is an urgency to ensure digital resilience for all government services.
 
@@ -43,7 +42,7 @@ The design system and especially the engineering of it plays a crucial part in d
 
 </DSWSession>
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-govuk">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" videoUrl="https://youtu.be/PuxojwJ2OEE">
 
 A set of components is one thing, but the true magic comes when they are put in use together. At GOV.UK they make it easier to prototype realistic digital services in HTML, with the GOV.UK Prototype Kit.
 Designer Joe Lanman is involved in this project as a designer and tells you more about it!
@@ -58,7 +57,7 @@ Veera is a codename for a design system employed by many Estonian governmental a
 Attend if you are interested in learning from a complex real-life case study. This is a story from a country which is proud to be called the first digital society. It is also a story about managing expectations, importance of DX, self-restraint, and naming things.
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-web-components">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" videoUrl="https://youtu.be/QXHLivD5Y_Q">
 
 Nord is the design system of Nordhealth, a company that makes software for healthcare professionals. Design system lead David Darnes will tell you about their experience with Web Components and how they enable reuse of Nord components across a wide variety of contexts and technologies.
 
@@ -68,7 +67,7 @@ Of course, there is lots of nuance and there are some caveats and challenges. In
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub" vimeoUrl="https://vimeo.com/gebruikercentraal/design-systems-week-designops">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub" videoUrl="https://youtu.be/GYUcd17cLJM">
 
 DesignOps is the glue that keeps a design org together, and the connective tissue that links design to other disciplines across the company, and beyond. Even if your company doesn’t have a formal DesignOps team, this work is likely being done by someone.
 

--- a/docs/project/events/heartbeat.mdx
+++ b/docs/project/events/heartbeat.mdx
@@ -7,7 +7,7 @@ pagination_label: 2 wekelijkse updates van het kernteam en community
 slug: /events/heartbeat
 ---
 
-import VimeoPlayer from "react-player/vimeo";
+import ReactPlayer from "react-player";
 
 # Heartbeat
 
@@ -16,11 +16,17 @@ Sinds kort nemen we elke sessie op. Hieronder maken we deze sessies beschikbaar 
 
 Wil je er (online) bij zijn, heb je vragen of wil je zelf iets vertellen of presenteren tijdens een van de heartbeats? Stuur ons dan een mailtje op <a href="mailto:NLDesignSystem@gebruikercentraal.nl">NLDesignSystem@gebruikercentraal.nl</a>
 
+## 14 november 2023
+
+Rian van het kernteam vertelt over de uitbreiding van de formulierrichtlijnen waar zij met Hidde de Vries aan werkt. Ze was ook bij een gebruikerstest en blikt terug. Mees van Frameless laat de WEMBV-formulieren zien waar de afgelopen weken hard aan is gewerkt, ze worden deze week getest met gebruikers. Jeffrey bespreekt de “Figma-dag” voor designers die vorige week bij de Gemeente Utecht plaatsvond.
+
+<ReactPlayer url="https://www.youtube.com/watch?v=kcfdkSZfrf4" controls className="video-player" />
+
 ## 31 oktober 2023
 
-Francesca Vonk van VNG vertelt over de WMEBV-formulieren die worden ontwikkeld in Figma met NL Design System componenten, en binnenkort getest worden met gebruikers. Ook stelt Rian Rietveld voor: ze is nieuw in het team en gaat zich als toegankelijkheidsspecialist de komende tijd bezig houden met richtlijnen voor (toegankelijke) formulieren.
+Francesca van VNG vertelt over de WMEBV-formulieren die worden ontwikkeld in Figma met NL Design System componenten, en binnenkort getest worden met gebruikers. Ook stelt Rian voor: ze is nieuw in het team en gaat zich als toegankelijkheidsspecialist de komende tijd bezig houden met richtlijnen voor (toegankelijke) formulieren.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231031"
   controls
   className="video-player"
@@ -30,7 +36,7 @@ Francesca Vonk van VNG vertelt over de WMEBV-formulieren die worden ontwikkeld i
 
 Mark Meijerink presenteert over de Persoonlijke Regelingen Assistent (PRA), een project van Stichting ICTU voor het Ministerie van Binnenlandse Zaken. PRA is een app waarmee burgers en ondernemers gemakkelijk kunnen op welke regelingen en toeslagen ze recht hebben, gemaakt met, hoe kan het ook anders, NL Design System. Bart Nieuwenweg van Draad vertelt over het maken van een nieuw kaartencomponent voor de nieuwe website van de gemeente Den Haag, zijn eerste project met NL Design System.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231017"
   controls
   className="video-player"
@@ -40,7 +46,7 @@ Mark Meijerink presenteert over de Persoonlijke Regelingen Assistent (PRA), een 
 
 De heartbeat Design Systems Week special waar Rozerin van gemeente Den Haag en René van gemeente Utrecht vertellen over hun ervaring met het gebruik van de NL Design System Figma bibliotheek volgens het stappenplan op de website. Ook geeft Aline Nap van Logius een demo van haar Proof of Concept van variabelen in Figma te gebruiken in combinatie met Design Tokens.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231003"
   controls
   className="video-player"
@@ -50,7 +56,7 @@ De heartbeat Design Systems Week special waar Rozerin van gemeente Den Haag en R
 
 Vincent van gemeente Amsterdam laat zien wat Amsterdam design system voor mooie dingen heeft bijgedragen laatste tijd. Remko van leverancier Conduction laat zien hoe door gebruik van NL Design System community componenten ze nu 1 applicatie voor diverse gemeentes hebben kunnen gebruiken door alleen verschillende huisstijl thema's in te stellen.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230919"
   controls
   className="video-player"
@@ -60,7 +66,7 @@ Vincent van gemeente Amsterdam laat zien wat Amsterdam design system voor mooie 
 
 Waar Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen met de Figma bibliotheek, de component quick-scan met toegankelijkheid tips en samen een prototype maken in Figma. En kondigt Hidde de Design Systems Week 2023 aan.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230905"
   controls
   className="video-player"
@@ -70,7 +76,7 @@ Waar Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen
 
 Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen met de Figma bibliotheek, de component quick-scan met toegankelijkheid tips en samen een prototype maken in Figma. En kondigt Hidde de Design Systems Week 2023 aan.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230822"
   controls
   className="video-player"
@@ -80,7 +86,7 @@ Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen met 
 
 Jeroen du Chatinier vertelt over hoe je gebruikersondezoek kunt delen met de community op [gebruikersonderzoeken.nl](https://gebruikersonderzoeken.nl/)
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230711
 "
   controls
@@ -93,7 +99,7 @@ Jeroen Visser vertelt over hoe 1Overheid met Figma direct verbinding heeft gemaa
 
 Rida el Mazouji vertelt over zijn stageopdracht bij Frameless, waarin hij met een team van stagiairs (ook Nova, Rowan en Britt) de open source website OpenCatalogi.nl (ontwikkeld door Conduction) heeft gemigreerd naar NL Design System en het Rotterdam Design System heeft aangesloten op NL Design System door een thema te maken.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230627
 "
   controls
@@ -104,7 +110,7 @@ Rida el Mazouji vertelt over zijn stageopdracht bij Frameless, waarin hij met ee
 
 Robbert vertelt kort over de duizend-en-één soorten tabellen die we in het wild tegenkomen. Aan iedereen de oproep: heb jij een mooie toegankelijke tabel gemaakt, of kom je een interessante complexe tabel tegen die je graag terugziet in NL Design System? Deel het even in Slack! Kom ook kijken bij de Designer Open Hour op 18 juli, waarin we multidisciplinair naar de tabellen gaan kijken.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230613
 "
   controls
@@ -117,7 +123,7 @@ Nico Druif laat zien hoe de gemeente Amsterdam het zakelijk erfpacht-portaal ont
 
 Vincent Smedinga, Inge de Bondt en Tanja van der Heide vertellen hoe de gemeente Amsterdam is begonnen een nieuw design system te bouwen met NL Design System.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230516
 "
   controls
@@ -128,7 +134,7 @@ Vincent Smedinga, Inge de Bondt en Tanja van der Heide vertellen hoe de gemeente
 
 Het kernteam wil een handleiding maken over een kleurenpalet die helpt met toegankelijkheid van je huisstijl. Robbert deelt de eerste stappen in het onderzoek naar de contrast-eisen van een toegankelijk palet.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230418
 "
   controls
@@ -141,7 +147,7 @@ Jeroen du Chatinier deelt zijn _hopes and dreams_ over [gebruikersonderzoek van 
 
 Jeffrey laat zien hoe het kernteam white-label Figma componenten maakt, voor componenten die al door de community zijn gemaakt als white-label front-end componenten.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230404
 "
   controls
@@ -152,7 +158,7 @@ Jeffrey laat zien hoe het kernteam white-label Figma componenten maakt, voor com
 
 Jeffrey vertelt over waarom we de eerste zijn die het nieuwe Gebruiker Centraal-lettertype gaan gebruiken, en hoe we op basis van de NL Design System richtlijnen tot de conclusie kwamen dat onze site een beter lettertype nodig had.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230321
 "
   controls
@@ -163,7 +169,7 @@ Jeffrey vertelt over waarom we de eerste zijn die het nieuwe Gebruiker Centraal-
 
 Rozerin Ayerdem is UX-designer bij de gemeente Den Haag. Voor de nieuwe designs doet Den Haag gebruikersonderzoeken zodat dat de Mijn Omgeving gebruiksvriendelijk en begrijpelijk is voor alle inwoners. Deze heartbeat presenteert zij over gebruikersonderzoek van de Mijn Omgeving.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230309
 "
   controls
@@ -174,7 +180,7 @@ Rozerin Ayerdem is UX-designer bij de gemeente Den Haag. Voor de nieuwe designs 
 
 De gemeente Amsterdam gaat meedoen met NL Design System, en Vincent Smedinga vertelt waar ze op hebben gelet bij het onderzoek of meedoen met NL Design System een goed idee is.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230207"
   controls
   className="video-player"
@@ -184,7 +190,7 @@ De gemeente Amsterdam gaat meedoen met NL Design System, en Vincent Smedinga ver
 
 Kleine updates uit de community, waaronder de gemeente Utrecht die werkt aan dark mode voor 's avonds met design tokens. Sergei Maertens laat zien hoe hij een design tokens editor heeft gemaakt voor thema's uit de NL Design System community, die je bijvoorbeeld in Storybook gemakkelijk kunt gebruiken.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230124"
   controls
   className="video-player"
@@ -194,7 +200,7 @@ Kleine updates uit de community, waaronder de gemeente Utrecht die werkt aan dar
 
 Eerste heartbeat van het jaar met kleine updates van het kernteam over het onderhoud waar ze in de kerstvakantie mee bezig zijn geweest.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230110"
   controls
   className="video-player"
@@ -205,7 +211,7 @@ Eerste heartbeat van het jaar met kleine updates van het kernteam over het onder
 Laatste heartbeat van 2022 waar Egor de algemenere Rijkshuisstijl componenten, basis componenten, laat zien waar hij bij de RVO mee bezig is geweest.
 Daarnaast blikt Yolijn terug op de plannen die we voor 2022 hadden en wat daarvan terecht is gekomen.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221213"
   controls
   className="video-player"
@@ -217,7 +223,7 @@ Robbert vertelt over Proof of concept NL Design System componenten voor [onderzo
 Jeffrey verteld waar hij nu staat met componenten hergebruiken in Figma
 Yolijn laat de Playroom zien die is toegevoegd aan [Themes Storybook](https://nl-design-system.github.io/themes/?path=/playroom/button--gemeente-utrecht) waaraan zij nu werkt om in de thema storybook componenten in samenhang te zien.
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221115"
   controls
   className="video-player"
@@ -228,7 +234,7 @@ Yolijn laat de Playroom zien die is toegevoegd aan [Themes Storybook](https://nl
 Deze week laat Jeffrey zien hoe we de design tokens in Figma toepassen, koppelen aan de frontend en direct publiceren via Storybook.
 Daarna geeft Yolijn een korte demo van ons resultaat om NL Design System te integreren met Open Formulieren
 
-<VimeoPlayer
+<ReactPlayer
   url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221018"
   controls
   className="video-player"

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import style from './DSWSession.module.css';
 import { IconChevronRight } from '@tabler/icons-react';
 import { Heading, Paragraph } from '@utrecht/component-library-react/dist/css-module';
-import VimeoPlayer from 'react-player';
+import ReactPlayer from 'react-player';
 
 interface DSWSessionProps {
   headingLevel: 2 | 3 | 4 | 5 | 6;
@@ -15,7 +15,7 @@ interface DSWSessionProps {
   signupLink: string;
   lang?: 'en' | 'nl';
   organisation: string;
-  vimeoUrl?: string;
+  videoUrl?: string;
 }
 
 interface DSWSpeaker {
@@ -35,15 +35,15 @@ export const DSWSession = ({
   speakers,
   signupLink,
   organisation,
-  vimeoUrl,
+  videoUrl,
   children,
 }: PropsWithChildren<DSWSessionProps>) => (
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
       {title}
     </Heading>
-    {vimeoUrl ? (
-      <VimeoPlayer url={vimeoUrl} width="100%" height="100%" className={clsx(style['dsw-session__video'])} controls />
+    {videoUrl ? (
+      <ReactPlayer url={videoUrl} width="100%" height="100%" className={clsx(style['dsw-session__video'])} controls />
     ) : (
       <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
         {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}


### PR DESCRIPTION
(ten behoeve van https://github.com/nl-design-system/kernteam/issues/374)

We were using `VimeoPlayer` from `react-player`, by using `ReactPlayer` we can embed YouTube as well as Vimeo.

In this PR we update the first batch of videos to be served from YouTube instead of Vimeo. 

Will replace more Vimeo embeds with YT embeds in subsequent PR(s) until we have nothing from Vimeo.

Summary:

- rename  `vimeoUrl` prop to `videoUrl` to be more generic
- use `ReactPlayer` instead of `VimeoPlayer` to allow both YouTube and Vimeo at the same time
- update URLs for videos that already exist on YouTube