### PR TITLE
ci: avoid build for release with `skip ci`

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
       "conventionalCommits": true,
       "syncWorkspaceLock": true,
       "exact": true,
-      "message": "docs(release): design system packages"
+      "message": "docs(release): design system packages\n\n[skip ci]"
     }
   }
 }


### PR DESCRIPTION
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/

This should avoid using up ~250 screenshots from the Argos budget for every PR merge.