### PR TITLE
Fix design bugs

### DIFF
--- a/src/components/CardGroup.module.css
+++ b/src/components/CardGroup.module.css
@@ -94,18 +94,18 @@
   padding-inline: var(--card-content-padding-inline, 24px);
 }
 
-@media (width <= 996px) {
+@media (width => 768px) {
   .cardgroup--medium {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
     min-height: fit-content;
   }
 }
 
-@media (width <= 768px) {
+@media (width < 768px) {
   .cardgroup--medium {
     grid-auto-flow: row;
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .cardgroup__card--large {

--- a/src/components/HomepageHero.module.css
+++ b/src/components/HomepageHero.module.css
@@ -7,7 +7,7 @@
   background-color: #74295f;
   color: white;
   margin-block-end: 48px;
-  padding-block-start: 80px;
+  padding-block: 80px;
 }
 
 .homepage-hero__container {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,8 +35,6 @@
   -moz-osx-font-smoothing: auto !important;
 
   /* --docusaurus-announcement-bar-height: 50px; */
-  max-width: 100vw;
-  overflow-x: auto;
 }
 .container--narrow {
   --ifm-container-width: 784px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,8 @@
   -moz-osx-font-smoothing: auto !important;
 
   /* --docusaurus-announcement-bar-height: 50px; */
+  max-width: 100vw;
+  overflow-x: auto;
 }
 .container--narrow {
   --ifm-container-width: 784px;
@@ -516,7 +518,7 @@ li a {
   }
 }
 
-@media screen and (width <= 550px) {
+@media screen and (width <= 850px) {
   .footer__items {
     grid-auto-flow: row;
   }


### PR DESCRIPTION
Dit fixt twee dingen: 

- evenveel spacing boven en onderin het paarse blok (opgemerkt door en gecheckt met @jeffreylauwers), dit was wsl eerder geen issue door de schuine lijn die we hadden
- de horizontale scroll op mobiel (fixes https://github.com/nl-design-system/documentatie/issues/577); met meerdere dingen:
  -  er waren meer linkjes in de footer naast elkaar stonden dan in de ~`550px` pastte die we als triggerpunt gebruikten om van verticaal naar horizontaal te gaan 
  - de media query voor cards werd op mobiel en sommige schermen anders geïnterpreteerd dan we wilden, heb de logica omgedraaid zodat er pas twee kolommen worden getriggerd vanaf een zekere breedte ipv tot een zekere breedte niet getriggered, en daarnaast `minmax(0, 1fr)` gebruikt ipv `1fr` zodat de kolommen niet uit hun container breken; context: by default betekent `1fr` nl `minmax(auto, 1fr)`, en kan de content van één grid cell het hele grid groter maken; [context bij ietwat verwarrende betekenis 1fr](https://github.com/w3c/csswg-drafts/issues/1777))