### PR TITLE
build: update to Prettier 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "npm-check-updates": "16.14.12",
     "npm-package-json-lint": "7.1.0",
     "npm-run-all": "4.1.5",
-    "prettier": "2.8.8",
+    "prettier": "3.2.4",
     "react-hook-form": "7.49.3",
     "react-player": "2.14.1",
     "react-syntax-highlighter": "15.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: 4.1.5
         version: 4.1.5
       prettier:
-        specifier: 2.8.8
-        version: 2.8.8
+        specifier: 3.2.4
+        version: 3.2.4
       react-hook-form:
         specifier: 7.49.3
         version: 7.49.3(react@18.2.0)
@@ -11628,9 +11628,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.2.4:
+    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 

--- a/src/_generate-component-pages/index.ts
+++ b/src/_generate-component-pages/index.ts
@@ -71,11 +71,14 @@ componentIndex.forEach(({ state, id, name, implementations, backlog }) => {
 
   console.log(`File created: ${fileName}`);
 
-  const groupedImplementations = implementations.reduce((grouped, implementation) => {
-    const group = grouped[implementation.type] || [];
-    grouped[implementation.type] = [...group, implementation];
-    return grouped;
-  }, {} as { [key: string]: ComponentImplementation[] });
+  const groupedImplementations = implementations.reduce(
+    (grouped, implementation) => {
+      const group = grouped[implementation.type] || [];
+      grouped[implementation.type] = [...group, implementation];
+      return grouped;
+    },
+    {} as { [key: string]: ComponentImplementation[] },
+  );
 
   if (implementations.length) {
     fs.appendFileSync(fileName, getImplementationsSection());

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -1,18 +1,19 @@
-import { Button, HTMLContent } from '@utrecht/component-library-react/dist/css-module';
+import { Button } from '@utrecht/component-library-react/dist/css-module';
+import { HTMLContent } from '@utrecht/component-library-react/dist/css-module';
 import clsx from 'clsx';
-import prettierBabel from 'prettier/parser-babel';
-import prettierHTML from 'prettier/parser-html';
+import prettierBabel from 'prettier/plugins/babel.mjs';
+import prettierESTree from 'prettier/plugins/estree.mjs';
+import prettierHTML from 'prettier/plugins/html.mjs';
 import prettier from 'prettier/standalone';
-import React, { ReactNode } from 'react';
+import React, { isValidElement, ReactNode, useEffect, useState } from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { v4 as uuid } from 'uuid';
 import style from './Canvas.module.css';
-import { PrismStyle } from './PrismStyle';
+import { CodeBlockSyntaxHighlighting } from '/src/components/CodeBlockSyntaxHighlighting';
 
 interface CanvasProps {
   defaultCollapsed?: boolean;
-  code?: ReactNode;
+  code?: string | ReactNode | (() => ReactNode);
   children: ReactNode | (() => ReactNode);
   language: any;
   copy?: boolean;
@@ -27,31 +28,39 @@ const toggleExpanded = ({ target }) => {
 };
 
 export const Canvas = ({ code, copy = false, defaultCollapsed = true, children, language }: CanvasProps) => {
-  let reactNode;
-  if (typeof children === 'function') {
-    reactNode = children();
-  } else {
-    reactNode = children;
-  }
-  const formatted = prettier.format(ReactDOMServer.renderToStaticMarkup(code || reactNode), {
-    parser: 'html',
-    plugins: [prettierBabel, prettierHTML],
-    semi: false,
-    singleAttributePerLine: true,
-    embeddedLanguageFormatting: 'off',
-    htmlWhitespaceSensitivity: 'ignore',
-  });
+  // By default the `children` argument is converted to code.
+  let jsxTree = typeof children === 'function' ? children() : children;
+  // You can override the code from `children` with the `code` argument.
+  // The code argument can be a string, or JSX, or a function that generates JSX.
+  let codeJsxTree = typeof code === 'function' ? code() : isValidElement(code) ? code : undefined;
+  let unformattedCode = typeof code === 'string' ? code : ReactDOMServer.renderToStaticMarkup(codeJsxTree || jsxTree);
+  let [displayCode, setDisplayCode] = useState(unformattedCode);
+
+  useEffect(() => {
+    const formatWithPrettier = async () => {
+      displayCode = await prettier.format(unformattedCode, {
+        parser: language,
+        plugins: [prettierBabel, prettierESTree, prettierHTML],
+        semi: false,
+        singleAttributePerLine: true,
+        embeddedLanguageFormatting: 'off',
+        htmlWhitespaceSensitivity: 'ignore',
+      });
+      setDisplayCode(displayCode);
+    };
+    formatWithPrettier();
+  }, [unformattedCode]);
 
   const codeBlockId = uuid();
 
   const copyCode = () => {
-    navigator.clipboard.writeText(formatted).catch((err) => console.error('Copy code failed', err));
+    navigator.clipboard.writeText(displayCode).catch((err) => console.error('Copy code failed', err));
   };
 
   return (
     <div className={clsx(style['nlds-canvas'])}>
       <div className={clsx(style['nlds-canvas__example'])}>
-        <HTMLContent className="voorbeeld-theme">{reactNode}</HTMLContent>
+        <HTMLContent className="voorbeeld-theme">{jsxTree}</HTMLContent>
       </div>
       <div className={clsx(style['nlds-canvas__toolbar'])}>
         <Button
@@ -69,9 +78,7 @@ export const Canvas = ({ code, copy = false, defaultCollapsed = true, children, 
         id={codeBlockId}
         hidden={defaultCollapsed}
       >
-        <SyntaxHighlighter language={language} style={PrismStyle}>
-          {formatted}
-        </SyntaxHighlighter>
+        <CodeBlockSyntaxHighlighting syntax={language} textContent={displayCode} trim />
         {copy && (
           <div className={clsx(style['nlds-canvas__toolbar'])}>
             <Button

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import prettierBabel from 'prettier/plugins/babel.mjs';
 import prettierESTree from 'prettier/plugins/estree.mjs';
 import prettierHTML from 'prettier/plugins/html.mjs';
+import prettierPostcss from 'prettier/plugins/postcss.mjs';
 import prettier from 'prettier/standalone';
 import React, { isValidElement, ReactNode, useEffect, useState } from 'react';
 import * as ReactDOMServer from 'react-dom/server';
@@ -40,7 +41,7 @@ export const Canvas = ({ code, copy = false, defaultCollapsed = true, children, 
     const formatWithPrettier = async () => {
       displayCode = await prettier.format(unformattedCode, {
         parser: language,
-        plugins: [prettierBabel, prettierESTree, prettierHTML],
+        plugins: [prettierBabel, prettierESTree, prettierHTML, prettierPostcss],
         semi: false,
         singleAttributePerLine: true,
         embeddedLanguageFormatting: 'off',

--- a/src/components/CodeBlockSyntaxHighlighting.tsx
+++ b/src/components/CodeBlockSyntaxHighlighting.tsx
@@ -3,19 +3,19 @@ import { Highlight } from 'prism-react-renderer';
 import React, { Element, PropsWithChildren } from 'react';
 import nldsPrismTheme from '../../nldsPrism';
 
-export interface CodeBlockSyntaxHiglightingProps extends CodeBlockProps {
+export interface CodeBlockSyntaxHighlightingProps extends CodeBlockProps {
   lineNumber?: boolean;
   textContent: string;
   syntax?: string;
   trim?: boolean;
 }
 
-export function CodeBlockSyntaxHiglighting({
+export function CodeBlockSyntaxHighlighting({
   lineNumber,
   syntax,
   textContent,
   trim,
-}: PropsWithChildren<CodeBlockSyntaxHiglightingProps>): Element {
+}: PropsWithChildren<CodeBlockSyntaxHighlightingProps>): Element {
   let code = textContent;
 
   if (trim) {
@@ -41,4 +41,4 @@ export function CodeBlockSyntaxHiglighting({
   );
 }
 
-export default CodeBlockSyntaxHiglighting;
+export default CodeBlockSyntaxHighlighting;

--- a/src/components/examples/GraffitiForm.tsx
+++ b/src/components/examples/GraffitiForm.tsx
@@ -237,8 +237,8 @@ export const GraffitiForm = ({
                     ? postalCodeSpace === true
                       ? /^\d{4} [A-Za-z]{2}$/
                       : postalCodeSpace === false
-                      ? /^\d{4}[A-Za-z]{2}$/
-                      : /^\s*\d{4}\s*[A-Za-z]{2}\s*$/
+                        ? /^\d{4}[A-Za-z]{2}$/
+                        : /^\s*\d{4}\s*[A-Za-z]{2}\s*$/
                     : undefined,
                 })}
                 type="text"
@@ -556,8 +556,8 @@ export const GraffitiForm = ({
                   noAutoComplete === true || noAutoComplete.includes('telefoonnummer')
                     ? undefined
                     : telNational
-                    ? 'tel-national'
-                    : 'tel'
+                      ? 'tel-national'
+                      : 'tel'
                 }
                 invalid={!!errors['telefoonnummer']}
                 aria-describedby={`${phoneId}-description`}

--- a/src/theme/MDXComponents/Pre.tsx
+++ b/src/theme/MDXComponents/Pre.tsx
@@ -1,6 +1,6 @@
 import type { Props as MDXPreProps } from '@theme/MDXComponents/Pre';
 import React, { isValidElement } from 'react';
-import { CodeBlockSyntaxHiglighting } from '/src/components/CodeBlockSyntaxHiglighting';
+import { CodeBlockSyntaxHighlighting } from '/src/components/CodeBlockSyntaxHighlighting';
 import { Element, Props } from 'react';
 
 export default function MDXPre(props: MDXPreProps): React.Element {
@@ -23,5 +23,5 @@ export default function MDXPre(props: MDXPreProps): React.Element {
     }
   }
 
-  return <CodeBlockSyntaxHiglighting syntax={syntax} textContent={textContent} trim />;
+  return <CodeBlockSyntaxHighlighting syntax={syntax} textContent={textContent} trim />;
 }

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -108,8 +108,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   const resultsFooterComponent = useMemo(
     () =>
       // eslint-disable-next-line react/no-unstable-nested-components
-      (footerProps) =>
-        <ResultsFooter {...footerProps} onClose={onClose} />,
+      (footerProps) => <ResultsFooter {...footerProps} onClose={onClose} />,
     [onClose],
   );
   const transformSearchClient = useCallback(


### PR DESCRIPTION
This doesn't work yet, because Prettier switched to an asynchronous API with `await` and that doesn't play well with server side formatting of code snippets yet.