### PR TITLE
Voeg FAQ toe als FAQ pagina

### DIFF
--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -24,7 +24,7 @@ Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden. Zo worde
 
 Het NL Design System bestaat uit verschillende soorten onderdelen:
 
-- [richtlijnen](/richtlijnen): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
+- [richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
 - [componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
 - [patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
 - [handboek](/handboek/introductie): documentatie over het gebruik van NL Design System.
@@ -58,7 +58,7 @@ Als organisatie die meewerkt aan NL Design System beslis je dus mee over nieuwe 
 
 ## Welke NLDS-richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?
 
-In de community zijn al verschillende richtlijnen en componenten te vinden. Voor vragen, meld je gerust in de Slack-community van Code for NL.
+In de community zijn al verschillende richtlijnen en componenten te vinden. Voor vragen, meld je gerust in de [Slack-community van Code for NL](https://praatmee.codefor.nl/) (kanaal `#nldesignsystem`).
 
 ## Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?
 
@@ -79,16 +79,16 @@ Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in h
 
 ## Zijn er al andere organisaties die meedoen? Hebben jullie wat contactgegevens voor mij?
 
-NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. [Op onze website](/community/wie-doet-mee/) vind je een overzicht van organisaties die zelf en/of via hun leveranciers meedoen met NL Design System.
+NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. Op onze website vind je een [overzicht van organisaties](/community/wie-doet-mee/) die zelf en/of via hun leveranciers meedoen met NL Design System.
 
 Meedoen kan op allerlei manieren, van alleen gebruiken tot zelf meebouwen:
 
-- **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en apps.
+- **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen/introductie), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en apps.
 - **Doe kennis op**: kom naar bijeenkomsten als de tweewekelijkse Heartbeat, Design Systems Week of hackatons. Of word lid van onze [Slack community bij CodeForNL](https://praatmee.codefor.nl/) (kanaal: #nl-design-system).
 - **Werk mee**: deel je eigen richtlijnen, componenten of onderzoek, of geef feedback op de bestaande bouwstenen.
 
 ## Hoe is security geregeld binnen NLDS?
 
-Het kernteam beheert de _repository's_ waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
+Het kernteam beheert de [_repository's_](https://github.com/orgs/nl-design-system/repositories) waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
 
 We passen best practices toe om te zorgen dat deze repository's up to date en veilig blijven, zoals automatisch instellen van rechten, _branch protection_ en procedures voor het regelmatig updaten van dependency's.

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -78,7 +78,7 @@ Voor vragen, design of development: meld je gerust in de [Slack-community van Co
 
 NL Design System helpt op dit moment op twee manieren bij de toegankelijkheidsopgave van organisaties:
 
-1. Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, uitleg van de [WCAG-criteria](https://www.w3.org/Translations/WCAG21-nl/) en tips die verder dan gaan de WCAG.
+1. Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, voorbeelden waarmee je aan[WCAG](https://www.w3.org/Translations/WCAG21-nl/) kunt voldoen en tips die verder dan gaan de WCAG.
 2. Onze componenten kunnen worden gebruikt om toegankelijke producten te maken. Als componenten de laatste fase hebben bereikt (Hall of Fame), garanderen we zelfs dat ze voldoen aan toegankelijkheidseisen én zijn ze in productie getest.
 
 ## Mijn leverancier heeft vragen over NL Design System. Naar wie van jullie kan ik hem verwijzen?

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -89,7 +89,7 @@ Ben je zelf leverancier en wil je voor klanten met NL Design System aan de slag?
 
 ## Ik wil mijn manager voorstellen om mee te doen met NL Design System. Wat zijn de kosten en doorlooptijd? Waar moet ik zelf voor zorgen?
 
-Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in het beschikbaar stellen van resources en de tijd vrijmaken waarin ze samenwerken.
+Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in het beschikbaar stellen van mensen en de tijd vrijmaken waarin ze samenwerken.
 
 ## Zijn er al andere organisaties die meedoen?
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -27,7 +27,8 @@ Het NL Design System bestaat uit verschillende soorten onderdelen:
 - [Richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
 - [Componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
 - [Patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
-- [handboek](/handboek/introductie): documentatie over het gebruik van NL Design System.
+
+Er is ook een [handboek](/handboek/introductie), documentatie over het gebruik van NL Design System.
 
 Deze onderdelen ontstaan niet bij het kernteam, maar in de community. Bijvoorbeeld omdat een gemeente of ministerie een specifiek component of patroon nodig heeft.
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -32,7 +32,7 @@ NL Design System is een project dat specialisten van verschillende overheidsorga
 
 Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden, en hebben meer tijd om gebruikers centraal te stellen. Zo worden online overheidsomgevingen consistenter, gebruiksvriendelijker en toegankelijker.
 
-## Hoe werkt het NL Design System en waarom?
+## Hoe werkt het NL Design System?
 
 Het NL Design System bestaat uit verschillende soorten onderdelen:
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -19,7 +19,7 @@ Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van N
 - [Wat is het estafettemodel? Hoe werkt dat model?](#wat-is-het-estafettemodel-hoe-werkt-dat-model)
 - [Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?](#waarom-maken-jullie-niet-gewoon-zelf-componenten-richtlijnen-en-ontwerpen-en-stellen-die-beschikbaar)
 - [Waarom hebben jullie een community? Wat doet die voor mij?](#waarom-hebben-jullie-een-community-wat-doet-die-voor-mij)
-- [Welke NLDS-richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?](#welke-nlds-richtlijnen-en-componenten-kan-ik-nu-direct-gebruiken-om-mijn-website-digitaal-gebruiksvriendelijk-en-toegankelijk-te-krijgen)
+- [Welke richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?](#welke-nlds-richtlijnen-en-componenten-kan-ik-nu-direct-gebruiken-om-mijn-website-digitaal-gebruiksvriendelijk-en-toegankelijk-te-krijgen)
 - [Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?](#ik-wil-nl-design-system-gaan-gebruiken-voor-mijn-toegankelijkheidsopgave-maar-waar-moet-ik-beginnen)
 - [Mijn leverancier heeft vragen over NL Design System. Naar wie van jullie kan ik hem verwijzen?](#mijn-leverancier-heeft-vragen-over-nl-design-system-naar-wie-van-jullie-kan-ik-hem-verwijzen)
 - [Ik wil mijn manager voorstellen om mee te doen met NL Design System. Wat zijn de kosten en doorlooptijd? Waar moet ik zelf voor zorgen?](#ik-wil-mijn-manager-voorstellen-om-mee-te-doen-met-nl-design-system-wat-zijn-de-kosten-en-doorlooptijd-waar-moet-ik-zelf-voor-zorgen)
@@ -39,12 +39,11 @@ Het NL Design System bestaat uit verschillende soorten onderdelen:
 - [Richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
 - [Componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
 - [Patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
+- Er is ook een [handboek](/handboek/introductie) over het gebruik van NL Design System.
 
-Er is ook een [handboek](/handboek/introductie), documentatie over het gebruik van NL Design System.
+De community neemt het initiatief voor deze onderdelen, bijvoorbeeld wanneer een gemeente of ministerie een specifiek component of patroon nodig heeft.
 
-Deze onderdelen ontstaan niet bij het kernteam, maar in de community. Bijvoorbeeld omdat een gemeente of ministerie een specifiek component of patroon nodig heeft.
-
-Als blijkt dat meer organisaties datzelfde component willen gebruiken, wordt er samengewerkt aan een ultieme versie, waarop het kernteam regie voert, kwaliteit bewaakt en garanties geeft. Dit doen we met het ‘[estafettemodel](/handboek/estafettemodel)’. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd.
+Het kernteam geeft ondersteuning als blijkt dat meer organisaties datzelfde component willen gebruiken. Dan wordt er samengewerkt aan een ultieme versie, waarop het kernteam regie voert, kwaliteit bewaakt en garanties geeft. Dit doen we met het ‘[estafettemodel](/handboek/estafettemodel)’. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd.
 
 ## Wat is het estafettemodel? Hoe werkt dat model?
 
@@ -99,11 +98,19 @@ NL Design System wordt gebruikt in verschillende projecten van overheidsorganisa
 Meedoen kan op allerlei manieren, van alleen gebruiken tot zelf meebouwen:
 
 - **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen/introductie), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en applicaties.
-- **Doe kennis op**: kom naar bijeenkomsten als de tweewekelijkse Heartbeat, Design Systems Week of hackatons. Of word lid van onze [Slack community bij CodeForNL](https://praatmee.codefor.nl/) (kanaal: #nl-design-system).
-- **Werk mee**: deel je eigen richtlijnen, componenten of onderzoek, of geef feedback op de bestaande bouwstenen.
+- **Doe kennis op**: kom naar bijeenkomsten als de tweewekelijkse Heartbeat, Design Systems Week of hackatons. Of word lid van onze [Slack community bij Code for NL](https://praatmee.codefor.nl/) (kanaal: #nl-design-system).
+- **Werk mee**: deel je eigen richtlijnen, componenten of onderzoek, [maak een thema voor je huisstijl](/handboek/developer/thema-maken), of geef feedback op de bestaande bouwstenen.
 
 ## Hoe is security geregeld binnen NLDS?
 
-Het kernteam beheert de [repository's](https://github.com/orgs/nl-design-system/repositories) waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
+Het kernteam helpt de community om hun [repository's](https://github.com/orgs/nl-design-system/repositories) vers en veilig te houden, zodat iedereen gerust gebruik kan maken van de componenten en thema's.
+
+- Alle code wordt verplicht door een tweede teamlid gecontroleerd.
+- Elke dag worden backups gemaakt van de NL Design System projecten op GitHub.
+- Elke maand werken we samen om updates te installeren.
+- De updates gaan niet automatisch, alle wijzigingen worden door twee personen gecontroleerd.
+- Organisaties die werken op [github.com/nl-design-system](github.com/nl-design-system) worden [geholpen met infrastructuur](http://github.com/nl-design-system/terraform) die toegang tot de code en de integriteit van de code bewaakt.
+- Twee-factor-authenticatie (2FA) is verplicht voor alle bijdragen aan NL Design System.
+- Alle code controleren we automatisch op secure coding practices, en voldoen aan die regels is verplicht.
 
 We passen best practices toe om te zorgen dat deze repository's up to date en veilig blijven, zoals automatisch instellen van rechten, branch protection en procedures voor het regelmatig updaten van dependency's.

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -1,0 +1,94 @@
+---
+title: Veelgestelde vragen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Veelgestelde vragen
+pagination_label: Veelgestelde vragen
+description: Een overzicht van vragen die ons regelmatig gesteld worden.
+keywords:
+  - faq
+  - nl design system
+---
+
+# Veelgestelde vragen
+
+Het kernteam van NL Design System krijgt soms vragen die regelmatig terugkomen. Op deze pagina geven we op een aantal antwoord, zodat ze makkelijk terug te vinden zijn.
+
+## Wat is het NL Design System?
+
+NL Design System is een project dat specialisten van verschillende overheidsorganisaties laat samenwerken aan concrete oplossingen voor websites en applicaties. Denk bijvoorbeeld aan code, ontwerp en richtlijnen.
+
+Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden. Zo worden online overheidsomgevingen consistenter, gebruiksvriendelijker en toegankelijker.
+
+## Hoe werkt het NL Design System en waarom?
+
+Het NL Design System bestaat uit verschillende soorten onderdelen:
+
+- [richtlijnen](/richtlijnen): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
+- [componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
+- [patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
+- [handboek](/handboek/introductie): documentatie over het gebruik van NL Design System.
+
+Deze onderdelen ontstaan niet bij het kernteam, maar in de community. Bijvoorbeeld omdat een gemeente of ministerie een specifiek component nodig heeft.
+
+Als blijkt dat meer organisaties datzelfde component willen gebruiken, wordt er samengewerkt aan een ultieme versie, waarop het kernteam regie voert, kwaliteit bewaakt en garanties geeft. Dit doen we met het [estafettemodel](/handboek/estafettemodel)”. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd.
+
+## Wat is het estafettemodel? Hoe werkt dat model?
+
+De aanpak binnen NL Design System om samen te werken noemen we het “[estafettemodel](/handboek/estafettemodel)”. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd. Zo gaan onderdelen van [“Help Wanted”](/handboek/estafettemodel#help-wanted) naar [“Community”](/handboek/estafettemodel#community) naar [“Candidate”](/handboek/estafettemodel#candidate) naar [“Hall of Fame”](/handboek/estafettemodel#hall-of-fame). Elke stap heeft een eigen checklist, waarmee we kwaliteit waarborgen en bepalen wie wat doet.
+
+Elke stap heeft ook een eigen doel. De “Community” stap geeft organisaties alle vrijheid om te innoveren en van elkaar te gebruiken. In de “Candidate” stap is het onderdeel algemener gemaakt, breder ingezet en klaar voor de laatste feedback. Tot slot wordt het onderdeel definitief in de “Hall of Fame” stap, met garanties op toegankelijkheid en gebruiksvriendelijkheid.
+
+Door zo'n uitgebreid stappenplan te doorlopen, zorgen we voor een aantal zekerheden:
+
+- **Goed onderzocht**: we nemen gebruikersonderzoek als basis voor bruikbare richtlijnen, componenten, patronen en betere toegankelijkheid.
+- **Publiek beschikbaar**: we maken open source werken makkelijker, waardoor samenwerken makkelijk wordt.
+- **Samen ontwikkeld**: oplossingen worden gebouwd en gebruikt door een actieve community.
+- **Breed gedragen**: onderdelen zijn bij meerdere organisaties gebruikt en daardoor getest met zoveel mogelijk verschillende use cases.
+
+## Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?
+
+We ontwerpen de onderdelen niet zelf, omdat we de doelen van deelnemende organisaties centraal willen stellen. En, nog belangrijker, de behoeften van hun gebruikers. Doordat specialisten in de community samenwerken stimuleren we vanaf het begin breed draagvlak. Zo worden oplossingen direct in de praktijk gebruikt en kunnen ze gelijk met de juiste doelgroep worden getest.
+
+## Waarom hebben jullie een community? Wat doet die dan voor mij?
+
+Overheidsorganisaties hebben veel overlap in de online diensten die ze aanbieden. Die overlap maakt samenwerken logisch en dat doen wij als community. Want als we dezelfde uitdagingen hebben, kunnen we vast ook van elkaar leren wat betreft oplossingen.
+
+Als organisatie die meewerkt aan NL Design System beslis je dus mee over nieuwe ‘bouwblokken’, profiteer je van wat er al is en maak je gebruik van de expertise van het kernteam én de rest van de community.
+
+## Welke NLDS-richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?
+
+In de community zijn al verschillende richtlijnen en componenten te vinden. Voor vragen, meld je gerust in de Slack-community van Code for NL.
+
+## Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?
+
+NL Design System helpt op dit moment op twee manieren bij de toegankelijkheidsopgave van organisaties:
+
+1. Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, uitleg van de [WCAG-criteria](https://www.w3.org/Translations/WCAG21-nl/) en tips die verder dan gaan de WCAG.
+2. Onze componenten kunnen worden gebruikt om toegankelijke producten te maken. Als componenten de laatste fase hebben bereikt (Hall of Fame), garanderen we zelfs dat ze voldoen aan toegankelijkheidseisen én zijn ze in productie getest.
+
+## Mijn leverancier heeft vragen over NL Design System. Naar wie van jullie kan ik hem verwijzen?
+
+Veel organisaties werken met NL Design System via hun leveranciers. Bijvoorbeeld doordat hun leveranciers onze componenten gebruiken, of meedoen in de community.
+
+Ben je zelf leverancier en wil je voor klanten met NL Design System aan de slag? Neem dan contact op met het [kernteam](/project/kernteam), we helpen je graag op weg.
+
+## Ik wil mijn manager voorstellen om mee te doen met NL Design System. Wat zijn de kosten en doorlooptijd? Waar moet ik zelf voor zorgen?
+
+Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in het beschikbaar stellen van resources en de tijd vrijmaken waarin ze samenwerken.
+
+## Zijn er al andere organisaties die meedoen? Hebben jullie wat contactgegevens voor mij?
+
+NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. [Op onze website](/community/wie-doet-mee/) vind je een overzicht van organisaties die zelf en/of via hun leveranciers meedoen met NL Design System.
+
+Meedoen kan op allerlei manieren, van alleen gebruiken tot zelf meebouwen:
+
+- **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en apps.
+- **Doe kennis op**: kom naar bijeenkomsten als de tweewekelijkse Heartbeat, Design Systems Week of hackatons. Of word lid van onze [Slack community bij CodeForNL](https://praatmee.codefor.nl/) (kanaal: #nl-design-system).
+- **Werk mee**: deel je eigen richtlijnen, componenten of onderzoek, of geef feedback op de bestaande bouwstenen.
+
+## Hoe is security geregeld binnen NLDS?
+
+Het kernteam beheert de _repository's_ waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
+
+We passen best practices toe om te zorgen dat deze repository's up to date en veilig blijven, zoals automatisch instellen van rechten, _branch protection_ en procedures voor het regelmatig updaten van dependency's.

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: Veelgestelde vragen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Veelgestelde vragen
 pagination_label: Veelgestelde vragen
 description: Een overzicht van vragen die ons regelmatig gesteld worden.
@@ -13,6 +13,18 @@ keywords:
 # Veelgestelde vragen
 
 Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van NL Design System gesteld worden.
+
+- [Wat is het NL Design System?](#wat-is-het-nl-design-system)
+- [Hoe werkt het NL Design System en waarom?](#hoe-werkt-het-nl-design-system-en-waarom)
+- [Wat is het estafettemodel? Hoe werkt dat model?](#wat-is-het-estafettemodel-hoe-werkt-dat-model)
+- [Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?](#waarom-maken-jullie-niet-gewoon-zelf-componenten-richtlijnen-en-ontwerpen-en-stellen-die-beschikbaar)
+- [Waarom hebben jullie een community? Wat doet die voor mij?](#waarom-hebben-jullie-een-community-wat-doet-die-voor-mij)
+- [Welke NLDS-richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?](#welke-nlds-richtlijnen-en-componenten-kan-ik-nu-direct-gebruiken-om-mijn-website-digitaal-gebruiksvriendelijk-en-toegankelijk-te-krijgen)
+- [Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?](#ik-wil-nl-design-system-gaan-gebruiken-voor-mijn-toegankelijkheidsopgave-maar-waar-moet-ik-beginnen)
+- [Mijn leverancier heeft vragen over NL Design System. Naar wie van jullie kan ik hem verwijzen?](#mijn-leverancier-heeft-vragen-over-nl-design-system-naar-wie-van-jullie-kan-ik-hem-verwijzen)
+- [Ik wil mijn manager voorstellen om mee te doen met NL Design System. Wat zijn de kosten en doorlooptijd? Waar moet ik zelf voor zorgen?](#ik-wil-mijn-manager-voorstellen-om-mee-te-doen-met-nl-design-system-wat-zijn-de-kosten-en-doorlooptijd-waar-moet-ik-zelf-voor-zorgen)
+- [Zijn er al andere organisaties die meedoen?](#zijn-er-al-andere-organisaties-die-meedoen)
+- [Hoe is security geregeld binnen NLDS?](#hoe-is-security-geregeld-binnen-nlds)
 
 ## Wat is het NL Design System?
 
@@ -51,7 +63,7 @@ Door zo'n uitgebreid stappenplan te doorlopen, zorgen we voor een aantal zekerhe
 
 We ontwikkelen de onderdelen niet zelf, omdat we de doelen van deelnemende organisaties centraal willen stellen. En, nog belangrijker, de behoeften van hun gebruikers. Doordat specialisten in de community samenwerken stimuleren we vanaf het begin breed draagvlak. Zo worden oplossingen direct in de praktijk gebruikt en kunnen ze gelijk met de juiste doelgroep worden getest.
 
-## Waarom hebben jullie een community? Wat doet die dan voor mij?
+## Waarom hebben jullie een community? Wat doet die voor mij?
 
 Overheidsorganisaties hebben veel overlap in de online diensten die ze aanbieden. Die overlap maakt samenwerken logisch en dat doen wij als community. Want als we dezelfde uitdagingen hebben, kunnen we vast ook van elkaar leren wat betreft oplossingen.
 
@@ -78,7 +90,7 @@ Ben je zelf leverancier en wil je voor klanten met NL Design System aan de slag?
 
 Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in het beschikbaar stellen van resources en de tijd vrijmaken waarin ze samenwerken.
 
-## Zijn er al andere organisaties die meedoen? Hebben jullie wat contactgegevens voor mij?
+## Zijn er al andere organisaties die meedoen?
 
 NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. Op de pagina [‘Wie doet mee?’](/community/wie-doet-mee/) vind je een overzicht van organisaties die zelf en/of via hun leveranciers meedoen met NL Design System.
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -71,7 +71,9 @@ Als organisatie die meewerkt aan NL Design System beslis je dus mee over nieuwe 
 
 ## Welke NLDS-richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?
 
-In de community zijn al verschillende richtlijnen en componenten te vinden. Voor vragen, meld je gerust in de [Slack-community van Code for NL](https://praatmee.codefor.nl/) (kanaal `#nldesignsystem`).
+In de community zijn al veel verschillende [richtlijnen](/richtlijnen) en [componenten](/componenten) te vinden. De richtlijnen zijn direct op deze website te vinden, voor de componenten kun je terecht bij de organisaties waar ze gemaakt zijn. Op de pagina [componenten](/componenten) vind je links naar de relevante Storybooks en Figma-bestanden.
+
+Voor vragen, design of development: meld je gerust in de [Slack-community van Code for NL](https://praatmee.codefor.nl/) (kanaal `#nldesignsystem`).
 
 ## Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -15,7 +15,7 @@ keywords:
 Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van NL Design System gesteld worden.
 
 - [Wat is het NL Design System?](#wat-is-het-nl-design-system)
-- [Hoe werkt het NL Design System en waarom?](#hoe-werkt-het-nl-design-system-en-waarom)
+- [Hoe werkt het NL Design System?](#hoe-werkt-het-nl-design-system)
 - [Wat is het estafettemodel? Hoe werkt dat model?](#wat-is-het-estafettemodel-hoe-werkt-dat-model)
 - [Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?](#waarom-maken-jullie-niet-gewoon-zelf-componenten-richtlijnen-en-ontwerpen-en-stellen-die-beschikbaar)
 - [Waarom hebben jullie een community? Wat doet die voor mij?](#waarom-hebben-jullie-een-community-wat-doet-die-voor-mij)

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -12,7 +12,7 @@ keywords:
 
 # Veelgestelde vragen
 
-Het kernteam van NL Design System krijgt soms vragen die regelmatig terugkomen. Op deze pagina geven we op een aantal antwoord, zodat ze makkelijk terug te vinden zijn.
+Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van NL Design System gesteld worden.
 
 ## Wat is het NL Design System?
 
@@ -24,20 +24,20 @@ Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden. Zo worde
 
 Het NL Design System bestaat uit verschillende soorten onderdelen:
 
-- [richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
-- [componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
-- [patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
+- [Richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
+- [Componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
+- [Patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
 - [handboek](/handboek/introductie): documentatie over het gebruik van NL Design System.
 
-Deze onderdelen ontstaan niet bij het kernteam, maar in de community. Bijvoorbeeld omdat een gemeente of ministerie een specifiek component nodig heeft.
+Deze onderdelen ontstaan niet bij het kernteam, maar in de community. Bijvoorbeeld omdat een gemeente of ministerie een specifiek component of patroon nodig heeft.
 
-Als blijkt dat meer organisaties datzelfde component willen gebruiken, wordt er samengewerkt aan een ultieme versie, waarop het kernteam regie voert, kwaliteit bewaakt en garanties geeft. Dit doen we met het [estafettemodel](/handboek/estafettemodel)”. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd.
+Als blijkt dat meer organisaties datzelfde component willen gebruiken, wordt er samengewerkt aan een ultieme versie, waarop het kernteam regie voert, kwaliteit bewaakt en garanties geeft. Dit doen we met het ‘[estafettemodel](/handboek/estafettemodel)’. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd.
 
 ## Wat is het estafettemodel? Hoe werkt dat model?
 
-De aanpak binnen NL Design System om samen te werken noemen we het “[estafettemodel](/handboek/estafettemodel)”. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd. Zo gaan onderdelen van [“Help Wanted”](/handboek/estafettemodel#help-wanted) naar [“Community”](/handboek/estafettemodel#community) naar [“Candidate”](/handboek/estafettemodel#candidate) naar [“Hall of Fame”](/handboek/estafettemodel#hall-of-fame). Elke stap heeft een eigen checklist, waarmee we kwaliteit waarborgen en bepalen wie wat doet.
+De aanpak binnen NL Design System om samen te werken noemen we het ‘[estafettemodel](/handboek/estafettemodel)’. Hierin krijgen richtlijnen, componenten en patronen een status, die aangeeft hoe ver ze zijn gevorderd. Zo gaan onderdelen van ‘[Help Wanted](/handboek/estafettemodel#help-wanted)’ naar ‘[Community](/handboek/estafettemodel#community)’ naar ‘[Candidate](/handboek/estafettemodel#candidate)’ naar ‘[Hall of Fame](/handboek/estafettemodel#hall-of-fame)’. Elke stap heeft een eigen checklist, waarmee we kwaliteit waarborgen en bepalen wie wat doet.
 
-Elke stap heeft ook een eigen doel. De “Community” stap geeft organisaties alle vrijheid om te innoveren en van elkaar te gebruiken. In de “Candidate” stap is het onderdeel algemener gemaakt, breder ingezet en klaar voor de laatste feedback. Tot slot wordt het onderdeel definitief in de “Hall of Fame” stap, met garanties op toegankelijkheid en gebruiksvriendelijkheid.
+Elke stap heeft ook een eigen doel. De ‘Community’ stap geeft organisaties alle vrijheid om te innoveren en van elkaar te gebruiken. In de ‘Candidate’ stap is het onderdeel algemener gemaakt, breder ingezet en klaar voor de laatste feedback. Tot slot wordt het onderdeel definitief in de ‘Hall of Fame’ stap, met garanties op toegankelijkheid en gebruiksvriendelijkheid.
 
 Door zo'n uitgebreid stappenplan te doorlopen, zorgen we voor een aantal zekerheden:
 
@@ -46,9 +46,9 @@ Door zo'n uitgebreid stappenplan te doorlopen, zorgen we voor een aantal zekerhe
 - **Samen ontwikkeld**: oplossingen worden gebouwd en gebruikt door een actieve community.
 - **Breed gedragen**: onderdelen zijn bij meerdere organisaties gebruikt en daardoor getest met zoveel mogelijk verschillende use cases.
 
-## Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?
+## Waarom maken jullie niet gewoon zelf componenten en patronen?
 
-We ontwerpen de onderdelen niet zelf, omdat we de doelen van deelnemende organisaties centraal willen stellen. En, nog belangrijker, de behoeften van hun gebruikers. Doordat specialisten in de community samenwerken stimuleren we vanaf het begin breed draagvlak. Zo worden oplossingen direct in de praktijk gebruikt en kunnen ze gelijk met de juiste doelgroep worden getest.
+We ontwikkelen de onderdelen niet zelf, omdat we de doelen van deelnemende organisaties centraal willen stellen. En, nog belangrijker, de behoeften van hun gebruikers. Doordat specialisten in de community samenwerken stimuleren we vanaf het begin breed draagvlak. Zo worden oplossingen direct in de praktijk gebruikt en kunnen ze gelijk met de juiste doelgroep worden getest.
 
 ## Waarom hebben jullie een community? Wat doet die dan voor mij?
 
@@ -79,16 +79,16 @@ Meedoen is gratis en kan stap voor stap. De kosten voor organisaties zitten in h
 
 ## Zijn er al andere organisaties die meedoen? Hebben jullie wat contactgegevens voor mij?
 
-NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. Op onze website vind je een [overzicht van organisaties](/community/wie-doet-mee/) die zelf en/of via hun leveranciers meedoen met NL Design System.
+NL Design System wordt gebruikt in verschillende projecten van overheidsorganisaties door heel Nederland. Veel van deze projecten zijn in ontwikkeling, sommige projecten staan live. Op de pagina [‘Wie doet mee?’](/community/wie-doet-mee/) vind je een overzicht van organisaties die zelf en/of via hun leveranciers meedoen met NL Design System.
 
 Meedoen kan op allerlei manieren, van alleen gebruiken tot zelf meebouwen:
 
-- **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen/introductie), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en apps.
+- **Gebruik de bouwstenen**: gebruik [richtlijnen](/richtlijnen/introductie), [componenten](/componenten) of [onderzoek](/onderzoek) voor je websites en applicaties.
 - **Doe kennis op**: kom naar bijeenkomsten als de tweewekelijkse Heartbeat, Design Systems Week of hackatons. Of word lid van onze [Slack community bij CodeForNL](https://praatmee.codefor.nl/) (kanaal: #nl-design-system).
 - **Werk mee**: deel je eigen richtlijnen, componenten of onderzoek, of geef feedback op de bestaande bouwstenen.
 
 ## Hoe is security geregeld binnen NLDS?
 
-Het kernteam beheert de [_repository's_](https://github.com/orgs/nl-design-system/repositories) waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
+Het kernteam beheert de [repository's](https://github.com/orgs/nl-design-system/repositories) waarin de diverse NL Design System projecten publiek worden ontsloten, zoals thema's en organisatie-specifieke design systems.
 
-We passen best practices toe om te zorgen dat deze repository's up to date en veilig blijven, zoals automatisch instellen van rechten, _branch protection_ en procedures voor het regelmatig updaten van dependency's.
+We passen best practices toe om te zorgen dat deze repository's up to date en veilig blijven, zoals automatisch instellen van rechten, branch protection en procedures voor het regelmatig updaten van dependency's.

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -37,7 +37,7 @@ Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden. Zo worde
 Het NL Design System bestaat uit verschillende soorten onderdelen:
 
 - [Richtlijnen](/richtlijnen/introductie): adviezen over verschillende onderwerpen, zoals het [maken van formulieren](/richtlijnen/formulieren/).
-- [Componenten](/componenten): bouwblokken waarmee websites en applicaties kunnen worden opgebouwd, zoals knoppen, invulvelden en tabellen.
+- [Componenten](/componenten): bouwblokken waarmee websites en applicaties worden opgebouwd, zoals knoppen, invulvelden en tabellen.
 - [Patronen](/voorbeelden/patronen): voorbeelden van hoe componenten samen kunnen worden gebruikt voor specifieke taken die gebruikers willen doen, op basis van inzichten uit [gebruikersonderzoek](/voorbeelden/onderzoek).
 - Er is ook een [handboek](/handboek/introductie) over het gebruik van NL Design System.
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -30,7 +30,7 @@ Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van N
 
 NL Design System is een project dat specialisten van verschillende overheidsorganisaties laat samenwerken aan concrete oplossingen voor websites en applicaties. Denk bijvoorbeeld aan code, ontwerp en richtlijnen.
 
-Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden. Zo worden online overheidsomgevingen consistenter, gebruiksvriendelijker en toegankelijker.
+Het doel: organisaties hoeven minder vaak hetzelfde wiel uit te vinden, en hebben meer tijd om gebruikers centraal te stellen. Zo worden online overheidsomgevingen consistenter, gebruiksvriendelijker en toegankelijker.
 
 ## Hoe werkt het NL Design System en waarom?
 

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -249,6 +249,7 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         { type: 'doc', id: 'project/over-nlds' },
+        { type: 'doc', id: 'project/faq' },
         { type: 'doc', id: 'project/kernteam' },
         { type: 'doc', id: 'project/blijf-op-de-hoogte' },
         { type: 'doc', id: 'project/links' },


### PR DESCRIPTION
Context: deze fixes https://github.com/nl-design-system/kernteam/issues/597 in de [Mediakit v1 milestone](https://github.com/nl-design-system/kernteam/milestone/66).

[PREVIEW van FAQ pagina](https://documentatie-git-add-faq-nl-design-system.vercel.app/project/faq)

Hiermee voegen we de FAQ ook toe als FAQ. Antwoorden proberen zoveel mogelijk formuleringen te gebruiken als op elders op de site, maar worden soms door de vraag naar een net iets andere formulering gedwongen (feature, geen bug).

@Robbert de [laatste vraag over security](https://documentatie-git-add-faq-nl-design-system.vercel.app/project/faq#hoe-is-security-geregeld-binnen-nlds) is nieuw en hebben we nog niet eerder gecheckt, wil je kritisch kijken naar of het antwoord klopt en goede voorbeelden geeft van wat we nu doen qua security?

@jeffreylauwers @rianrietveld vraag voor jullie om de tekst vanuit niet-developer en accessibilityspecialist perspectief te bekijken op leesbaarheid en duidelijkheid.