### PR TITLE
fix: geef codeblokken in blog posts weer een achtergrondkleur

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,6 +18,8 @@
   --nlds-navbar-link-active-border-color: #5eba5b;
   --nlds-sidebar-menu-item-active-border-color: #148839;
 
+  --nlds-code-block-background-color: #011627;
+
   -webkit-font-smoothing: auto !important;
   -moz-osx-font-smoothing: auto !important;
   --ifm-container-width: 1030px;


### PR DESCRIPTION
Ik zag dat codeblokken in de blog posts geen achtergrondkleur kregen, mogelijk door slordigheid mijnerzijds. Dit lost dat voor nu op.

voor: 
<img width="626" alt="code blok met witte achtergrond en weinig contrast" src="https://github.com/nl-design-system/documentatie/assets/178782/556eb0bf-e5ae-4500-b068-47144db46176">


na: 
<img width="534" alt="zoals hierboven maar met zwarte achtergrond en daardoor goed contrast" src="https://github.com/nl-design-system/documentatie/assets/178782/3c039714-ba17-476f-b3d9-b79b28d591fa">


uit commit message:



> This is ugly, there is likely a more specific place this should go. It is also set on `pre`, but the inline style that the markdown processor sets on one of its containing divs needs the variable to be set already (and targeting that specific div seems potentially more likely to break).