### PR TITLE
chore: redirect /factsheets

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,7 @@ services:
     volumes:
       - ./build:/usr/local/apache2/htdocs/
       - ./static/.htaccess:/usr/local/apache2/htdocs/.htaccess
+      - ./static/factsheets:/usr/local/apache2/htdocs/factsheets
       - ./httpd.conf:/usr/local/apache2/conf/httpd.conf
     build:
       dockerfile: httpd.Dockerfile

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -18,3 +18,6 @@ RedirectMatch 301 "^/project/events(.*)$" "/community/events$1"
 Redirect 301 "/project/wie-doet-mee" "/community/wie-doet-mee"
 
 Redirect 301 "/onderzoek" "/voorbeelden/onderzoek"
+
+# until we have multiple factsheets and turn /factsheets into an overview page
+RedirectMatch 302 "^/factsheets/?$" "/factsheets/managers"


### PR DESCRIPTION
Temporarily redirect to /factsheets/managers

Also add a volume mount for `./static/factsheets` to the Docker file