### PR TITLE
feat: add blog post on wembv user tests

### DIFF
--- a/blog/2023/20231121-wmebv-gebruikerstesten.md
+++ b/blog/2023/20231121-wmebv-gebruikerstesten.md
@@ -3,7 +3,7 @@ title: "Gebruikerstesten met Wmebv-formulieren: eerste lessen"
 slug: wmebv-gebruikerstesten
 authors:
   - name: Hidde de Vries
-    title: Public relations & Toegankelijkheidsspecialist NL Design System
+    title: Public relations lead & Toegankelijkheidsspecialist NL Design System
     url: https://www.linkedin.com/in/hiddedevries/
 tags: [NL design system, gebruikerstesten, formulieren]
 hide_table_of_contents: false
@@ -26,7 +26,7 @@ In het kader van Wembv, werkte UX designer Francesca Vonk de afgelopen maanden a
 
 In Francesca's voorbeeldscenario's zoekt Jeroen van Drouwen, een (fictief) persoon, contact met zijn gemeente over de status van zijn aanvraag bijstandsuitkering. Hij had al iets moeten horen, en wil weten hoe het zit. Er waren twee scenario's: met en zonder DigiD. Deze situaties zijn grotendeels in front-end code gebouwd (uiteraard met NL Design System componenten). Er waren ook enkele schermen in Figma, en er was een heuse Gmail-omgeving opgezet met een tijdelijke nep-accounts, zodat het extra realistisch was.
 
-In totaal deden met deze test 7 participanten mee, deels visueel en fysiek beperkt. In een kantoorsituatie hebben ze op een laptop beide testscenario's uitgebreid doorlopen. Ons team keek via Teams mee.
+In totaal deden met deze test 7 participanten mee, met uiteenlopende beperkingen (waaronder visueel, fysiek en cognitief). In een kantoorsituatie hebben ze op een laptop beide testscenario's uitgebreid doorlopen. Ons team keek via Teams mee.
 
 ## Eerste lessen
 
@@ -35,7 +35,7 @@ Gebruikerstesten blijken altijd weer ontzettend leerzaam te zijn. De ene gebruik
 We zijn de punten nog uitgebreid aan het verwerken, maar hier zijn vast zes punten die ons opvielen:
 
 - Voor ons was het formulier min of meer een gegeven, maar eigenlijk iedereen gaf aan liever te bellen met de vraag.
-- De participanten waren vaak wel bekend met DigiD, maar waren er ook huiverig.
+- De participanten waren vaak wel bekend met DigiD, maar waren er ook huiverig voor.
 - Taalgebruik was vaak een barrière, uitdrukkingen als “melding openbare ruimte” leidden tot verwarring.
 - De foutmeldingen werden heel goed begrepen.
 - Meerdere participanten zeiden normaliter liever een telefoon of tablet te gebruiken dan de testlaptop (dit kunnen we in vervolgtesten beter faciliteren).
@@ -47,4 +47,4 @@ _Er was veel feedback. Met post-it's op Miro verzamelden we wat ons opviel._
 
 ## Het vervolg
 
-We vonden het erg waardevol om te zien hoe dit formulier werkte voor mensen buiten ons eigen team. Met de bevindingen gaan we alvast aan de slag. Op termijn hopen we opnieuw een test te kunnen gaan doen.
+We vonden het erg waardevol om te zien hoe dit formulier werkte voor mensen buiten ons eigen team. Met de bevindingen gaan we alvast aan de slag, en we zijn van plan ze te publiceren op [gebruikersonderzoeken.nl](http://gebruikersonderzoeken.nl/). Alleen door gebruikersonderzoek te herhalen kunnen we onze aannames valideren, dus op termijn willen we zeker opnieuw gaan testen.

--- a/blog/2023/20231121-wmebv-gebruikerstesten.md
+++ b/blog/2023/20231121-wmebv-gebruikerstesten.md
@@ -1,0 +1,50 @@
+---
+title: "Gebruikerstesten met Wmebv-formulieren: eerste lessen"
+slug: wmebv-gebruikerstesten
+authors:
+  - name: Hidde de Vries
+    title: Public relations & Toegankelijkheidsspecialist NL Design System
+    url: https://www.linkedin.com/in/hiddedevries/
+tags: [NL design system, gebruikerstesten, formulieren]
+hide_table_of_contents: false
+date: 2023-11-21
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/postits.png
+---
+
+In de afgelopen maanden werkte het NL Design System kernteam samen met VNG aan generieke formulieren. Vorige week testten we ze met gebruikers bij Stichting Accessibility in Utrecht.
+
+## Waarom Wmebv-formulieren?
+
+Om wat context te geven: we maakten deze formulieren specifiek vanwege de [Wet modernisering elektronisch bestuurlijk verkeer](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-modernisering-elektronisch-bestuurlijk-verkeer/) (Wembv). Deze wet treedt volgend jaar in werking en geeft burgers en bedrijven het recht overheidszaken digitaal te regelen. Veel organisaties zijn hierdoor met hun formulieren bezig. Inclusief organisaties in de NL Design System community.
+
+![videogesprek waarin scherm gedeeld wordt, miro.com is open en er staan voorbeelden van schermen in met formulieren](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/generiek-formulier-heartbeat.png)
+_Francesca legt het generieke formulier uit tijdens de [NL Design System Heartbeat van 31 oktober](https://www.youtube.com/watch?v=lcG9DFG4NgQ)_
+
+In het kader van Wembv, werkte UX designer Francesca Vonk de afgelopen maanden aan een generiek formulier. Dit deed ze namens [VNG Realisatie](https://vng.nl/artikelen/vng-realisatie), en samen met het NL Design System kernteam, community-leden (in het bijzonder UX-collega Rozerin Ayerdem van de gemeente Den Haag), front-end stagiairs van Frameless en een jurist van VNG. Uiteindelijk zal ze voor VNG een handreiking schrijven met haar bevindingen.
+
+## De test
+
+In Francesca's voorbeeldscenario's zoekt Jeroen van Drouwen, een (fictief) persoon, contact met zijn gemeente over de status van zijn aanvraag bijstandsuitkering. Hij had al iets moeten horen, en wil weten hoe het zit. Er waren twee scenario's: met en zonder DigiD. Deze situaties zijn grotendeels in front-end code gebouwd (uiteraard met NL Design System componenten). Er waren ook enkele schermen in Figma, en er was een heuse Gmail-omgeving opgezet met een tijdelijke nep-accounts, zodat het extra realistisch was.
+
+In totaal deden met deze test 7 participanten mee, deels laaggeletterd en deels met visuele beperkingen. In een kantoorsituatie hebben ze op een laptop beide testscenario's uitgebreid doorlopen. Ons team keek via Teams mee.
+
+## Eerste lessen
+
+Gebruikerstesten blijken altijd weer ontzettend leerzaam te zijn. De ene gebruiker is de ander niet, en er is veel verschil tussen hoe mensen hun computers willen en kunnen gebruiken. Dat bleek ook vorige week weer.
+
+We zijn de punten nog uitgebreid aan het verwerken, maar hier zijn vast zes punten die ons opvielen:
+
+- voor ons was het formulier min of meer een gegeven, maar eigenlijk iedereen gaf aan liever te bellen met de vraag
+- de participanten waren vaak wel bekend met DigiD, maar waren er ook huiverig
+- taalgebruik was vaak een barrière, uitdrukkingen als “melding openbare ruimte” leidden tot verwarring
+- de foutmeldingen werden heel goed begrepen
+- meerdere participanten zeiden normaliter liever een telefoon of tablet te gebruiken dan de testlaptop (dit kunnen we in vervolgtesten beter faciliteren)
+- de snelheid waarmee participanten door een formulier gingen verschilde enorm, en op de “5 minuten” die op de eerste pagina werden aangekondigd werd verschillend gereageerd (van “wat lang!“ tot “wat kort!”)
+
+![mirobord vol met postits in heel veel kleuren](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/postits.png)
+
+_Er was veel feedback. Met post-it's op Miro verzamelden we wat ons opviel._
+
+## Het vervolg
+
+We vonden het erg waardevol om te zien hoe dit formulier werkte voor mensen buiten ons eigen team. Met de bevindingen gaan we alvast aan de slag. Op termijn hopen we opnieuw een test te kunnen gaan doen.

--- a/blog/2023/20231121-wmebv-gebruikerstesten.md
+++ b/blog/2023/20231121-wmebv-gebruikerstesten.md
@@ -26,7 +26,7 @@ In het kader van Wembv, werkte UX designer Francesca Vonk de afgelopen maanden a
 
 In Francesca's voorbeeldscenario's zoekt Jeroen van Drouwen, een (fictief) persoon, contact met zijn gemeente over de status van zijn aanvraag bijstandsuitkering. Hij had al iets moeten horen, en wil weten hoe het zit. Er waren twee scenario's: met en zonder DigiD. Deze situaties zijn grotendeels in front-end code gebouwd (uiteraard met NL Design System componenten). Er waren ook enkele schermen in Figma, en er was een heuse Gmail-omgeving opgezet met een tijdelijke nep-accounts, zodat het extra realistisch was.
 
-In totaal deden met deze test 7 participanten mee, deels laaggeletterd en deels met visuele beperkingen. In een kantoorsituatie hebben ze op een laptop beide testscenario's uitgebreid doorlopen. Ons team keek via Teams mee.
+In totaal deden met deze test 7 participanten mee, deels visueel en fysiek beperkt. In een kantoorsituatie hebben ze op een laptop beide testscenario's uitgebreid doorlopen. Ons team keek via Teams mee.
 
 ## Eerste lessen
 
@@ -34,12 +34,12 @@ Gebruikerstesten blijken altijd weer ontzettend leerzaam te zijn. De ene gebruik
 
 We zijn de punten nog uitgebreid aan het verwerken, maar hier zijn vast zes punten die ons opvielen:
 
-- voor ons was het formulier min of meer een gegeven, maar eigenlijk iedereen gaf aan liever te bellen met de vraag
-- de participanten waren vaak wel bekend met DigiD, maar waren er ook huiverig
-- taalgebruik was vaak een barrière, uitdrukkingen als “melding openbare ruimte” leidden tot verwarring
-- de foutmeldingen werden heel goed begrepen
-- meerdere participanten zeiden normaliter liever een telefoon of tablet te gebruiken dan de testlaptop (dit kunnen we in vervolgtesten beter faciliteren)
-- de snelheid waarmee participanten door een formulier gingen verschilde enorm, en op de “5 minuten” die op de eerste pagina werden aangekondigd werd verschillend gereageerd (van “wat lang!“ tot “wat kort!”)
+- Voor ons was het formulier min of meer een gegeven, maar eigenlijk iedereen gaf aan liever te bellen met de vraag.
+- De participanten waren vaak wel bekend met DigiD, maar waren er ook huiverig.
+- Taalgebruik was vaak een barrière, uitdrukkingen als “melding openbare ruimte” leidden tot verwarring.
+- De foutmeldingen werden heel goed begrepen.
+- Meerdere participanten zeiden normaliter liever een telefoon of tablet te gebruiken dan de testlaptop (dit kunnen we in vervolgtesten beter faciliteren).
+- De snelheid waarmee participanten door een formulier gingen verschilde enorm, en op de “5 minuten” die op de eerste pagina werden aangekondigd werd verschillend gereageerd (van “wat lang!“ tot “wat kort!”).
 
 ![mirobord vol met postits in heel veel kleuren](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/postits.png)
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -631,6 +631,10 @@ abbr[title] {
   margin-inline-start: calc(-1 * var(--utrecht-breadcrumb-nav-item-padding-inline-start, 0));
 }
 
+#__blog-post-container > p:first-child {
+  font-size: var(--utrecht-paragraph-lead-font-size);
+}
+
 /* WCAG EM rapport */
 .wcag-em dt {
   font-weight: bold;


### PR DESCRIPTION
## Nieuwe content:

- blog post over wembv user tests

## Andere dingen

- de eerste paragraaf een lead grootte gegeven in `custom.css`, vind ik een stuk mooier dan huidig (als eerste stapje; misschien later verder itereren aan blog post styles)