### PR TITLE
fix: add redirect from old “alle richtlijnen” pages

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -12,5 +12,7 @@ RedirectMatch 301 "^/meedoen/als-developer/(.*)$" "/handboek/developer$1"
 RedirectMatch 301 "^/meedoen/als-designer/(.*)$" "/handboek/designer$1"
 RedirectMatch 301 "^/meedoen(.*)$" "/handboek$1"
 
+RedirectMatch 301 "^/richtlijnen/formulieren/alle-richtlijnen/(.*)$" "/richtlijnen/formulieren/$1"
+
 RedirectMatch 301 "^/project/events(.*)$" "/community/events$1"
 Redirect 301 "/project/wie-doet-mee" "/community/wie-doet-mee"


### PR DESCRIPTION
URLs like https://nldesignsystem.nl/richtlijnen/formulieren/alle-richtlijnen/foutmeldingen/ are currently broken because we removed the `alle-richtlijnen` bit, this tries to send people to the same page without the `alle-richtlijnen` prefix, which should exist for all cases.