### PR TITLE
feat: remove reading time from blogposts

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,6 +33,7 @@ const config = {
         blog: {
           postsPerPage: 'ALL',
           blogSidebarCount: 0,
+          showReadingTime: false,
         },
         theme: {
           customCss: [


### PR DESCRIPTION
Zoals Robbert zei, hmmm kunnen we die eruit halen?

- [x] Verwijder `reading time` uit blogposts