### PR TITLE
build: use pnpm cache

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,20 +12,22 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
+          cache: pnpm
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: |
-            args: [--frozen-lockfile]
-          version: 8
+      - name: Install dependencies
+        run: |
+          pnpm install
 
       - name: "Continuous Integration: lint"
         run: |
@@ -40,7 +42,7 @@ jobs:
           pnpm run --if-present test
 
       - name: "Retain build artifact: website"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: website
           path: build/
@@ -52,27 +54,29 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v3.0.0
+        with:
+          version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: .nvmrc
+          cache: pnpm
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          run_install: |
-            args: [--frozen-lockfile]
-          version: 8
+      - name: Install dependencies
+        run: |
+          pnpm install
 
       - name: "Install headless browsers for end-to-end testing"
         run: |
           pnpm run --if-present install-test-browsers
 
       - name: "Restore build artifact: website"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           name: website
           path: build/
@@ -94,7 +98,7 @@ jobs:
           pnpm run --if-present publish:argos
 
       - name: "Retain build artifact: test report"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: playwright-report
           path: tmp/playwright-html-report/
@@ -102,7 +106,7 @@ jobs:
 
       - name: "Retain build artifact: screenshots"
         if: ${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'visual regression test')) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: screenshots
           path: tmp/screenshots/
@@ -115,10 +119,10 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: "Restore build artifact: website"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           name: website
           path: build/
@@ -136,22 +140,24 @@ jobs:
 
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Set up Node.js version
-        uses: actions/setup-node@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3.0.0
         with:
-          node-version-file: ".nvmrc"
+          version: 8.14
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
+      - name: Set up Node.js version
+        uses: actions/setup-node@v4.0.2
         with:
-          run_install: |
-            args: [--frozen-lockfile]
-          version: 8
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: |
+          pnpm install
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:


### PR DESCRIPTION
Bump `pnpm/action-setup` to the latest version, make sure the pnpm cache is used.

Make version numbers of all actions explicit.