### PR TITLE
docs: make example canvas optional

### DIFF
--- a/docs/richtlijnen/formulieren/05-voorspelbaar.mdx
+++ b/docs/richtlijnen/formulieren/05-voorspelbaar.mdx
@@ -49,11 +49,8 @@ _Dit is verplicht om te voldoen aan WCAG 2.1, criterium [2.4.2 Paginatitel](http
 >
   <Canvas
     language="html"
-    code={
-      <>
-        <title>Uw gegevens - Afspraak maken - Voorbeeldinstantie</title>
-      </>
-    }
+    code={<title>Uw gegevens - Afspraak maken - Voorbeeldinstantie</title>}
+    defaultCollapsed={false}
   ></Canvas>
 </Guideline>
 
@@ -62,14 +59,7 @@ _Dit is verplicht om te voldoen aan WCAG 2.1, criterium [2.4.2 Paginatitel](http
   title="Te algemene paginatitel"
   description={<Paragraph>Zorg dat de informatie in de titel specifiek genoeg is.</Paragraph>}
 >
-  <Canvas
-    language="html"
-    code={
-      <>
-        <title>Voorbeeldinstantie</title>
-      </>
-    }
-  ></Canvas>
+  <Canvas defaultCollapsed={false} language="html" code={<title>Voorbeeldinstantie</title>}></Canvas>
 </Guideline>
 
 ## Velden onder elkaar

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -60,9 +60,11 @@ export const Canvas = ({ code, copy = false, defaultCollapsed = true, children, 
 
   return (
     <div className={clsx(style['nlds-canvas'])}>
-      <div className={clsx(style['nlds-canvas__example'])}>
-        <HTMLContent className="voorbeeld-theme">{jsxTree}</HTMLContent>
-      </div>
+      {jsxTree && (
+        <div className={clsx(style['nlds-canvas__example'])}>
+          <HTMLContent className="voorbeeld-theme">{jsxTree}</HTMLContent>
+        </div>
+      )}
       <div className={clsx(style['nlds-canvas__toolbar'])}>
         <Button
           className={clsx(style['nlds-canvas__button'], style['nlds-canvas__toggle-code-button'])}


### PR DESCRIPTION
Voorbeeld zonder canvas:

<img width="805" alt="Screenshot 2024-01-23 at 10 57 00" src="https://github.com/nl-design-system/utrecht/assets/30694/1f7456df-eca8-4160-a92a-22141d7d4058">
