### PR TITLE
Verduidelijk introductiepagina

### DIFF
--- a/docs/handboek/developer/03-thema-maken.mdx
+++ b/docs/handboek/developer/03-thema-maken.mdx
@@ -11,7 +11,7 @@ import { VideoPlayer } from "../../../src/components/VideoPlayer";
 
 # NL Design System thema maken
 
-Zoals beschreven in [Ontwikkel een thema voor jouw organisatie](/meedoen/als-developer/aan-de-slag#ontwikkel-een-thema-voor-jouw-organisatie): thema's zijn technisch JSON-bestanden waarin design tokens zijn gedefinieerd. Met tooling maken we ze beschikbaar als custom properties in CSS.
+Zoals beschreven in [Ontwikkel een thema voor jouw organisatie](/handboek/developer/aan-de-slag#ontwikkel-een-thema-voor-jouw-organisatie): thema's zijn technisch JSON-bestanden waarin design tokens zijn gedefinieerd. Met tooling maken we ze beschikbaar als custom properties in CSS.
 
 ## Design tokens vastleggen
 

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -13,11 +13,11 @@ keywords:
 
 # Introductie
 
-We maken toegankelijk, inclusief en gebruiksvriendelijk ontwikkelen makkelijk. Op deze pagina lees je meer over wat dat technisch betekent. Voor meer informatie over het project zelf, zie [Over NL Design System](/project/over-nlds).
+NL Design System maakt toegankelijk, inclusief en gebruiksvriendelijk ontwikkelen makkelijk. Op deze pagina lees je meer over wat dat technisch betekent. Voor meer informatie over het project zelf, zie [Over NL Design System](/project/over-nlds).
 
 ## Meer dan alleen ontwerp
 
-NL Design System gaat niet alleen over ontwerp. We bereiken onze doelen met een aantal verschillende onderdelen die samen gebruikt kunnen worden:
+Een design system verzamelt herbruikbare onderdelen om bepaalde doelen te bereiken. Bij ons gaat het om deze onderdelen, die samen gebruikt kunnen worden:
 
 - Richtlijnen voor hoe je de beste digitale diensten maakt, zoals voor het [maken van formulieren](/richtlijnen/formulieren/).
 - Design kit voor grafisch vormgevers en UX-ontwerpers.
@@ -27,45 +27,31 @@ NL Design System gaat niet alleen over ontwerp. We bereiken onze doelen met een 
 - Technische infrastructuur om werk efficiënt te testen, te delen en uit te rollen (zoals een voorbeeldrepository met Storybook en visuele regressietests).
 - Stijlgids om de huisstijl van je organisatie consistent te gebruiken.
 
-Hoewel dit verschillende middelen zijn, hebben ze allemaal als doel om makkelijk consistente, toegankelijke en gebruiksvriendelijke websites en applicaties te maken.
+We verzamelen dus meer dan alleen ontwerp. Al deze onderdelen hebben dit gedeelde doel: makkelijk consistente, toegankelijke en gebruiksvriendelijke websites en applicaties maken.
 
 ## Basisonderdelen voor de hele overheid
 
-NL Design System bevat componenten, patronen en richtlijnen, aangevuld met vele huisstijlen van organisaties die meedoen. Allemaal basisonderdelen waarover je afspraken kunt maken, gebruikersonderzoek kunt doen en van elkaar kunt leren.
+Waar veel design systems een specifieke organisatie bedienen, werkt NL Design System met organisaties verspreid over de hele overheid: van gemeenten tot Rijk.
 
 Juist overheidsorganisaties hebben baat bij één duidelijke set herbruikbare basisonderdelen. Hierdoor kunnen vele kleinere organisaties meeliften op het onderzoek en de ontwikkeling door anderen, en iedereen kan een steentje bijdragen door kleine verbeteringen aan te dragen.
 
-Voor de eindgebruiker is het essentieel dat het gebruik van een site of applicatie duidelijk, toegankelijk en voorspelbaar is. Nog veel meer als voor een levensgebeurtenis, zoals een verhuizing, gebruik gemaakt moet worden van verschillende applicaties van verschillende organisaties.
+Voor de eindgebruiker is het essentieel dat het gebruik van een website of applicatie duidelijk, toegankelijk en voorspelbaar is. Dat wordt in het bijzonder duidelijk bij levensgebeurtenissen, zoals een verhuizing: dan moeten mensen vaak gebruik maken van allerlei verschillende applicaties van verschillende organisaties.
 
 Als ook nieuwe inzichten en gebruikersonderzoek gedeeld worden, kunnen we daar met z'n allen betere richtlijnen, componenten en thema's mee maken. Deze nieuwe versies kunnen dan gebruikt worden in alle applicaties die met NL Design System zijn gebouwd en zo direct de gebruikerservaring van vele eindgebruikers verbeteren.
 
 ### Eén geteste toegankelijke huisstijl voor iedereen?
 
-In Nederland hebben de vele overheidsorganisaties een eigen identiteit en huisstijl. Rijkhuisstijl is voorbehouden voor de Rijksoverheid en mag door alle andere organisaties, zoals gemeentes, niet gebruikt worden.
-Dit is een belangrijk verschil met bijvoorbeeld GOV.UK, die wel één huisstijl kent die door lokale overheiden gebruikt mag worden.
+Dat we samenwerken, betekent niet dat alles wat met NL Design System gemaakt wordt er hetzelfde uit ziet. Dat kan ook niet, want in Nederland hebben de meeste overheidsorganisaties een eigen identiteit, en de Rijkhuisstijl kan alleen worden gebruikt door de Rijksoverheid.
 
-Met het NL Design System kan de hele overheid in Nederland samenwerken aan een begrijpelijke, gebruiksvriendelijke én toegankelijke online dienstverlening. Een dienstverlening die logisch en samenhangend is, maar niet per se uniform, want binnen de afspraken blijft er ruimte voor de eigen identiteit van overheidsorganisaties.
+Door [thema's te maken](/handboek/developer/thema-maken) met beschikbare [design tokens](/handboek/design-tokens/) kunnen applicaties gebruikmaken van dezelfde componenten, zélfs als deze door een andere organisatie gebouwd zijn. Deze thema's kunnen dan weer goed getest worden op toegankelijkheid en gebruiksvriendelijkheid. En ze kunnen voor de verschillende applicaties van één organisatie hergebruikt worden, zelfs als deze door verschillende leveranciers zijn gebouwd.
 
-Door thema's te maken met beschikbare design tokens kunnen applicaties super snel gebruik maken van dezelfde componenten, zélfs als deze door een andere organisatie gebouwd zijn. Deze thema's kunnen dan weer goed getest worden op toegankelijkheid en gebruiksvriendelijkheid en voor de verschillende applicaties van een organisatie hergebruikt worden (zelfs als deze door verschillende leveranciers zijn gebouwd).
+### Samenwerken aan een herbruikbare componentenbibliotheek
 
-### Samen werken aan een herbruikbare componenten bibliotheek
+De community rondom NL Design System omvat 500+ specialisten van verschillende overheidsorganisaties en hun leveranciers.
+We willen niet steeds hetzelfde wiel uitvinden, maar ook niet door elkaar geblokkeerd worden in de ontwikkeling van nieuwe applicaties.
 
-Het NL Design System bestaan uit een community van 560+ leden, een multidisciplinaire groep van geïnteresseerden van verschillende overheidsorganisaties en bedrijven die met overheden werken.
-Deze community heeft een gedeelde ambitie om niet telkens het wiel opnieuw uit te vinden, maar wil ook niet geblokkeerd worden in de ontwikkeling van nieuwe applicaties.
+Om elkaar niet in de weg te zitten, werken we met het “[estafettemodel](/handboek/estafettemodel)”. Kortgezegd kunnen organisaties voor componenten die nog niet centraal beschikbaar een eigen versie maken. Deze versie wordt in grote lijnen gebouwd volgens de gedeelde architectuur, maar hoeft niet compleet te zijn.
 
-Om zoveel mogelijk context te hebben bij het ontwikkelen van een component en gebruik te maken van de inzichten van anderen, hebben we ook een gedeelde ["levende" backlog](http://github.com/nl-design-system/backlog/issues). Deze bevat de gedeelde informatie over eisen en status van componenten en bij wie het component ontwikkeld wordt.
+Andere organisaties die dit component vervolgens ook goed kunnen gebruiken, kunnen dan helpen deze completer te krijgen. Uiteindelijk voldoet het component én is het op meerdere plekken getest en verbeterd.
 
-Om te voorkomen dat deze wens voor compleetheid de ontwikkeling van applicaties blokkeert, werken we met z'n allen volgens "het estafettemodel" voor gedistribueerde ontwikkeling.
-Kortgezegd kan zo voor de componenten die nog niet in de componenten bibliotheek beschikbaar zijn snel een eigen versie gemaakt worden. Deze versie wordt in grote lijnen gebouwd volgens de architectuur, maar hoeft niet compleet te zijn.
-Andere organisaties die dit component vervolgens ook goed kunnen gebruiken, kunnen dan helpen deze completer te krijgen. Uiteindelijk voldoet het component én is het op meerdere plekken getest en verbeterd. Dit component komt dan in NL Design Systems "hall of fame".
-
-Zo'n "hall of fame" component:
-
-- Heeft documentatie van alle configuratie-opties, en beschrijft het beoogd gebruik
-- Is getest met thema’s van diverse organisaties
-- Heeft algemene documentatie over toegankelijkheid
-- Heeft waar nodig contentrichtlijnen
-- Wordt "in productie" gebruikt in tenminste twéé websites
-- Is succesvol meegenomen in toegankelijkheisonderzoek en gebruikersonderzoek waarvan de uitkomsten beschikbaar zijn
-
-Met een aantal actieve organisaties werken we toe naar deze breed inzetbare componenten bibliotheek. De organisaties en componenten die zij maken kun je vinden onder de [NL Design System organisatie op GitHub](http://github.com/nl-design-system).
+Met een aantal actieve organisaties werken we toe naar deze breed inzetbare componenten bibliotheek. De eisen voor componenten per fase vind je in de [Definition of Done](/componenten/definition-of-done). De organisaties en componenten die zij maken kun je vinden onder de [NL Design System organisatie op GitHub](http://github.com/nl-design-system).

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -47,7 +47,7 @@ Door [thema's te maken](/handboek/developer/thema-maken) met beschikbare [design
 
 ### Samenwerken aan een herbruikbare componentenbibliotheek
 
-De community rondom NL Design System omvat 500+ specialisten van verschillende overheidsorganisaties en hun leveranciers.
+De community rondom NL Design System bestaat uit 500+ specialisten van verschillende overheidsorganisaties en hun leveranciers.
 We willen niet steeds hetzelfde wiel uitvinden, maar ook niet door elkaar geblokkeerd worden in de ontwikkeling van nieuwe applicaties.
 
 Om elkaar niet in de weg te zitten, werken we met het “[estafettemodel](/handboek/estafettemodel)”. Kortgezegd kunnen organisaties voor componenten die nog niet centraal beschikbaar een eigen versie maken. Deze versie wordt in grote lijnen gebouwd volgens de gedeelde architectuur, maar hoeft niet compleet te zijn.

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -48,7 +48,7 @@ Door [thema's te maken](/handboek/developer/thema-maken) met beschikbare [design
 ### Samenwerken aan een herbruikbare componentenbibliotheek
 
 De community rondom NL Design System bestaat uit 500+ specialisten van verschillende overheidsorganisaties en hun leveranciers.
-We willen niet steeds hetzelfde wiel uitvinden, maar ook niet door elkaar geblokkeerd worden in de ontwikkeling van nieuwe applicaties.
+We willen niet steeds hetzelfde wiel uitvinden, maar elkaar ook niet vertragen bij de ontwikkeling van nieuwe applicaties.
 
 Om elkaar niet in de weg te zitten, werken we met het “[estafettemodel](/handboek/estafettemodel)”. Kortgezegd kunnen organisaties voor componenten die nog niet centraal beschikbaar een eigen versie maken. Deze versie wordt in grote lijnen gebouwd volgens de gedeelde architectuur, maar hoeft niet compleet te zijn.
 


### PR DESCRIPTION
fixes https://github.com/nl-design-system/kernteam/issues/598 

Paar verduidelijkingen: 

- meer gericht op professional die straks misschien aan de slag gaat met code of design en wil begrijpen hoe het concreet werkt; minder op voordelen
- linkjes toegevoegd en gefixt
- uitleg estafettemodel compacter gemaakt met verwijzing naar estafettemodelpagina en definition of done