### PR TITLE
fix: update broken redirects

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -2,15 +2,15 @@ DirectoryIndex index.html
 
 Redirect 301 /footer/toegankelijkheidsverklaring /toegankelijkheidsverklaring
 Redirect 301 /footer/colofon /colofon
-Redirect 301 /videos/design-system-week-2022 /videos/design-systems-week-2022
+Redirect 301 /videos/design-system-week-2022 /events/design-systems-week-2022
 
-Redirect 301 /videos(.*)$ /project/events$1
+RedirectMatch 301 /videos(.*)$ /project/events$1
 
-Redirect 301 /meedoen/als-organisatie/(.*)$ /handboek/organisatie$1
-Redirect 301 /meedoen/als-leverancier/(.*)$ /handboek/leverancier$1
-Redirect 301 /meedoen/als-developer/(.*)$ /handboek/developer$1
-Redirect 301 /meedoen/als-designer/(.*)$ /handboek/designer$1
-Redirect 301 /meedoen(.*)$ /handboek$1
+RedirectMatch 301 /meedoen/als-organisatie/(.*)$ /handboek/organisatie$1
+RedirectMatch 301 /meedoen/als-leverancier/(.*)$ /handboek/leverancier$1
+RedirectMatch 301 /meedoen/als-developer/(.*)$ /handboek/developer$1
+RedirectMatch 301 /meedoen/als-designer/(.*)$ /handboek/designer$1
+RedirectMatch 301 /meedoen(.*)$ /handboek$1
 
-Redirect 301 /project/events(.*)$ /community/events$1
- Redirect 301 /project/wie-doet-mee /community/wie-doet-mee
+RedirectMatch 301 /project/events(.*)$ /community/events$1
+Redirect 301 /project/wie-doet-mee /community/wie-doet-mee


### PR DESCRIPTION
The patterns weren't matched, this should match them. The redirect to 2022 videos wasn't going to the new page, this adds the right page.