### PR TITLE
TOC link fix

### DIFF
--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -17,7 +17,7 @@ Op deze pagina geven we antwoord op vragen die regelmatig aan het kernteam van N
 - [Wat is het NL Design System?](#wat-is-het-nl-design-system)
 - [Hoe werkt het NL Design System?](#hoe-werkt-het-nl-design-system)
 - [Wat is het estafettemodel? Hoe werkt dat model?](#wat-is-het-estafettemodel-hoe-werkt-dat-model)
-- [Waarom maken jullie niet gewoon zelf componenten, richtlijnen en ontwerpen en stellen die beschikbaar?](#waarom-maken-jullie-niet-gewoon-zelf-componenten-richtlijnen-en-ontwerpen-en-stellen-die-beschikbaar)
+- [Waarom maken jullie niet gewoon zelf componenten en patronen?](#waarom-maken-jullie-niet-gewoon-zelf-componenten-en-patronen)
 - [Waarom hebben jullie een community? Wat doet die voor mij?](#waarom-hebben-jullie-een-community-wat-doet-die-voor-mij)
 - [Welke richtlijnen en componenten kan ik nu direct gebruiken om mijn website digitaal, gebruiksvriendelijk en toegankelijk te krijgen?](#welke-nlds-richtlijnen-en-componenten-kan-ik-nu-direct-gebruiken-om-mijn-website-digitaal-gebruiksvriendelijk-en-toegankelijk-te-krijgen)
 - [Ik wil NL Design System gaan gebruiken voor mijn toegankelijkheidsopgave maar waar moet ik beginnen?](#ik-wil-nl-design-system-gaan-gebruiken-voor-mijn-toegankelijkheidsopgave-maar-waar-moet-ik-beginnen)


### PR DESCRIPTION
Link to "Waarom maken jullie niet gewoon zelf componenten en patronen?" was incorrect, and the title was inconsistent.