### PR TITLE
WCAG-pagina's: Voeg link naar succescriterium binnen de WCAG Quickref pagina toe

### DIFF
--- a/docs/wcag/1.1.1.mdx
+++ b/docs/wcag/1.1.1.mdx
@@ -21,6 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.1.1 Non-text Content</span>](https://www.w3.org/TR/WCAG22/#non-text-content).
 - Nederlandse vertaling van het WCAG-succescriterium: [1.1.1 Niet-tekstuele content](https://www.w3.org/Translations/WCAG21-nl/#tekstalternatieven).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.1.1 Non-text Content</span>](https://www.w3.org/WAI/WCAG22/quickref/#non-text-content).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.1.1: Non-text Content</span>](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html).
 
 ## Korte samenvatting

--- a/docs/wcag/1.3.5.mdx
+++ b/docs/wcag/1.3.5.mdx
@@ -19,8 +19,9 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 ## W3C referenties
 
-- Engelse tekst van het WCAG-succescriterium [<span lang="en">1.3.5 Identify Input Purpose</span>](https://www.w3.org/TR/WCAG22/#identify-input-purpose).
-- Nederlandse vertaling van het WCAG-succescriterium [1.3.5 Identificeer het doel van de input](https://www.w3.org/Translations/WCAG21-nl/#niet-tekstuele-content).
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.3.5 Identify Input Purpose</span>](https://www.w3.org/TR/WCAG22/#identify-input-purpose).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.3.5 Identificeer het doel van de input](https://www.w3.org/Translations/WCAG21-nl/#niet-tekstuele-content).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/quickref/#identify-input-purpose).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html).
 
 ## Korte samenvatting

--- a/docs/wcag/2.1.1.mdx
+++ b/docs/wcag/2.1.1.mdx
@@ -22,6 +22,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.1.1 Keyboard</span>](https://www.w3.org/TR/WCAG22/#keyboard).
 - Nederlandse vertaling van het WCAG-succescriterium: [2.1.1 Toetsenbord](https://www.w3.org/Translations/WCAG21-nl/#toetsenbord).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/quickref/#keyboard).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).
 
 ## Korte samenvatting

--- a/docs/wcag/3.3.1.mdx
+++ b/docs/wcag/3.3.1.mdx
@@ -21,6 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.1 Error Identification</span>](https://www.w3.org/TR/WCAG22/#error-identification).
 - Nederlandse vertaling van het WCAG-succescriterium: [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG21-nl/#foutidentificatie).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.1 Error Identification</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-identification).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.1 Identification</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html).
 
 ## Korte samenvatting

--- a/docs/wcag/3.3.3.mdx
+++ b/docs/wcag/3.3.3.mdx
@@ -21,6 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.3 Error Suggestion</span>](https://www.w3.org/TR/WCAG22/#error-suggestion).
 - Nederlandse vertaling van het WCAG-succescriterium: [3.3.3 Foutsuggestie](https://www.w3.org/Translations/WCAG21-nl/#foutsuggestie).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-suggestion).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html).
 
 ## Korte samenvatting

--- a/docs/wcag/3.3.4.mdx
+++ b/docs/wcag/3.3.4.mdx
@@ -21,6 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.4 Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/TR/WCAG22/#error-prevention-legal-financial-data).
 - Nederlandse vertaling van het WCAG-succescriterium: [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](https://www.w3.org/Translations/WCAG21-nl/#foutpreventie-wettelijk-financieel-gegevens).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.4 Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-legal-financial-data).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.4:Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html).
 
 ## Korte samenvatting

--- a/docs/wcag/4.1.3.mdx
+++ b/docs/wcag/4.1.3.mdx
@@ -21,11 +21,12 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">4.1.3 Status Messages</span>](https://www.w3.org/TR/WCAG22/#status-messages).
 - Nederlandse vertaling van het WCAG-succescriterium: [4.1.3 Statusberichten](https://www.w3.org/Translations/WCAG21-nl/#statusberichten).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 4.1.3 Status Messages</span>](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 4.1.3: Status Messages</span>](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html).
 
 ## Korte samenvatting
 
-Je kunt updates met belangrijke informatie met de gebruiker delen via een statusbericht. Als dit bericht bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor gebruikers, die de melding niet zien, deze informatie toch meekrijgen.
+Je kunt updates met belangrijke informatie met de gebruiker delen via een statusbericht. Als dit bericht bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die de melding niet zien, deze informatie toch meekrijgen.
 
 Het doel van dit succescriterium is om gebruikers te informeren over statusberichten, zonder onverwacht hun werk te onderbreken door bijvoorbeeld de focus te verplaatsen.
 


### PR DESCRIPTION
Related issue: https://github.com/nl-design-system/documentatie/issues/753
URLs:
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/1.1.1
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/1.3.5
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/2.1.1
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/3.3.1
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/3.3.3
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/3.3.4
- https://documentatie-git-wcag-add-link-to-quickref-nl-design-system.vercel.app/wcag/4.1.3
