### PR TITLE
feat: add `CodeBlockSyntaxHighlighting` component

### DIFF
--- a/packages/nlds-design-tokens/src/tokens.json
+++ b/packages/nlds-design-tokens/src/tokens.json
@@ -196,7 +196,11 @@
     },
     "code-block": {
       "font-size": { "value": "18px" },
-      "line-height": { "value": "24px" }
+      "line-height": { "value": "24px" },
+      "padding-block-end": { "value": "16px" },
+      "padding-block-start": { "value": "16px" },
+      "padding-inline-end": { "value": "16px" },
+      "padding-inline-start": { "value": "16px" }
     },
     "paragraph": {
       "font-size": { "value": "18px" },

--- a/src/components/Bingo.tsx
+++ b/src/components/Bingo.tsx
@@ -1,3 +1,4 @@
+import Head from '@docusaurus/Head';
 import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/dist/css-module';
 import clsx from 'clsx';
 import React from 'react';
@@ -47,6 +48,9 @@ export const Bingo = ({ items }: BingoProps) => {
 
   return (
     <div className={style['bingo']}>
+      <Head>
+        <meta name="argos" content="false" />
+      </Head>
       <div className={style['bingo__form']}>
         {bingoNumbers.map((bingoNumber) => (
           <div className={style['bingo__number']} key={bingoNumber}>

--- a/src/components/CodeBlockSyntaxHiglighting.tsx
+++ b/src/components/CodeBlockSyntaxHiglighting.tsx
@@ -1,0 +1,44 @@
+import { CodeBlock, CodeBlockProps } from '@utrecht/component-library-react/dist/css-module';
+import { Highlight } from 'prism-react-renderer';
+import React, { Element, PropsWithChildren } from 'react';
+import nldsPrismTheme from '../../nldsPrism';
+
+export interface CodeBlockSyntaxHiglightingProps extends CodeBlockProps {
+  lineNumber?: boolean;
+  textContent: string;
+  syntax?: string;
+  trim?: boolean;
+}
+
+export function CodeBlockSyntaxHiglighting({
+  lineNumber,
+  syntax,
+  textContent,
+  trim,
+}: PropsWithChildren<CodeBlockSyntaxHiglightingProps>): Element {
+  let code = textContent;
+
+  if (trim) {
+    code = code.trim();
+  }
+
+  return (
+    <Highlight theme={nldsPrismTheme} code={code} language={syntax || ''}>
+      {({ style, tokens, getLineProps, getTokenProps }) => (
+        <CodeBlock style={style}>
+          {tokens.map((line, i) => (
+            <span key={i} {...getLineProps({ line })}>
+              {lineNumber && <span>{i + 1}</span>}
+              {line.map((token, key) => (
+                <span key={key} {...getTokenProps({ token })} />
+              ))}
+              {'\n'}
+            </span>
+          ))}
+        </CodeBlock>
+      )}
+    </Highlight>
+  );
+}
+
+export default CodeBlockSyntaxHiglighting;

--- a/src/theme/MDXComponents/Pre.tsx
+++ b/src/theme/MDXComponents/Pre.tsx
@@ -1,15 +1,27 @@
-import CodeBlock from '@theme/CodeBlock';
-import type { Props } from '@theme/MDXComponents/Pre';
+import type { Props as MDXPreProps } from '@theme/MDXComponents/Pre';
 import React, { isValidElement } from 'react';
+import { CodeBlockSyntaxHiglighting } from '/src/components/CodeBlockSyntaxHiglighting';
+import { Element, Props } from 'react';
 
-export default function MDXPre(props: Props): React.Element {
-  return (
-    <CodeBlock
-      // If this pre is created by a ``` fenced codeblock, unwrap the children
-      {...(isValidElement(props.children) &&
-      (props.children.props as { originalType: string } | null)?.originalType === 'code'
-        ? props.children.props
-        : { ...props })}
-    />
-  );
+export default function MDXPre(props: MDXPreProps): React.Element {
+  let syntax;
+  let textContent = '';
+
+  if (isValidElement(props.children)) {
+    const elementProps = (props.children as Element).props as Props;
+    const match =
+      typeof elementProps.className === 'string'
+        ? elementProps.className.match(/(?:^|.*\s)(?:language-)([^\s]+)(?:\s+|$)/)
+        : null;
+
+    if (match) {
+      syntax = match[1];
+    }
+
+    if (typeof elementProps.children === 'string') {
+      textContent = elementProps.children;
+    }
+  }
+
+  return <CodeBlockSyntaxHiglighting syntax={syntax} textContent={textContent} trim />;
 }

--- a/test/visual/argos-visual-regression.test.ts
+++ b/test/visual/argos-visual-regression.test.ts
@@ -39,6 +39,11 @@ const screenshotPathname = (pathname: string) => {
     const url = siteUrl + pathname;
     await page.goto(url);
     await page.waitForFunction(waitForDocusaurusHydration);
+
+    const noVisualRegressionTest = (await page.locator('meta[name="argos"][content="false"]').count()) > 0;
+
+    test.skip(noVisualRegressionTest, 'Skipped because of <meta name="argos" content="false">');
+
     await argosScreenshot(page, `${screenshotPath}${pathnameToArgosName(pathname)}`);
   });
 };


### PR DESCRIPTION
## test stability

Added a new feature to the visual regression test runner: pages that contain `<meta name="argos" content="false">` are skipped. The bingo page will now be skipped, because the randomized content caused the test to (practically) always fail.

<img width="1015" alt="Screenshot 2024-01-17 at 13 32 06" src="https://github.com/nl-design-system/documentatie/assets/30694/d52026ca-8cc5-4bca-b870-b20e5e88b9ca">

<img width="254" alt="Screenshot 2024-01-17 at 13 33 50" src="https://github.com/nl-design-system/documentatie/assets/30694/e9c97fc2-d281-466a-8305-bf5c15e04802">

## code example

The code examples using three backticks from `.md` files are now highlighted using a new component: `CodeBlockSyntaxHighlighting`, which extends the Utrecht `CodeBlock`.

<img width="813" alt="Screenshot 2024-01-17 at 13 39 41" src="https://github.com/nl-design-system/documentatie/assets/30694/6b602893-d97c-4a8f-8f95-cb32478d70bb">
