### PR TITLE
Fix foutmeldingen feedback

### DIFF
--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-feedback.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-feedback.md
@@ -13,7 +13,7 @@ Twee ARIA-attributen zijn belangrijk voor screenreaderfeedback:
 - `aria-required="true"` vertelt dat een veld verplicht is.
 - `aria-invalid="true"` vertelt dat een veld niet goed is ingevuld.
 
-Initieel staat de waarde van `aria-invalid` op `false`. Verander bij foutmeldingen de waarde van `true` naar `false`. Eventueel kan het attribuut `aria-invalid` kan ook worden weggelaten totdat de tot validatie is uitgevoerd.
+Initieel staat de waarde van `aria-invalid` op `false`. Verander bij foutmeldingen de waarde van `false` naar `true`. Eventueel kan het attribuut `aria-invalid` kan ook worden weggelaten totdat de validatie is uitgevoerd.
 
 ```html
 <label for="voorbeeld">Voorbeeld</label>

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-location.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-location.md
@@ -2,4 +2,4 @@
 
 Voor foutmeldingen geldt hetzelfde als voor descriptions: de beste locatie is boven het formulierveld. Bovendien moet de foutmelding `aria-describedby` gekoppeld zijn aan het formulierveld.
 
-Hoe dit te doen is beschreven bij de [richlijnen over descriptions](/richtlijnen/formulieren/alle-richtlijnen/descriptions).
+Hoe dit te doen is beschreven bij de [richtlijnen over descriptions](/richtlijnen/formulieren/alle-richtlijnen/descriptions).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
@@ -12,6 +12,6 @@ Dit type foutafhandeling geeft onvoldoende informatie. In veel browsers wordt ni
 
 Wanneer er voldoende tijd en kennis, heeft het de voorkeur om zelf client-side validatie toe te voegen.
 
-Om specifiek aan hulptechnologieën te communiceren dat een veld verplicht is, kan  `aria-required` worden gebruikt. Als je alleen `aria-required` gebruikt, zal de browser niet zelf valideren of feedback geven.
+Om specifiek aan hulptechnologieën te communiceren dat een veld verplicht is, kan `aria-required` worden gebruikt. Als je alleen `aria-required` gebruikt, zal de browser niet zelf valideren of feedback geven.
 
 Door het toegankelijk maken van foutmeldingen voldoe je aan het WCAG-succescriterium [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG21-nl/#foutidentificatie) (niveau A).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
@@ -4,14 +4,14 @@
 
 De meeste browsers kunnen zelf controleren of een veld is ingevuld. Dit gebeurt als het HTML-attribuut `required` in het formulierveld staat.
 
-Dit type foutafhandeling geeft onvoldoende informatie en is niet altijd toegankelijk genoeg voor screenreadergebruikers.
-
 ```html
 <input type="text" id="voorbeeld" name="voorbeeld" required />
 ```
 
-De richtlijn [Voorkom fouten](richtlijnen/formulieren/alle-richtlijnen/help-de-gebruiker) gaat hier dieper op in.
+Dit type foutafhandeling geeft onvoldoende informatie. In veel browsers wordt niet aan alle gebruikers overgebracht dat het veld verplicht is, en mist uitleg wanneer niet wordt voldaan een een opgegeven `pattern`. Zie ook: [Avoid default field validation](https://adrianroselli.com/2019/02/avoid-default-field-validation.html) van Adrian Roselli.
 
-Alhoewel het gebruik van `required` in plaats van `aria-required` niet fout is, geven we de voorkeur aan `aria-required`. Met `aria-required` wordt het veld voor hulptechnologieën, zoals een screenreader, gemarkeerd als verplicht, maar gaat de browser niet zelf valideren.
+Wanneer er voldoende tijd en kennis, heeft het de voorkeur om zelf client-side validatie toe te voegen.
+
+Om specifiek aan hulptechnologieën te communiceren dat een veld verplicht is, kan  `aria-required` worden gebruikt. Als je alleen `aria-required` gebruikt, zal de browser niet zelf valideren of feedback geven.
 
 Door het toegankelijk maken van foutmeldingen voldoe je aan het WCAG-succescriterium [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG21-nl/#foutidentificatie) (niveau A).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary-code.mdx
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary-code.mdx
@@ -4,13 +4,12 @@ import { Guideline } from "@site/src/components/Guideline";
 <Guideline
   appearance="do"
   title="Een samenvatting van de fouten boven het formulier."
-  description="Met role=alert op een span in het kopje van het formulier."
+  description="Verplaats focus naar de samenvatting of de kop van de samenvatting."
 >
   <Canvas language="html">
     {() => (
       <>
-        <h2>
-          <span role="alert">Er was een probleem met je inzending. Controleer de onderstaande velden</span>
+        <h2>Invoerfouten gevonden in het formulier</span>
         </h2>
         <ul>
           <li>

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary-code.mdx
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary-code.mdx
@@ -9,17 +9,13 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <h2>Invoerfouten gevonden in het formulier</span>
-        </h2>
+        <h2>Invoerfouten gevonden in het formulier</h2>
         <ul>
           <li>
             <a href="#naam">Vul uw naam in.</a>
           </li>
           <li>
             <a href="#email">Vul uw e-mailadres in.</a>
-          </li>
-          <li>
-            <a href="#privacybeleid">Ga akkoord met ons privacybeleid.</a>
           </li>
         </ul>
         <form>[...]</form>

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary.md
@@ -1,8 +1,8 @@
 ## Samenvatting boven het formulier
 
-Een zeer gebruikersvriendelijke manier om fouten weer te geven is een combinatie van een
+Een zeer gebruikersvriendelijke manier om fouten weer te geven is een combinatie van:n
 
-- samenvatting boven het formulier en;
+- een samenvatting boven het formulier en;
 - per formulierveld de foutmelding herhalen.
 
 Elke foutmelding in de samenvatting is ook een link naar het formulier. Hierdoor kan de toetsenbordgebruiker direct doorgaan naar het veld met de foutmelding.
@@ -11,8 +11,8 @@ De constructie is als volgt:
 
 - Na het versturen van een formulier met fouten wordt **boven** het formulier een lijst met fouten getoond.
 - Deze lijst heeft een kopje met bijvoorbeeld de tekst:
-  "Er was een probleem met je inzending. Controleer de onderstaande velden.".
-- Dit kopje krijgt de toetsenbordfocus zodat het meteen in beeld staat en ook voorgelezen wordt door een screenreader.
+  "Er was een probleem met je inzending. Verbeter de fouten voor je verder gaat.".
 - Daaronder staat een lijst met de foutmeldingen. Elke foutmelding is ook een link naar het bijbehorende formulierveld.
+- Het kopje boven de fouten krijgt de toetsenbordfocus. Dan staat het meteen in beeld, wordt het voorgelezen door screenreaders en is de tabvolgorde logisch: de links naar de betreffende velden zijn de eerstvolgende items.
 
 Door het schrijven van duidelijke foutmeldingen voldoe je aan het WCAG-succescriterium [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG21-nl/#foutidentificatie) (niveau A).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-summary.md
@@ -1,6 +1,6 @@
 ## Samenvatting boven het formulier
 
-Een zeer gebruikersvriendelijke manier om fouten weer te geven is een combinatie van:n
+Een zeer gebruikersvriendelijke manier om fouten weer te geven is een combinatie van:
 
 - een samenvatting boven het formulier en;
 - per formulierveld de foutmelding herhalen.

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-timing.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-timing.md
@@ -4,7 +4,7 @@ Het is van belang _wanneer_ een veld op fouten wordt gecheckt.
 
 Stel, je typt een e-mailadres en na het invoeren van het eerste karakter verschijnt al een foutmelding "Ongeldig e-mailadres".
 
-Die melding verdwijnt pas als het hele e-mailadres is ingevuld. Dit is niet alleen irritant, het kan ook onzekerheid en verwarring veroorzaken. Wat doe ik fout? Ik ben nog niet klaar met invullen en het is nu al fout!
+Die melding verdwijnt pas als het hele e-mailadres is ingevuld. Dit is niet alleen irritant, het kan ook onzekerheid en verwarring veroorzaken. “Wat doe ik fout? Ik ben nog niet klaar met invullen en het is nu al fout!”
 
 Controleer een veld bijvoorbeeld als de gebruiker het veld heeft aangepast en daarna verlaat ('blur' en 'input') of wanneer het formulier wordt verzonden.
 

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/errors.mdx
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/errors.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Foutmeldingen
 pagination_label: Foutmeldingen
-description: Als een veld niet goed is ingevuld, moet voor iedereen duidelijk zijn wat er niet klopt. Hoe help je de gebruiker het beste als deze onjuiste of onvolledige informatie invult?
+description: Als een veld niet goed is ingevuld, moet voor iedereen duidelijk zijn wat er niet klopt. Hoe help je de gebruiker het beste als die onjuiste of onvolledige informatie invult?
 slug: foutmeldingen
 keywords:
   - informatie


### PR DESCRIPTION
We hadden in #538 nog een aantal issues gemist dus die heb ik hier nog gefixed. 

Eén ding is niet rechttoerechtaan fix, nl dat ik ook `role=alert` heb weggehaald van de samenvatting + opsomming met fouten, en de aanbeveling heb toegevoegd die focus te geven (ipv `role=alert`). Discussie daarover [hadden we in Slack](https://codefornl.slack.com/archives/C02CWGL2M18/p1706272632252879), mochten we daar nog over willen doorpraten kan ik die wijziging ook nog even uit deze PR halen.