### PR TITLE
docs: add lang=en to english text

### DIFF
--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-accessible-name.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-accessible-name.md
@@ -61,6 +61,6 @@ Deze optie heeft niet de voorkeur omdat er geen visuele tekst bij het icoontje s
 </button>
 ```
 
-Voor het toekennen van toegankelijke namen aan SVGs bestaan ook andere technieken, Carie Fisher beschrijft ze in [Accessible SVGs: Perfect Patterns For Screen Reader Users](https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/).
+Voor het toekennen van toegankelijke namen aan SVGs bestaan ook andere technieken, Carie Fisher beschrijft ze in [<span lang="en">Accessible SVGs: Perfect Patterns For Screen Reader Users</span>](https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/).
 
 Door te zorgen voor een toegankelijke naam voor de button, voldoe je aan één van de voorwaarden voor het WCAG-succescriterium: [4.1.2 Naam, rol en waarde](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value) (niveau A).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-disabled.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-disabled.md
@@ -13,10 +13,10 @@ Een goede oplossing en vervanging voor een disabled button: schrijf goede labelt
 
 Deze richtlijn is een aanbevolen werkwijze, gebaseerd op gebruikersonderzoek:
 
-- [The problem with disabled buttons and what to do instead](https://adamsilver.io/blog/the-problem-with-disabled-buttons-and-what-to-do-instead/), Adam Silver.
-- [Don't disable buttons](https://gomakethings.com/dont-disable-buttons/), Chris Ferdinandi in Go Make Things.
-- [Usability Pitfalls of Disabled Buttons, and How To Avoid Them](https://www.smashingmagazine.com/2021/08/frustrating-design-patterns-disabled-buttons/), Vitaly Friedman in Smashing Magazine.
-- [Disabled buttons suck](https://axesslab.com/disabled-buttons-suck/).
+- [<span lang="en">The problem with disabled buttons and what to do instead</span>](https://adamsilver.io/blog/the-problem-with-disabled-buttons-and-what-to-do-instead/), Adam Silver.
+- [<span lang="en">Don't disable buttons</span>](https://gomakethings.com/dont-disable-buttons/), Chris Ferdinandi in Go Make Things.
+- [<span lang="en">Usability Pitfalls of Disabled Buttons, and How To Avoid Them</span>](https://www.smashingmagazine.com/2021/08/frustrating-design-patterns-disabled-buttons/), Vitaly Friedman in Smashing Magazine.
+- [<span lang="en">Disabled buttons suck</span>](https://axesslab.com/disabled-buttons-suck/).
 
 Een paar praktische tips als de bestaande situatie niet gelijk aangepast kan worden:
 

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-placement.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-placement.md
@@ -7,8 +7,8 @@ Daarbij zullen gebruikers die inzoomen, een scherm vergrootglas gebruiken of een
 
 Deze richtlijn is een aanbevolen werkwijze, gebaseerd op gebruikersonderzoek:
 
-- [Primary & Secondary Actions in Web Forms](https://www.lukew.com/ff/entry.asp?571), Luke Wroblewski
-- [Where to put buttons on forms](https://adamsilver.io/blog/where-to-put-buttons-on-forms/), Adam Silver
+- [<span lang="en">Primary & Secondary Actions in Web Forms</span>](https://www.lukew.com/ff/entry.asp?571), Luke Wroblewski
+- [<span lang="en">Where to put buttons on forms</span>](https://adamsilver.io/blog/where-to-put-buttons-on-forms/), Adam Silver
 
 ![Button uitgelijnd met formulier labels en invoervelden](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_formulier_buttons_placement--do.png)
 ![Button niet uitgelijnd met formulier labels en invoervelden](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_formulier_buttons_placement--dont.png)

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-text.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_button-text.md
@@ -11,12 +11,12 @@ Dit is geruststellend en duidelijk. De gebruiker weet wat er gaat gebeuren en za
 
 ![Een button met het label 'wijzig' en een button met het label 'Wijzig uw gegevens'.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_formulier_buttons_label.png)
 
-Buttons kunnen tekst bevatten, een icoontje en een combinatie van beide. Uit gebruikersonderzoek blijkt dat niet iedereen alle icoontjes snapt. Het is beter om naast een icoontje ook zichtbare tekst te plaatsen. Volgens de Nielsen Norman Group in [Icon Usability](https://www.nngroup.com/articles/icon-usability/).
+Buttons kunnen tekst bevatten, een icoontje en een combinatie van beide. Uit gebruikersonderzoek blijkt dat niet iedereen alle icoontjes snapt. Het is beter om naast een icoontje ook zichtbare tekst te plaatsen. Volgens de Nielsen Norman Group in [<span lang="en">Icon Usability</span>](https://www.nngroup.com/articles/icon-usability/).
 
 > Het begrijpen van een icoon is gebaseerd op eerdere ervaringen. Omdat de meeste iconen geen vaste betekenis hebben, zijn tekstlabels nodig om de betekenis eenduidig over te brengen.
 
 Deze richtlijn is een aanbevolen werkwijze, gebaseerd op gebruikersonderzoek:
 
-- [Wat overheden kunnen leren van de ideale webshop](https://www.ncdt.nl/programma/wat-overheden-kunnen-leren-van-de-ideale-webshop), presentatie van Anouk Butterlin.
-- [Why Your Form Buttons Should Never Say 'Submit'](https://uxmovement.com/forms/why-your-form-buttons-should-never-say-submit/), UX Movement.
-- [3 common examples of button text that degrades UX and how to rewrite them so they’re clear](https://adamsilver.io/blog/3-common-examples-of-button-text-that-degrades-ux-and-how-to-rewrite-them-so-theyre-clear/), Adam Silver.
+- [<span lang="en">Wat overheden kunnen leren van de ideale webshop</span>](https://www.ncdt.nl/programma/wat-overheden-kunnen-leren-van-de-ideale-webshop), presentatie van Anouk Butterlin.
+- [<span lang="en">Why Your Form Buttons Should Never Say 'Submit'</span>](https://uxmovement.com/forms/why-your-form-buttons-should-never-say-submit/), UX Movement.
+- [<span lang="en">3 common examples of button text that degrades UX and how to rewrite them so they’re clear</span>](https://adamsilver.io/blog/3-common-examples-of-button-text-that-degrades-ux-and-how-to-rewrite-them-so-theyre-clear/), Adam Silver.

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_confirmation-success.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_confirmation-success.md
@@ -14,4 +14,4 @@ Geef de gebruiker zekerheid welke informatie is verstuurd. Dit kan bijvoorbeeld 
 
 Alleen de melding geven "Uw formulier is verzonden", of automatisch naar de voorpagina gaan is onvoldoende.
 
-Goede feedback is geen vereiste om te voldoen aan WCAG, maar wordt wel geadviseerd in [Technique G199: Providing success feedback when data is submitted successfully](https://www.w3.org/WAI/WCAG22/Techniques/general/G199.html).
+Goede feedback is geen vereiste om te voldoen aan WCAG, maar wordt wel geadviseerd in [<span lang="en">Technique G199: Providing success feedback when data is submitted successfully</span>](https://www.w3.org/WAI/WCAG22/Techniques/general/G199.html).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_description-placement.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_description-placement.md
@@ -2,4 +2,4 @@
 
 Plaats alle descriptions op een consistente plek, liefst tussen het label en het formulierveld. Omdat de gebruiker van boven naar beneden leest, komt deze informatie na het label op een logisch moment in de leesvolgorde.
 
-Ook is dan de kans dat de informatie overlapt met bijvoorbeeld browserpopups kleiner. Lees hiervoor het artikel [Avoid Messages Under Fields](https://adrianroselli.com/2017/01/avoid-messages-under-fields.html) van Adrian Roselli.
+Ook is dan de kans dat de informatie overlapt met bijvoorbeeld browserpopups kleiner. Lees hiervoor het artikel [<span lang="en">Avoid Messages Under Fields</span>](https://adrianroselli.com/2017/01/avoid-messages-under-fields.html) van Adrian Roselli.

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-clarity.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-clarity.md
@@ -12,7 +12,7 @@ Maak foutmeldingen daarom zo veel mogelijk beschrijvend en op maat. Schrijf in p
 
 Gebruik een punt aan het eind van de foutmelding (of andere melding). Dan stopt de screenreader even en is het duidelijker dat de foutmelding apart een zin is.
 
-Het design system van GOV.UK geeft duidelijke (Engelstalige) informatie over de tekst van foutmeldingen [Be clear and concise](https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise).
+Het design system van GOV.UK geeft duidelijke (Engelstalige) informatie over de tekst van foutmeldingen [<span lang="en">Be clear and concise</span>](https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise).
 
 Door het schrijven van foutmeldingen en een duidelijke toelichting op wat er mis gaat, voldoe je aan de volgende WCAG-succescriteria:
 

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-no-native.md
@@ -8,7 +8,7 @@ De meeste browsers kunnen zelf controleren of een veld is ingevuld. Dit gebeurt 
 <input type="text" id="voorbeeld" name="voorbeeld" required />
 ```
 
-Dit type foutafhandeling geeft onvoldoende informatie. In veel browsers wordt niet aan alle gebruikers overgebracht dat het veld verplicht is, en mist uitleg wanneer niet wordt voldaan een een opgegeven `pattern`. Zie ook: [Avoid default field validation](https://adrianroselli.com/2019/02/avoid-default-field-validation.html) van Adrian Roselli.
+Dit type foutafhandeling geeft onvoldoende informatie. In veel browsers wordt niet aan alle gebruikers overgebracht dat het veld verplicht is, en mist uitleg wanneer niet wordt voldaan een een opgegeven `pattern`. Zie ook: [<span lang="en">Avoid default field validation</span>](https://adrianroselli.com/2019/02/avoid-default-field-validation.html) van Adrian Roselli.
 
 Wanneer er voldoende tijd en kennis is, heeft het de voorkeur om zelf client-side validatie toe te voegen.
 

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-timing.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_errors-timing.md
@@ -8,4 +8,4 @@ Die melding verdwijnt pas als het hele e-mailadres is ingevuld. Dit is niet alle
 
 Controleer een veld bijvoorbeeld als de gebruiker het veld heeft aangepast en daarna verlaat ('blur' en 'input') of wanneer het formulier wordt verzonden.
 
-Meer informatie over de bezwaren van "live" validatie: [The problem with live validation and what to do instead](https://adamsilver.io/blog/the-problem-with-live-validation-and-what-to-do-instead/) van Adam Silver.
+Meer informatie over de bezwaren van "live" validatie: [<span lang="en">The problem with live validation and what to do instead</span>](https://adamsilver.io/blog/the-problem-with-live-validation-and-what-to-do-instead/) van Adam Silver.

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_help-allow-copy-paste.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_help-allow-copy-paste.md
@@ -6,4 +6,4 @@ Een wachtwoord moet veilig zijn. Als je het knippen en plakken van een wachtwoor
 
 Kopiëren/plakken vanuit een wachtwoordmanager is een veel veiligere manier om een gebruiker een wachtwoord te laten invullen.
 
-Zoals het Britse National Cyber Security Centre uitlegt in [Let them paste passwords](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).
+Zoals het Britse National Cyber Security Centre uitlegt in [<span lang="en">Let them paste passwords</span>](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_help-allow-copy-paste.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_help-allow-copy-paste.md
@@ -6,4 +6,4 @@ Een wachtwoord moet veilig zijn. Als je het knippen en plakken van een wachtwoor
 
 Kopiëren/plakken vanuit een wachtwoordmanager is een veel veiligere manier om een gebruiker een wachtwoord te laten invullen.
 
-Zoals het Britse National Cyber Security Centre uitlegt in [<span lang="en">Let them paste passwords</span>](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).
+Zoals het Britse <span lang="en">National Cyber Security Centre</span> uitlegt in [<span lang="en">Let them paste passwords</span>](https://www.ncsc.gov.uk/blog-post/let-them-paste-passwords).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_label-above-field.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_label-above-field.md
@@ -16,4 +16,4 @@ Je brein verbindt automatisch wat er bij elkaar is geplaatst, dus zorg er ook vo
 
 Plaats labels buiten het formulierveld en niet daarbinnen. Op deze manier heeft het label altijd een vaste positie en kan het in een leesbare grootte worden getoond.
 
-Gebruik geen zogenaamde “floating labels”. Deze zijn moeilijker te begrijpen. Zie: [Material Design Text Fields Are Badly Designed in Smashing Magazine](https://www.smashingmagazine.com/2021/02/material-design-text-fields/).
+Gebruik geen zogenaamde “floating labels”. Deze zijn moeilijker te begrijpen. Zie: [<span lang="en">Material Design Text Fields Are Badly Designed in Smashing Magazine</span>](https://www.smashingmagazine.com/2021/02/material-design-text-fields/).

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_label-always-visible.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_label-always-visible.md
@@ -4,7 +4,7 @@
 
 Waarom? Als het label verdwijnt bij het typen kan er verwarring ontstaan: wat moet je ook alweer invullen? Daarom is een placeholder geen goede vervanging van het label.
 
-De placeholder kan ook voor verwarring zorgen bij gebruikers. Is het al veld ingevuld? Zie het onderzoek [Placeholders in Form Fields Are Harmful](https://www.nngroup.com/articles/form-design-placeholders/) van de Nielsen Norman Group.
+De placeholder kan ook voor verwarring zorgen bij gebruikers. Is het al veld ingevuld? Zie het onderzoek [<span lang="en">Placeholders in Form Fields Are Harmful</span>](https://www.nngroup.com/articles/form-design-placeholders/) van de Nielsen Norman Group.
 
 Een label vertelt **wat** je moet invullen en een placeholder **hoe** je een formulierveld moet invullen. Voor een e-mailveld kan het label bijvoorbeeld “Jouw e-mailadres” zijn en de placeholder “naam@voorbeeld.com”.
 

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/_placeholder-clarity.md
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/_placeholder-clarity.md
@@ -2,4 +2,4 @@
 
 De placeholder kan ook voor verwarring zorgen bij gebruikers. Is een veld al ingevuld? De combinatie van een label met een [description](/richtlijnen/formulieren/alle-richtlijnen/descriptions) is een betere manier om de gebruiker te vertellen hoe een veld in te vullen. Herhaal nooit de labeltekst in de placeholder, dat geeft geen extra informatie en is dus zinloos.
 
-Zie het onderzoek [Placeholders in Form Fields Are Harmful](https://www.nngroup.com/articles/form-design-placeholders/) van de Nielsen Norman Group en [The problem with placeholders and what to do instead](https://adamsilver.io/blog/the-problem-with-placeholders-and-what-to-do-instead/) van Adam Silver.
+Zie het onderzoek [<span lang="en">Placeholders in Form Fields Are Harmful</span>](https://www.nngroup.com/articles/form-design-placeholders/) van de Nielsen Norman Group en [The problem with placeholders and what to do instead](https://adamsilver.io/blog/the-problem-with-placeholders-and-what-to-do-instead/) van Adam Silver.

--- a/docs/richtlijnen/formulieren/00-alle-richtlijnen/multistep.mdx
+++ b/docs/richtlijnen/formulieren/00-alle-richtlijnen/multistep.mdx
@@ -29,7 +29,7 @@ import MultistepTiming from "./_multistep-timing.md";
 
 Bestaat een formulier uit veel vragen, dan kan het gebruiksvriendelijk en overzichtelijk zijn om het formulier in meerdere stappen op te delen, of om een vraag per stap te stellen.
 
-Of je een meerstappenformulier gebruikt hangt af van de hoeveelheid en de complexiteit van de vragen die je de bezoekers wilt stellen. Doe vooraf gebruikersonderzoek voordat je beslist een formulier in meerdere stappen op te delen. Adam Silver beschrijft zijn overwegingen in [Better Form Design: One Thing Per Page (Case Study)](https://www.smashingmagazine.com/2017/05/better-form-design-one-thing-per-page/).
+Of je een meerstappenformulier gebruikt hangt af van de hoeveelheid en de complexiteit van de vragen die je de bezoekers wilt stellen. Doe vooraf gebruikersonderzoek voordat je beslist een formulier in meerdere stappen op te delen. Adam Silver beschrijft zijn overwegingen in [<span lang="en">Better Form Design: One Thing Per Page (Case Study)</span>](https://www.smashingmagazine.com/2017/05/better-form-design-one-thing-per-page/).
 
 Kies je voor een opzet met meerdere stappen, dan is het volgende belangrijk:
 


### PR DESCRIPTION
Aan alle Engelstalige linkteksten lang="en" toegevoegd.
In markdown wordt het dan bijvoorbeeld voor een link:
```
[<span lang="en">Accessible SVGs: Perfect Patterns For Screen Reader Users</span>](https://www.smashingmagazine.com/2021/05/accessible-svg-patterns-comparison/)
```

en `<span lang="en">Accessible SVGs: Perfect Patterns For Screen Reader Users</span>` voor teksten.


Issue: https://github.com/nl-design-system/documentatie/issues/583
