### PR TITLE
Richtlijnen: voegt interne links naar RL toe op een pagina

### DIFF
--- a/docs/richtlijnen/formulieren/_errors-feedback.md
+++ b/docs/richtlijnen/formulieren/_errors-feedback.md
@@ -1,4 +1,4 @@
-## Feedback voor screenreadergebruikers
+## Geef feedback aan screenreadergebruikers
 
 We geven je 3 extra manieren om feedback te geven over foutmeldingen voor screenreadergebruikers. Met `aria-required`, `aria-invalid` in het formulierveld en het `<title>` element in de `<head>` van de webpagina.
 

--- a/docs/richtlijnen/formulieren/_errors-summary.md
+++ b/docs/richtlijnen/formulieren/_errors-summary.md
@@ -1,4 +1,4 @@
-## Samenvatting boven het formulier
+## Zet een samenvatting van de foutmeldingen boven het formulier
 
 Een zeer gebruikersvriendelijke manier om fouten weer te geven is een combinatie van:
 

--- a/docs/richtlijnen/formulieren/buttons.mdx
+++ b/docs/richtlijnen/formulieren/buttons.mdx
@@ -46,13 +46,13 @@ De hier beschreven richtlijnen gelden voor al deze buttons.
 
 Voor de toegankelijkheid en goede code van het formulier zijn de volgende punten belangrijk voor een button:
 
-- Toetsenbordbediening van een button.
-- Verstuur een formulier niet automatisch na wijzigen of invullen, maar gebruik een submitbutton.
-- Plaatsing van een button binnen een formulier.
-- Duidelijk buttontekst die beschrijft wat de button doet.
-- De toegankelijke naam van een button.
-- Afbeeldingen en iconen als buttons.
-- Disabled submitbuttons.
+- [Toetsenbordbediening van een button](#toetsenbordbediening-van-een-button).
+- [Verstuur een formulier niet automatisch na het wijzigen of invullen van een formulierveld](#verstuur-een-formulier-niet-automatisch-na-het-wijzigen-of-invullen-van-een-formulierveld).
+- [Plaatsing van een button binnen een formulier](#plaatsing-van-een-button-binnen-een-formulier).
+- [Duidelijk buttontekst die beschrijft wat de button doet](#duidelijk-buttontekst-die-beschrijft-wat-de-button-doet).
+- [De toegankelijke naam van een button](#de-toegankelijke-naam-van-een-button).
+- [Afbeeldingen als buttons](#afbeeldingen-als-buttons).
+- [Disabled submitbuttons](#disabled-submitbuttons).
 
 <ButtonKeyboard />
 <ButtonKeyboardCode />

--- a/docs/richtlijnen/formulieren/confirmation.mdx
+++ b/docs/richtlijnen/formulieren/confirmation.mdx
@@ -30,10 +30,10 @@ Een bevestigingspagina informeert gebruikers dat hun data met succes is verstuur
 
 Belangrijk voor het informeren van de gebruiker is hierbij:
 
-- Vermeld dat het formulier succesvol is verzonden.
-- Maak de succesmelding toegankelijk voor alle gebruikers.
-- Vertel wat de vervolgacties zijn.
-- Zorg dat de gebruiker contact op kan nemen bij vragen.
+- [Vermeld dat het formulier succesvol is verzonden](#vermeld-dat-het-formulier-succesvol-is-verzonden).
+- [Maak de succesmelding toegankelijk voor alle gebruikers](#maak-de-succesmelding-toegankelijk-voor-alle-gebruikers).
+- [Vertel wat de vervolgacties zijn](#vertel-wat-de-vervolgacties-zijn).
+- [Zorg dat de gebruiker contact op kan nemen bij vragen](#zorg-dat-de-gebruiker-contact-op-kan-nemen-bij-vragen).
 
 <ConfirmationSuccess />
 

--- a/docs/richtlijnen/formulieren/descriptions.mdx
+++ b/docs/richtlijnen/formulieren/descriptions.mdx
@@ -37,12 +37,12 @@ We geven deze extra informatie hier de verzamelnaam "descriptions", om aan te sl
 
 Belangrijk voor een goede description:
 
-- Koppel een description in code aan het formulierveld.
-- Plaats descriptions tussen label en formulierveld.
-- Je kunt ook meerdere descriptions koppelen.
-- Fieldset: Plaats descriptions tussen legend en eerste item.
-- Houd het aanklikbare gedeelte groot genoeg.
-- Houd de description kort en to-the-point.
+- [Koppel een description in code aan het formulierveld](#koppel-een-description-aan-het-formulierveld).
+- [Plaats descriptions tussen label en formulierveld](#plaats-descriptions-tussen-label-en-formulierveld).
+- [Meerdere descriptions koppelen](#meerdere-descriptions-koppelen).
+- [Fieldset: Plaats descriptions tussen legend en eerste item](#fieldset-plaats-descriptions-tussen-legend-en-eerste-item).
+- [Houd het aanklikbare gedeelte groot genoeg](#houd-het-aanklikbare-gedeelte-groot-genoeg).
+- [Houd de description kort en to-the-point](#houd-de-description-kort-en-to-the-point).
 
 <DescriptionAssociated />
 <DescriptionAssociatedCode />

--- a/docs/richtlijnen/formulieren/errors.mdx
+++ b/docs/richtlijnen/formulieren/errors.mdx
@@ -35,13 +35,13 @@ Formuliervalidatie werkt het best met duidelijke en goed getimede foutmeldingen 
 
 Belangrijk bij het aangeven van fouten:
 
-- Controleer op het juiste moment op fouten.
-- Schrijf een foutmelding uit in tekst.
-- Schrijf een duidelijke foutmelding.
-- Zet de foutmeldingen bij de betreffende formuliervelden.
-- Gebruik geen HTML-formuliervalidatie.
-- Zet een samenvatting van de foutmeldingen boven het formulier.
-- Geef feedback aan screenreadergebruikers.
+- [Controleer op het juiste moment op fouten](#controleer-op-het-juiste-moment-op-fouten).
+- [Schrijf een foutmelding uit in tekst](#schrijf-een-foutmelding-uit-in-tekst).
+- [Schrijf een duidelijke foutmelding](#schrijf-een-duidelijke-foutmelding).
+- [Zet de foutmeldingen bij de betreffende formuliervelden](#zet-de-foutmeldingen-bij-de-betreffende-formuliervelden).
+- [Gebruik geen HTML-formuliervalidatie](#gebruik-geen-html-formuliervalidatie).
+- [Zet een samenvatting van de foutmeldingen boven het formulier](#zet-een-samenvatting-van-de-foutmeldingen-boven-het-formulier).
+- [Geef feedback aan screenreadergebruikers](#geef-feedback-aan-screenreadergebruikers).
 
 Twee uitgebreide bronnen die de aspecten van foutmeldingen goed beschrijven:
 

--- a/docs/richtlijnen/formulieren/help-the-user.mdx
+++ b/docs/richtlijnen/formulieren/help-the-user.mdx
@@ -36,12 +36,12 @@ import HelpRequired from "./_help-show-required.md";
 
 Een formulier invullen moet zo gemakkelijk mogelijk zijn. Hoe help je je gebruiker het beste?
 
-- Vermeld het duidelijk of een veld verplicht is.
-- Sta knippen en plakken van gegevens (zoals een wachtwoord) toe.
-- Keur niet te snel af.
-- Geef geldige waardes aan voor een invoerveld.
-- Vul bekende informatie in waar mogelijk.
-- Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken.
+- [Vermeld duidelijk of een veld verplicht is](#vermeld-duidelijk-of-een-veld-verplicht-is).
+- [Sta knippen en plakken van gegevens (zoals een wachtwoord) toe](#sta-knippen-en-plakken-van-een-wachtwoord-toe).
+- [Keur niet te snel af](#keur-niet-te-snel-af).
+- [Geef geldige waardes aan voor een invoerveld](#geef-geldige-waardes-aan-voor-een-invoerveld).
+- [Vul bekende informatie in waar mogelijk](#vul-bekende-informatie-in-waar-mogelijk).
+- [Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken](#maak-het-mogelijk-een-inzending-te-controleren-te-wijzigen-of-ongedaan-te-maken).
 
 <HelpRequired />
 <HelpRequiredCode />

--- a/docs/richtlijnen/formulieren/keyboard-behaviour.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour.mdx
@@ -29,7 +29,7 @@ Sommige gebruikers navigeren door een formulier met hun `Tab`-toets. Zorg dat al
 Hierbij is van toepassing:
 
 - [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/#maak-toetsenbord-focus-goed-zichtbaar) op de pagina Visueel Ontwerp van formulieren.
-- Gebruik geen positieve tabindex.
+- [Gebruik geen positieve tabindex](#gebruik-geen-positieve-tabindex).
 
 Documentatie over hoe formuliervelden moeten werken met het toetsenbord:
 

--- a/docs/richtlijnen/formulieren/labels.mdx
+++ b/docs/richtlijnen/formulieren/labels.mdx
@@ -34,12 +34,12 @@ import VisibleAccessibleName from "./_label-visible-accessible-name.md";
 Een label geeft aan welke gegevens de gebruiker bij een formulierveld in kan vullen.
 Voor de toegankelijkheid van labels en dus ook formuliervelden zijn de volgende punten belangrijk:
 
-- Geef een formulierveld een toegankelijke naam met een label.
-- De zichtbare naam moet overeenkomen met de toegankelijke naam.
-- Zet het label boven het formulierveld.
-- Zorg ervoor dat het label altijd zichtbaar is.
-- Zet alleen tekst in het label.
-- Gebruik duidelijke labelteksten.
+- [Geef een formulierveld een toegankelijke naam met een label](#geef-een-formulierveld-toegankelijke-naam-met-een-label).
+- [De zichtbare naam moet overeenkomen met de toegankelijke naam](#de-zichtbare-naam-moet-overeenkomen-met-de-toegankelijke-naam).
+- [Zet het label boven het formulierveld](#zet-het-label-boven-het-formulierveld).
+- [Zorg ervoor dat het label altijd zichtbaar is](#zorg-ervoor-dat-het-label-altijd-zichtbaar-is).
+- [Zet alleen tekst in het label](#zet-alleen-tekst-in-het-label).
+- [Gebruik duidelijke labelteksten](#gebruik-duidelijke-labelteksten).
 
 <AccessibleName />
 <AccessibleNameCode />

--- a/docs/richtlijnen/formulieren/links.mdx
+++ b/docs/richtlijnen/formulieren/links.mdx
@@ -26,11 +26,12 @@ import LinkNotInLabel from "./_link-not-in-label.md";
 # Links in een formulier
 
 Soms wil je binnen een formulier verwijzen naar een andere pagina, bijvoorbeeld de algemene voorwaarden of het privacybeleid. Zo’n link kun je boven het formulier zetten, maar ook bij een specifieke vraag plaatsen.
+
 Voor het plaatsen van een link binnen een formulier zijn voor de toegankelijkheid de volgende punten belangrijk:
 
-- Plaats de link boven het gerelateerde formulierveld.
-- Zet geen link in een label.
-- Geef aan als een link in een nieuwe tab opent.
+- [Plaats de link boven het gerelateerde formulierveld](#plaats-de-link-boven-het-gerelateerde-formulierveld).
+- [Zet geen link in een label](#zet-geen-link-in-een-label).
+- [Geef aan als een link in een nieuwe tab opent](#geef-aan-als-een-link-in-een-nieuwe-tab-opent).
 
 <LinkAboveField />
 <LinkAboveFieldCode />

--- a/docs/richtlijnen/formulieren/multistep.mdx
+++ b/docs/richtlijnen/formulieren/multistep.mdx
@@ -34,11 +34,11 @@ Of je een meerstappenformulier gebruikt hangt af van de hoeveelheid en de comple
 
 Kies je voor een opzet met meerdere stappen, dan is het volgende belangrijk:
 
-- Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt.
-- Plaats informatie over de stappen boven het formulier.
-- Zorg voor een consistente navigatie en benaming van links en buttons.
-- Bied als laatste stap een opsomming aan van alle ingevoerde gegevens.
-- Geef duidelijk aan wanneer het formulier verzonden gaat worden.
+- [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](#geef-aan-hoeveel-stappen-er-zijn-en-in-welke-stap-de-gebruiker-zich-bevindt).
+- [Plaats de informatie over waar de gebruiker is in de stappen boven het formulier](#plaats-de-informatie-over-waar-de-gebruiker-is-in-de-stappen-boven-het-formulier).
+- [Zorg voor een consistente navigatie en benaming van links en buttons](#zorg-voor-een-consistente-navigatie-en-benaming-van-links-en-buttons).
+- [Bied als laatste stap een opsomming aan van alle ingevoerde gegevens](#bied-als-laatste-stap-een-opsomming-aan-van-alle-ingevoerde-gegevens).
+- [Geef duidelijk aan wanneer het formulier verzonden gaat worden](#geef-duidelijk-aan-wanneer-het-formulier-verzonden-gaat-worden).
 
 <MultistepStepcount />
 <MultistepStepcountCode />

--- a/docs/richtlijnen/formulieren/placeholders.mdx
+++ b/docs/richtlijnen/formulieren/placeholders.mdx
@@ -32,9 +32,9 @@ Een [label](/richtlijnen/formulieren/labels/) vertelt **wat** je moet invullen e
 
 Voor de toegankelijkheid en gebruiksvriendelijkheid van een placeholder is het volgende van belang:
 
-- Een placeholder is geen vervanger van een label.
-- Voorkom verwarring bij de gebruiker.
-- Zorg voor een voldoende kleurcontract voor de placeholdertekst.
+- [Een placeholder is geen vervanger van een label](#een-placeholder-is-geen-vervanger-van-een-label).
+- [Voorkom verwarring bij de gebruiker](#voorkom-verwarring-bij-de-gebruiker).
+- [Zorg voor een voldoende kleurcontract voor de placeholdertekst](#zorg-voor-een-goed-kleurcontrast-van-de-placeholdertekst).
 
 <PlaceholderLabel />
 <PlaceholderLabelCode />

--- a/docs/richtlijnen/formulieren/questions.mdx
+++ b/docs/richtlijnen/formulieren/questions.mdx
@@ -34,11 +34,11 @@ Welke informatie heb je nodig van je gebruiker? En welke niet? Waarom heb je bep
 
 Bij het uitvragen van informatie in een formulier zijn de volgende punten belangrijk:
 
-- Leg uit waarom informatie nodig is.
-- Check of informatie ècht nodig is.
-- Biedt verschillende manieren om contact op te nemen.
-- Vraag niet meerdere keren dezelfde informatie uit.
-- Geef invoervelden geen minimum en/of maximum aantal in te voeren tekens.
+- [Leg uit waarom informatie nodig is](#leg-uit-waarom-informatie-nodig-is).
+- [Check of informatie ècht nodig is](#check-of-informatie-ècht-nodig-is).
+- [Biedt verschillende manieren om contact op te nemen](#biedt-verschillende-manieren-om-contact-op-te-nemen).
+- [Vraag niet meerdere keren dezelfde informatie uit](#vraag-niet-meerdere-keren-dezelfde-informatie-uit).
+- [Geef invoervelden geen minimum en/of maximum aantal in te voeren tekens](#geef-invoervelden-geen-minimummaximum-tekstlengte).
 
 <QuestionWhy />
 <QuestionWhyCode />

--- a/docs/richtlijnen/formulieren/visual-design.mdx
+++ b/docs/richtlijnen/formulieren/visual-design.mdx
@@ -33,14 +33,14 @@ import VisualDesignUseOfColor from "./_visual-design-use-of-color.md";
 
 # Visueel ontwerp van een formulier
 
-- Geef duidelijk aan waar het invoerveld is.
-- Geef tekst voldoende kleurcontrast.
-- Geef placeholders voldoende kleurcontrast.
-- Maak de toetsenbordfocus goed zichtbaar.
-- Maak aanklikbare formuliervelden groot genoeg.
-- Geef fouten weer met meer dan alleen kleur.
-- Gebruik geen afbeelding voor knoppen maar stijl tekst met CSS.
-- Zorg voor een logische volgorde van de informatie.
+- [Geef duidelijk aan waar het invoerveld is](#geef-duidelijk-aan-waar-een-invoerveld-is).
+- [Geef tekst voldoende kleurcontrast](#geef-tekst-voldoende-kleurcontrast).
+- [Geef placeholders voldoende kleurcontrast](#geef-placeholders-voldoende-kleurcontrast).
+- [Maak de toetsenbordfocus goed zichtbaar](#maak-toetsenbord-focus-goed-zichtbaar).
+- [Maak aanklikbare formuliervelden groot genoeg](#maak-aanklikbare-formuliervelden-groot-genoeg).
+- [Geef fouten weer met meer dan alleen kleur](#geef-fouten-weer-met-meer-dan-alleen-kleur).
+- [Gebruik geen afbeelding voor knoppen maar stijl tekst met CSS](#gebruik-geen-afbeelding-voor-knoppen-maar-stijl-tekst-met-css).
+- [Zorg voor een logische volgorde van de informatie](#zorg-voor-een-logische-volgorde-van-de-informatie).
 
 <VisualDesignFieldContrast />
 <VisualDesignFieldContrastCode />

--- a/docs/richtlijnen/formulieren/when-which.mdx
+++ b/docs/richtlijnen/formulieren/when-which.mdx
@@ -26,8 +26,8 @@ import WhenWhichUsability from "./_when-which-usability.md";
 
 Je wilt natuurlijk dat zoveel mogelijk mensen een formulier kunnen invullen op de makkelijkste manier. We geven twee richtlijnen die hierbij helpen.
 
-- Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief.
-- Kies voor het meest gebruiksvriendelijke formulierelement.
+- [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](#zorg-dat-iedereen-een-formulierelement-kan-bedienen-of-geef-een-alternatief).
+- [Kies voor het meest gebruiksvriendelijke formulierelement](#kies-voor-het-meest-gebruiksvriendelijke-formulierelement).
 
 Er is nog veel te onderzoeken over wat het beste formulierelement is voor wat je wilt uitvragen. Doe je gebruikersonderzoek? Deel dan alsjeblieft je bevindingen op [gebruikersonderzoeken.nl](http://gebruikersonderzoeken.nl/) zodat we hiervan allemaal kunnen leren.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -282,12 +282,12 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 
 /* Display internal link below sticky header */
 .theme-doc-markdown h2:before {
-  content: '';
+  content: "";
   display: block;
   position: relative;
   width: 0;
   height: 4em;
-  margin-top: -4em
+  margin-top: -4em;
 }
 
 code,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -280,6 +280,16 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
   --ifm-h1-font-size: var(--utrecht-heading-3-font-size);
 }
 
+/* Display internal link below sticky header */
+.theme-doc-markdown h2:before {
+  content: '';
+  display: block;
+  position: relative;
+  width: 0;
+  height: 4em;
+  margin-top: -4em
+}
+
 code,
 pre {
   font-family: "Fira Code VF" !important;


### PR DESCRIPTION
Bovenin elke pagina zijn nu de opsomming naar de richtlijnen op die pagina vervangen door interne links.
Related issue: https://github.com/nl-design-system/documentatie/issues/752
