### PR TITLE
Replace remaining Vimeo embeds with YouTube embed

### DIFF
--- a/docs/meedoen/als-developer/03-thema-maken.mdx
+++ b/docs/meedoen/als-developer/03-thema-maken.mdx
@@ -7,7 +7,7 @@ pagination_label: Thema maken
 description: NL Design System thema maken
 ---
 
-import VimeoPlayer from "react-player/vimeo";
+import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # NL Design System thema maken
 
@@ -15,8 +15,8 @@ We hebben twee opnames van de onboarding-week 2021 waarin we vertellen over desi
 
 ## Design tokens vastleggen
 
-<VimeoPlayer url="https://vimeo.com/648638044" controls />
+<VideoPlayer videoId="jSvjnU7oY5Y" />
 
 ## Design tokens inzetten
 
-<VimeoPlayer url="https://vimeo.com/649672645" controls />
+<VideoPlayer videoId="-guAi7Lvl6g" />

--- a/docs/meedoen/als-developer/05-component-inzetten.mdx
+++ b/docs/meedoen/als-developer/05-component-inzetten.mdx
@@ -11,10 +11,10 @@ keywords:
   - component gebruiken
 ---
 
-import VimeoPlayer from "react-player/vimeo";
+import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # Bestaand component inzetten
 
 We hebben een opname van de onboarding-week 2021 waarin we vertellen over het gebruiken van bestaande componenten uit de community:
 
-<VimeoPlayer url="https://vimeo.com/648638044" controls />
+<VideoPlayer videoId="7P6YUT3pmi8" />

--- a/docs/meedoen/design-tokens/README.mdx
+++ b/docs/meedoen/design-tokens/README.mdx
@@ -14,7 +14,7 @@ keywords:
 
 <!-- @license CC0-1.0 -->
 
-import VimeoPlayer from "react-player/vimeo";
+import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # Design tokens
 
@@ -351,11 +351,11 @@ We hebben twee opnames van de onboarding-week 2021 waarin we vertellen over desi
 
 ### Design tokens vastleggen
 
-<VimeoPlayer url="https://vimeo.com/648638044" controls />
+<VideoPlayer videoId="jSvjnU7oY5Y" />
 
 ### Design tokens inzetten
 
-<VimeoPlayer url="https://vimeo.com/649672645" controls />
+<VideoPlayer videoId="-guAi7Lvl6g" />
 
 ## Meer informatie
 

--- a/docs/project/blijf-op-de-hoogte.mdx
+++ b/docs/project/blijf-op-de-hoogte.mdx
@@ -32,4 +32,4 @@ Dit is in de week van ['Uit het doolhof!'](https://www.gebruikercentraal.nl/agen
 
 ### 2022
 
-We hebben alle Design Systems week 2022 sessies opgenomen en deze kun je op de [Design Systems Week 2022 pagina](/events/design-systems-week-2022) vinden en op je gemak terug kijken.
+We hebben alle Design Systemsp week 2022 sessies opgenomen en deze kun je op de [Design Systems Week 2022 pagina](/events/design-systems-week-2022) vinden en op je gemak terug kijken.

--- a/docs/project/events/design-systems-week-2022.mdx
+++ b/docs/project/events/design-systems-week-2022.mdx
@@ -7,7 +7,7 @@ pagination_label: Design Systems Week 2022
 slug: /events/design-systems-week-2022
 ---
 
-import VimeoPlayer from "react-player";
+import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # Design Systems Week 2022
 
@@ -19,70 +19,67 @@ Alle sessies worden opgenomen en op deze pagina beschikbaar gemaakt. Om ze zo sn
 
 In deze eerste sessie openen we de Design Systems week en leggen Angela Imhof en Robbert Broersma uit waarom NL Design System er is, wat NL Design System is en wat jij ermee kunt.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-intro" controls />
+<VideoPlayer videoId="Fr8DAm7GDm0" />
 
 ## Samenwerken aan NL Design System
 
 In deze sessie leggen Robbert Broersma, Yolijn van der Kolk en Jeffrey Lauwers van het kernteam uit hoe ze graag willen samenwerken. Hoe bouwen we nu samen aan een beter, toegankelijker en gebruiksvriendelijker design system? Wat bedoelen we met het Estafettemodel?
 
-<VimeoPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-samen-bouwen-aan-nl-design-system"
-  controls
-/>
+<VideoPlayer videoId="ffKtQO_zlZE" />
 
 ## RVO Design System
 
 Robert Roose is design lead bij de Rijksdienst voor Ondernemend Nederland (RVO), waar hij verantwoordelijk is voor het ontwikkelen van een design system gebaseerd op de Rijkshuisstijl. Hij verteld hoe de RVO het design system gebruikt en verder ontwikkelt en hoe de samenwerking met NL Design System hen vergaat.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-rvo" controls />
+<VideoPlayer videoId="p5cuPu1wJdg" />
 
 ## Toegankelijkheid - Hidde de Vries
 
 Componenten zijn een revolutie gebleken voor onze manier van werken, omdat het wiel uitvinden nu nog meer één keer hoeft. Met een succesvolle aanpak scheelt het teams veel tijd. Samenwerken aan componenten maakt ook mogelijk een positieve impact te hebben op toegankelijkheid. Deze presentatie verkent praktische strategieën om toegankelijke componenten te maken, zodat meer mensen je digitale dienstverlening goed kunnen gebruiken.
 Met zijn ervaring als front-end developer en toegankelijkheidsspecialist kan Hidde je alles vertellen over het toepassen van toegankelijkheidseisen binnen design systems. In deze sessie
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-hidde-de-vries" controls />
+<VideoPlayer videoId="Hjn6IzmDTsY" />
 
 ## Iconen op basis van gebruikersonderzoek
 
 Martijn Rietveld is mede-oprichter van OpenGemeenten. OpenGemeenten bouwt samen met gemeenten aan veilige en toegankelijke online dienstverlening. Martijn vertelt hoe OpenGemeenten iconen op basis van gebruikersonderzoek ontwikkelt en hoe ze deze iconen in samenwerking verbeteren en delen met anderen.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-opengemeenten-iconen" controls />
+<VideoPlayer videoId="WPAcvV5YKF0" />
 
 ## Gemeente Utrecht Design System
 
 Jeroen du Chatinier, UX-designer bij de gemeente Utrecht, vertelt in deze online sessie hoe Utrecht een design system heeft gebouwd en hoe zij het doorontwikkelen.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-utrecht" controls />
+<VideoPlayer videoId="8-GYHyCyTP4" />
 
 ## Belastingdienst Design System - Bold
 
 De afgelopen jaren hebben we hard gewerkt aan een volwaardig design system. Nu krijgen onze verschillende websites, zoals de mijn-omgevingen en informatieve website een uniforme look and feel. Het design system helpt ons om de gebruikerservaring en toegankelijkheid te verbeteren.
 Realisatie is 1 ding, maar het is ook belangrijk dat het Design System goed gebruikt wordt. Dat gebruikers mee kunnen denken en bijdragen leveren aan Bold.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-belastingdienst-bold" controls />
+<VideoPlayer videoId="YbVBDupVuwQ" />
 
 ## DSO-toolkit
 
 Het Digitaal Stelsel Omgevingswet (DSO) is een stelsel van vele applicaties dat uitvoering van de nieuwe Omgevingswet gaat ondersteunen. Het design system (DSO-Toolkit) speelt een cruciale rol in de ontwikkeling van een gebruiksvriendelijk en toegankelijk omgevingsloket.
 Tijdens de presentatie zoomen we in op de rol van het design system binnen het Agile-ontwikkelproces (SAFE) en hoe we samenwerken aan een toegankelijke gebruikservaring voor het gehele omgevingsloket. Deze presentatie wordt gegeven door Sander Haaksma, Lead UX Digitaal Stelsel Omgevingswet.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-dso-toolkit" controls />
+<VideoPlayer videoId="5I_UFoZrxgM" />
 
 ## Gemeente Den Haag Design System
 
 Rozerin Ayerdem en Youri van Heumen van de gemeente Den Haag werken sinds het begin samen met NL Design System. Als digital designer en front-end developer kunnen zij je in deze online sessie vertellen hoe zij hun kennis delen om samen aan een beter NL Design System te bouwen.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-den-haag" controls />
+<VideoPlayer videoId="MDAvhU_WCgI" />
 
 ## NS Design System - Nessie
 
 In deze presentatie vertelt Digital Product Designer Jelle Pieter de Graaf alles over de ontwikkeling van Nessie. wereldklasse. Een design system zorgt ervoor dat je nieuwe oplossingen in een handomdraai kunt ontwerpen en ontwikkelen. En dat designs consistent zijn over alle platformen heen. Precies de problemen die NS wilde oplossen.
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-ns" controls />
+<VideoPlayer videoId="hh0tG_Q2k8U" />
 
 ## Open Formulieren en NL Design System
 
 Sergei Maertens werkt als Django-developer bij Maykin Media. In deze sessie vertelt hij alles over Open Formulieren: wat is het? Hoe werkt het met een design system? Wat is de huidige status van de gebruikte technologie en hoe is de samenwerking met NL Design System?
 
-<VimeoPlayer url="https://vimeo.com/gebruikercentraal/nl-design-system-week-2022-open-formulieren" controls />
+<VideoPlayer videoId="DnFOGFCnzes" />

--- a/docs/project/events/design-systems-week-2023/1-programma.md
+++ b/docs/project/events/design-systems-week-2023/1-programma.md
@@ -21,7 +21,7 @@ Kijk of luister je mee? Alle sessies zijn gratis online bij te wonen en duren on
 
 Dit jaar hebben we nationale én internationale sprekers. We laten ons inspireren door andere design systems en horen waarom organisaties in een design system investeren. Vanuit verschillende perspectieven leren we hoe design systems bijdragen aan toegankelijkheid en gaan we technisch de diepte in met design tokens en web components.
 
-<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" videoUrl="https://youtu.be/0w8DVyc9Mos">
+<DSWSession title="Toe­gan­kelijk­heid verzekeren met NL Design System" speakers={[speakers.PeterBerrevoets]} organisation="NL Design System" videoId="0w8DVyc9Mos">
 
 De overheid staat voor een enorme uitdaging: ervoor zorgen dat websites en apps toegankelijk worden voor iedereen. Maar hoe zorg je ervoor dat toegankelijkheid gegarandeerd onderdeel is van het ontwerp- en ontwikkelproces?
 
@@ -35,7 +35,7 @@ Tijd om nu ook de meerwaarde ervan te laten zien aan managers, beslissers en adv
 
 </DSWSession>
 
-<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" videoUrl="https://youtu.be/H2KVlMSKOmc">
+<DSWSession title="Waarom wij als leverancier werken met NL Design System" speakers={[speakers.MartijnRietveld]} organisation="OpenGemeenten" videoId="H2KVlMSKOmc">
 
 Heeft het NL Design System toegevoegde waarde voor leveranciers van overheden? En zijn er al leerzame voorbeelden van bijdragen van leveranciers die gebruikmaken van het NL Design System? Het antwoord op beide vragen: jazeker!
 
@@ -43,7 +43,7 @@ Martijn Rietveld van OpenGemeenten laat je zien wat de samenwerking met NL Desig
 
 </DSWSession>
 
-<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" videoUrl="https://youtu.be/n9m2TtD1esE">
+<DSWSession title="Onze componenten, jouw huisstijl: over design tokens" speakers={[speakers.JeffreyLauwers]} organisation="NL Design System" videoId="n9m2TtD1esE">
 
 NL Design System wil de beste componenten uit de community herbruikbaar maken voor de hele overheid. Daarom hebben de componenten van het NL Design System van zichzelf geen huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘design tokens’.
 
@@ -51,7 +51,7 @@ Jeffrey Lauwers van NL Design System vertelt kort over design tokens en laat zie
 
 </DSWSession>
 
-<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" videoUrl="https://youtu.be/TFQbp2yNABk">
+<DSWSession title="The future of design decisions" speakers={[speakers.JanSix, speakers.MarcoChristianKrenn]} organisation="Token Studio" videoId="TFQbp2yNABk">
 
 Marco-Christian Krenn en Jan Six presenteren samen The future of design decisions. Verdiep je in de overgang van design tokens naar dynamisch design. Deze overgang heeft gevolgen voor bijvoorbeeld toegankelijkheid en laat zien hoeveel impact designkeuzes hebben. Deze boeiende sessie onderstreept het essentiële verband tussen interne beslissingen en een single source of truth.
 
@@ -59,7 +59,7 @@ Je krijgt een kijkje in de toekomst van design tokens en leert over alle mogelij
 
 </DSWSession>
 
-<DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" videoUrl="https://youtu.be/rVCWIX0tmdM">
+<DSWSession title="Design system laten meegroeien met je organisatie" speakers={[speakers.ArashAzizi]} organisation="PostNL" videoId="rVCWIX0tmdM">
 
 Een design system is altijd in beweging, maar de manier waarop we eraan werken verandert naarmate het groeit. Sinds PostNL het design system Stamp introduceerde, heeft het zich ontwikkeld tot een belangrijk onderdeel van de digitale productontwikkeling. En met de volwassenheid komen er ook weer nieuwe vragen naar boven.
 
@@ -68,13 +68,13 @@ Een design system is namelijk niet alleen een ontwerp- of technische aangelegenh
 
 </DSWSession>
 
-<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" videoUrl="https://youtu.be/51B8OHE9nJ4">
+<DSWSession title="Trinity: het design system van de KvK" speakers={[speakers.HulyaBozkurt,speakers.JoshuaGrootveld]} organisation="Kamer van Koophandel" videoId="51B8OHE9nJ4">
 
 In deze sessie krijg je alles te horen over Trinity, het design system van de Kamer van Koophandel (KVK) dat wordt onderhouden door Team Matrix. Tooling, context en impact komt aan de orde, maar er wordt vooral dieper in gegaan op hoe KVK omgaat met de uitdagingen rondom de adoptie van het design system door de gebruikers. Ben jij erbij? Red pill or blue pill?
 
 </DSWSession>
 
-<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System" videoUrl="https://youtu.be/OUegy1OKtvs">
+<DSWSession title="Toegan­kelijke formulieren met NL Design System" speakers={[speakers.RobbertBroersma,speakers.HiddeDeVries]} organisation="NL Design System" videoId="OUegy1OKtvs">
 
 Ze zijn essentieel voor vrijwel alle digitale overheidsdiensten: formulieren. Zeker nu de Wet modernisering elektronisch bestuurlijk verkeer (WMEBV) burgers en bedrijven het recht gaat geven om elektronisch zaken te doen met de overheid. Logisch dus dat steeds meer organisaties NL Design System gebruiken voor formulieren.
 
@@ -82,7 +82,7 @@ In deze sessie vertellen ontwikkelaars Robbert Broersma en Hidde de Vries je ove
 
 </DSWSession>
 
-<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation=" Public Digital Innovation Space, Cabinet Office, Taiwan" videoUrl="https://youtu.be/_X2zQoL5okw">
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation=" Public Digital Innovation Space, Cabinet Office, Taiwan" videoId="_X2zQoL5okw">
 
 Digitale overheidsdiensten zouden vandaag de dag als publieke infrastructuur moeten worden gezien. Taiwan is in de ongebruikelijke positie dat digitale weerstand essentieel is voor alle overheidsdiensten.
 
@@ -90,7 +90,7 @@ Het design system, met name hoe het gebouwd wordt, speelt een belangrijke rol in
 
 </DSWSession>
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK" videoUrl="https://youtu.be/PuxojwJ2OEE">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} organisation="GOV.UK" videoId="PuxojwJ2OEE">
 
 Een verzameling losse componenten is 1 ding, maar het wordt pas écht interessant als ze bij elkaar komen. Zodat er een volwaardige, digitale overheidsdienst of -product ontstaat. Bij GOV.UK maken ze het makkelijker om te zien hoe zo’n dienst of product eruitziet. Daarvoor gebruiken ze de [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk/docs/).
 
@@ -106,13 +106,13 @@ Meld je aan als je wil leren van een complex praktijkvoorbeeld. Dit is het verha
 
 </DSWSession>
 
-<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning" videoUrl="https://youtu.be/kPbIbf1lM_Y">
+<DSWSession title="Betere toegankelijkheid met een design system" speakers={[speakers.DanielleRameau]} organisation="Sanoma Learning" videoId="kPbIbf1lM_Y">
 
 Hoe kan een design system helpen bij het verbeteren van toegankelijkheid, in 12 educatieve producten, die dagelijks worden gebruikt door 25 miljoen leerlingen over heel Europa? Dat is 1 van de vragen die Sanoma Learning de afgelopen tijd bezig hield. Design systems lead Daniëlle Rameau gaat je meer vertellen over hun aanpak.
 
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth" videoUrl="https://youtu.be/QXHLivD5Y_Q">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} organisation="Nordhealth" videoId="QXHLivD5Y_Q">
 
 Nord is het design system van Nordhealth, een bedrijf dat software maakt voor de gezondheidszorg. Design system lead David Darnes vertelt je in deze sessie over hoe het hen vergaat met Web Components, en hoe die ervoor zorgen dat ze Nord-componenten heel flexibel kunnen gebruiken, met allerlei verschillende technologieën.
 
@@ -122,7 +122,7 @@ Natuurlijk zijn er allerlei nuances en subtiliteiten rondom het gebruik van Web 
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub" videoUrl="https://youtu.be/GYUcd17cLJM">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} organisation="GitHub" videoId="GYUcd17cLJM">
 
 DesignOps (design operations) is het bindmiddel dat een designteam bij elkaar houdt. Daarnaast verbindt het design met andere disciplines binnen én buiten de eigen organisatie. Zelfs als je organisatie geen formeel DesignOps-team heeft, wordt design operations waarschijnlijk wel al door iemand bij jullie gedaan.
 
@@ -132,7 +132,7 @@ Het resultaat: DesignOps waarmee GitHub verder kan. Reden genoeg dus om de gelee
 
 </DSWSession>
 
-<DSWSession title="Management-panel: ervaringen met NL Design System uit de praktijk" speakers={[speakers.JeffreyKlardie, speakers.RoelDerksen, speakers.VincentVanBeek, speakers.PeterBerrevoets]} organisation="NL Design System" videoUrl="https://youtu.be/AfDlY1g2OTo">
+<DSWSession title="Management-panel: ervaringen met NL Design System uit de praktijk" speakers={[speakers.JeffreyKlardie, speakers.RoelDerksen, speakers.VincentVanBeek, speakers.PeterBerrevoets]} organisation="NL Design System" videoId="AfDlY1g2OTo">
 
 Er is tussen overheidsorganisaties enorm veel overlap in de online diensten die we bouwen. Van formulieren (van eenvoudig tot complex) tot zaaksystemen tot digitale processen voor burgers en ambtenaren. Al dit soort websites en apps willen we natuurlijk toegankelijk, inclusief en gebruiksvriendelijk opleveren.
 

--- a/docs/project/events/design-systems-week-2023/english/1-program.md
+++ b/docs/project/events/design-systems-week-2023/english/1-program.md
@@ -26,7 +26,7 @@ These are all sessions that will be in English, with sign up links to each. You 
 
 All sessions can be joined online for free. You will receive a link after sign-up. This link is valid for all talks during the week. Each talk will take about 30 minutes, including time for questions.
 
-<DSWSession title="The future of design decisions" speakers={[speakers.MarcoChristianKrenn, speakers.JanSix]} organisation="Token Studio" lang="en" videoUrl="https://youtu.be/TFQbp2yNABk">
+<DSWSession title="The future of design decisions" speakers={[speakers.MarcoChristianKrenn, speakers.JanSix]} organisation="Token Studio" lang="en" videoId="TFQbp2yNABk">
 
 Marco-Christian Krenn and Jan Six team up to present The future of design decisions. Delve into the transition from design tokens to dynamic design, impacting areas like accessibility, and revealing the profound implications of choices. This engaging discussion underscores the essential connection between internal decisions and the source of truth.
 
@@ -34,7 +34,7 @@ You get a glimpse into the future around design tokens and learn about all the p
 
 </DSWSession>
 
-<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" videoUrl="https://youtu.be/_X2zQoL5okw">
+<DSWSession title="Design systems as public infrastructure" speakers={[speakers.MuAnChiou]} organisation="Public Digital Innovation Space, Cabinet Office, Taiwan" lang="en" videoId="_X2zQoL5okw">
 
 Government digital services should be treated as public infrastructure in this day and age. Taiwan is in a rare position where there is an urgency to ensure digital resilience for all government services.
 
@@ -42,7 +42,7 @@ The design system and especially the engineering of it plays a crucial part in d
 
 </DSWSession>
 
-<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" videoUrl="https://youtu.be/PuxojwJ2OEE">
+<DSWSession title="The GOV.UK Prototype Kit" speakers={[speakers.JoeLanman]} lang="en" organisation="GOV.UK" videoId="PuxojwJ2OEE">
 
 A set of components is one thing, but the true magic comes when they are put in use together. At GOV.UK they make it easier to prototype realistic digital services in HTML, with the GOV.UK Prototype Kit.
 Designer Joe Lanman is involved in this project as a designer and tells you more about it!
@@ -57,7 +57,7 @@ Veera is a codename for a design system employed by many Estonian governmental a
 Attend if you are interested in learning from a complex real-life case study. This is a story from a country which is proud to be called the first digital society. It is also a story about managing expectations, importance of DX, self-restraint, and naming things.
 </DSWSession>
 
-<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" videoUrl="https://youtu.be/QXHLivD5Y_Q">
+<DSWSession title="Design Systems & Web Components: what works & what doesn’t" speakers={[speakers.DavidDarnes]} lang="en" organisation="Nordhealth" videoId="QXHLivD5Y_Q">
 
 Nord is the design system of Nordhealth, a company that makes software for healthcare professionals. Design system lead David Darnes will tell you about their experience with Web Components and how they enable reuse of Nord components across a wide variety of contexts and technologies.
 
@@ -67,7 +67,7 @@ Of course, there is lots of nuance and there are some caveats and challenges. In
 
 </DSWSession>
 
-<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub" videoUrl="https://youtu.be/GYUcd17cLJM">
+<DSWSession title="DesignOps: designing the API of design teams" speakers={[speakers.InayailiLeon]} lang="en" organisation="GitHub" videoId="GYUcd17cLJM">
 
 DesignOps is the glue that keeps a design org together, and the connective tissue that links design to other disciplines across the company, and beyond. Even if your company doesn’t have a formal DesignOps team, this work is likely being done by someone.
 

--- a/docs/project/events/heartbeat.mdx
+++ b/docs/project/events/heartbeat.mdx
@@ -7,7 +7,7 @@ pagination_label: 2 wekelijkse updates van het kernteam en community
 slug: /events/heartbeat
 ---
 
-import ReactPlayer from "react-player";
+import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # Heartbeat
 
@@ -20,78 +20,49 @@ Wil je er (online) bij zijn, heb je vragen of wil je zelf iets vertellen of pres
 
 Rian van het kernteam vertelt over de uitbreiding van de formulierrichtlijnen waar zij met Hidde de Vries aan werkt. Ze was ook bij een gebruikerstest en blikt terug. Mees van Frameless laat de WEMBV-formulieren zien waar de afgelopen weken hard aan is gewerkt, ze worden deze week getest met gebruikers. Jeffrey bespreekt de “Figma-dag” voor designers die vorige week bij de Gemeente Utecht plaatsvond.
 
-<ReactPlayer url="https://www.youtube.com/watch?v=kcfdkSZfrf4" controls className="video-player" />
+<VideoPlayer videoId="kcfdkSZfrf4" />
 
 ## 31 oktober 2023
 
 Francesca van VNG vertelt over de WMEBV-formulieren die worden ontwikkeld in Figma met NL Design System componenten, en binnenkort getest worden met gebruikers. Ook stelt Rian voor: ze is nieuw in het team en gaat zich als toegankelijkheidsspecialist de komende tijd bezig houden met richtlijnen voor (toegankelijke) formulieren.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231031"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="lcG9DFG4NgQ" />
 
 ## 17 oktober 2023
 
 Mark Meijerink presenteert over de Persoonlijke Regelingen Assistent (PRA), een project van Stichting ICTU voor het Ministerie van Binnenlandse Zaken. PRA is een app waarmee burgers en ondernemers gemakkelijk kunnen op welke regelingen en toeslagen ze recht hebben, gemaakt met, hoe kan het ook anders, NL Design System. Bart Nieuwenweg van Draad vertelt over het maken van een nieuw kaartencomponent voor de nieuwe website van de gemeente Den Haag, zijn eerste project met NL Design System.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231017"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="t87tquj-vbU" />
 
 ## 3 oktober 2023
 
 De heartbeat Design Systems Week special waar Rozerin van gemeente Den Haag en René van gemeente Utrecht vertellen over hun ervaring met het gebruik van de NL Design System Figma bibliotheek volgens het stappenplan op de website. Ook geeft Aline Nap van Logius een demo van haar Proof of Concept van variabelen in Figma te gebruiken in combinatie met Design Tokens.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20231003"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="7_P4Xgl_lmw" />
 
 ## 19 september 2023
 
 Vincent van gemeente Amsterdam laat zien wat Amsterdam design system voor mooie dingen heeft bijgedragen laatste tijd. Remko van leverancier Conduction laat zien hoe door gebruik van NL Design System community componenten ze nu 1 applicatie voor diverse gemeentes hebben kunnen gebruiken door alleen verschillende huisstijl thema's in te stellen.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230919"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="Asd3RhL0nQY" />
 
 ## 5 september 2023
 
 Waar Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen met de Figma bibliotheek, de component quick-scan met toegankelijkheid tips en samen een prototype maken in Figma. En kondigt Hidde de Design Systems Week 2023 aan.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230905"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="xiL66AiC7_E" />
 
 ## 22 augustus 2023
 
 Jeffrey laat zien hoe een custom onboarding kan werken door een huisstijlen met de Figma bibliotheek, de component quick-scan met toegankelijkheid tips en samen een prototype maken in Figma. En kondigt Hidde de Design Systems Week 2023 aan.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230822"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="iPXM5L3B6G8" />
 
 ## 11 juli 2023
 
 Jeroen du Chatinier vertelt over hoe je gebruikersondezoek kunt delen met de community op [gebruikersonderzoeken.nl](https://gebruikersonderzoeken.nl/)
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230711
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="ISEaZPPWenk" />
 
 ## 27 juni 2023
 
@@ -99,23 +70,13 @@ Jeroen Visser vertelt over hoe 1Overheid met Figma direct verbinding heeft gemaa
 
 Rida el Mazouji vertelt over zijn stageopdracht bij Frameless, waarin hij met een team van stagiairs (ook Nova, Rowan en Britt) de open source website OpenCatalogi.nl (ontwikkeld door Conduction) heeft gemigreerd naar NL Design System en het Rotterdam Design System heeft aangesloten op NL Design System door een thema te maken.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230627
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="XVTj2oIKtbk" />
 
 ## 13 juni 2023
 
 Robbert vertelt kort over de duizend-en-één soorten tabellen die we in het wild tegenkomen. Aan iedereen de oproep: heb jij een mooie toegankelijke tabel gemaakt, of kom je een interessante complexe tabel tegen die je graag terugziet in NL Design System? Deel het even in Slack! Kom ook kijken bij de Designer Open Hour op 18 juli, waarin we multidisciplinair naar de tabellen gaan kijken.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230613
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="IeJr8nS-O2U" />
 
 ## 16 mei 2023
 
@@ -123,23 +84,13 @@ Nico Druif laat zien hoe de gemeente Amsterdam het zakelijk erfpacht-portaal ont
 
 Vincent Smedinga, Inge de Bondt en Tanja van der Heide vertellen hoe de gemeente Amsterdam is begonnen een nieuw design system te bouwen met NL Design System.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230516
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="i4Cb3shiSKs" />
 
 ## 18 april 2023
 
 Het kernteam wil een handleiding maken over een kleurenpalet die helpt met toegankelijkheid van je huisstijl. Robbert deelt de eerste stappen in het onderzoek naar de contrast-eisen van een toegankelijk palet.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230418
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="C9KZSeEWd5U" />
 
 ## 4 april 2023
 
@@ -147,75 +98,44 @@ Jeroen du Chatinier deelt zijn _hopes and dreams_ over [gebruikersonderzoek van 
 
 Jeffrey laat zien hoe het kernteam white-label Figma componenten maakt, voor componenten die al door de community zijn gemaakt als white-label front-end componenten.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230404
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="qH9QR1zEI7I" />
 
 ## 21 maart 2023
 
 Jeffrey vertelt over waarom we de eerste zijn die het nieuwe Gebruiker Centraal-lettertype gaan gebruiken, en hoe we op basis van de NL Design System richtlijnen tot de conclusie kwamen dat onze site een beter lettertype nodig had.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230321
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="w-hYTRE2mrw" />
 
 ## 7 maart 2023
 
 Rozerin Ayerdem is UX-designer bij de gemeente Den Haag. Voor de nieuwe designs doet Den Haag gebruikersonderzoeken zodat dat de Mijn Omgeving gebruiksvriendelijk en begrijpelijk is voor alle inwoners. Deze heartbeat presenteert zij over gebruikersonderzoek van de Mijn Omgeving.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230309
-"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="hdYLI_tnLq8" />
 
 ## 7 februari 2023
 
 De gemeente Amsterdam gaat meedoen met NL Design System, en Vincent Smedinga vertelt waar ze op hebben gelet bij het onderzoek of meedoen met NL Design System een goed idee is.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230207"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="jFPrIPfWxO4" />
 
 ## 24 januari 2023
 
 Kleine updates uit de community, waaronder de gemeente Utrecht die werkt aan dark mode voor 's avonds met design tokens. Sergei Maertens laat zien hoe hij een design tokens editor heeft gemaakt voor thema's uit de NL Design System community, die je bijvoorbeeld in Storybook gemakkelijk kunt gebruiken.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230124"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="OYAC0xAtsZQ" />
 
 ## 10 januari 2023
 
 Eerste heartbeat van het jaar met kleine updates van het kernteam over het onderhoud waar ze in de kerstvakantie mee bezig zijn geweest.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20230110"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="QWgJ7dztwyY" />
 
 ## 13 december 2022
 
 Laatste heartbeat van 2022 waar Egor de algemenere Rijkshuisstijl componenten, basis componenten, laat zien waar hij bij de RVO mee bezig is geweest.
 Daarnaast blikt Yolijn terug op de plannen die we voor 2022 hadden en wat daarvan terecht is gekomen.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221213"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="Ux1LO7rcqYc" />
 
 ## 15 november 2022
 
@@ -223,19 +143,11 @@ Robbert vertelt over Proof of concept NL Design System componenten voor [onderzo
 Jeffrey verteld waar hij nu staat met componenten hergebruiken in Figma
 Yolijn laat de Playroom zien die is toegevoegd aan [Themes Storybook](https://nl-design-system.github.io/themes/?path=/playroom/button--gemeente-utrecht) waaraan zij nu werkt om in de thema storybook componenten in samenhang te zien.
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221115"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="qHEmFbfKQu4" />
 
 ## 18 oktober 2022
 
 Deze week laat Jeffrey zien hoe we de design tokens in Figma toepassen, koppelen aan de frontend en direct publiceren via Storybook.
 Daarna geeft Yolijn een korte demo van ons resultaat om NL Design System te integreren met Open Formulieren
 
-<ReactPlayer
-  url="https://vimeo.com/gebruikercentraal/nl-design-system-heartbeat-20221018"
-  controls
-  className="video-player"
-/>
+<VideoPlayer videoId="9Gibkuoh1uQ" />

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 import style from './DSWSession.module.css';
 import { IconChevronRight } from '@tabler/icons-react';
 import { Heading, Paragraph } from '@utrecht/component-library-react/dist/css-module';
-import ReactPlayer from 'react-player';
+import { VideoPlayer } from './VideoPlayer';
 
 interface DSWSessionProps {
   headingLevel: 2 | 3 | 4 | 5 | 6;
@@ -15,7 +15,7 @@ interface DSWSessionProps {
   signupLink: string;
   lang?: 'en' | 'nl';
   organisation: string;
-  videoUrl?: string;
+  videoId?: string;
 }
 
 interface DSWSpeaker {
@@ -35,15 +35,15 @@ export const DSWSession = ({
   speakers,
   signupLink,
   organisation,
-  videoUrl,
+  videoId,
   children,
 }: PropsWithChildren<DSWSessionProps>) => (
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
       {title}
     </Heading>
-    {videoUrl ? (
-      <ReactPlayer url={videoUrl} width="100%" height="100%" className={clsx(style['dsw-session__video'])} controls />
+    {videoId ? (
+      <VideoPlayer videoId={videoId} width="100%" height="100%" className={clsx(style['dsw-session__video'])} />
     ) : (
       <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
         {speakers.map((speaker) => speaker.name).join(' & ')} {lang === 'en' ? 'of' : 'van'} {organisation}

--- a/src/components/VideoPlayer.module.css
+++ b/src/components/VideoPlayer.module.css
@@ -1,0 +1,5 @@
+.video-player {
+  margin-block-start: 24px;
+  margin-block-end: 32px;
+  aspect-ratio: 16 / 9;
+}

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactPlayer from 'react-player';
+
+export const VideoPlayer = ({ videoId, ...restProps }) => (
+  <ReactPlayer url={`https://youtube.com/watch?v=${videoId}&disablekb=1`} controls {...restProps} />
+);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -4,5 +4,13 @@ import clsx from 'clsx';
 import style from './VideoPlayer.module.css';
 
 export const VideoPlayer = ({ videoId, className, ...restProps }) => (
-  <ReactPlayer url={`https://youtube.com/watch?v=${videoId}&disablekb=1`} className={`${clsx(style[`video-player`])} ${className}`} width="100%" height="100%" controls {...restProps} />
+  <ReactPlayer
+    url={`https://youtube.com/watch?v=${videoId}`}
+    className={`${clsx(style[`video-player`])} ${className}`}
+    width="100%"
+    height="100%"
+    controls
+    {...restProps}
+    config={{ youtube: { playerVars: { disablekb: 1 } } }}
+  />
 );

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactPlayer from 'react-player';
+import clsx from 'clsx';
+import style from './VideoPlayer.module.css';
 
-export const VideoPlayer = ({ videoId, ...restProps }) => (
-  <ReactPlayer url={`https://youtube.com/watch?v=${videoId}&disablekb=1`} controls {...restProps} />
+export const VideoPlayer = ({ videoId, className, ...restProps }) => (
+  <ReactPlayer url={`https://youtube.com/watch?v=${videoId}&disablekb=1`} className={`${clsx(style[`video-player`])} ${className}`} width="100%" height="100%" controls {...restProps} />
 );

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -631,10 +631,6 @@ abbr[title] {
   margin-inline-start: calc(-1 * var(--utrecht-breadcrumb-nav-item-padding-inline-start, 0));
 }
 
-.video-player {
-  margin-block-start: 24px;
-  margin-block-end: 32px;
-}
 /* WCAG EM rapport */
 .wcag-em dt {
   font-weight: bold;


### PR DESCRIPTION
fixes https://github.com/nl-design-system/kernteam/issues/374

## Video's toegevoegd

- alles van Design Systems Week 2022 
- alle Heartbeats
- de component inzetten, design tokens vastleggen en design tokens inzetten video's

## Andere aanpassingen

- VideoPlayer wrapper around `ReactPlayer`: This makes it easier to do accessibility improvements for all videos like turning off keyboard shortcuts (see https://www.200ok.nl/tips/youtube-embed/), use a different player/wrapper and to switch provider should we ever want to do that again.
- styles voor videoplayer (`.video-player` class) verhuisd naar module bij `VideoPlayer` wrapper