### PR TITLE
Richtlijnen: op elke pagina duidelijk vermelden dat de richtlijnen nog in beta zijn.

### DIFF
--- a/docs/richtlijnen/formulieren/_form_footer_info.md
+++ b/docs/richtlijnen/formulieren/_form_footer_info.md
@@ -1,4 +1,5 @@
-## Aanvullingen of opmerkingen?
+## Over deze richtlijnen
 
-Deze richtlijnen worden onderhouden door het NL Design System.
-Heb je aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
+
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.

--- a/docs/richtlijnen/stijl/_style_footer_info.md
+++ b/docs/richtlijnen/stijl/_style_footer_info.md
@@ -1,4 +1,5 @@
-## Aanvullingen of opmerkingen?
+## Over deze richtlijnen
 
-Deze richtlijnen voor stijl worden onderhouden door het NL Design System.
-Heb je aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/issues).
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
+
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.

--- a/docs/richtlijnen/stijl/iconen.md
+++ b/docs/richtlijnen/stijl/iconen.md
@@ -262,10 +262,8 @@ De iconenset die we bij het NL Design System gebruiken voor het Voorbeeld thema.
 
 ---
 
-## Help deze documentatie te verbeteren
+## Over deze richtlijnen
 
-Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun je een wijziging voorstellen via [Github](https://github.com/nl-design-system/documentatie).
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-## Vragen
-
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.

--- a/docs/richtlijnen/stijl/kleuren.md
+++ b/docs/richtlijnen/stijl/kleuren.md
@@ -152,10 +152,8 @@ Artikel waarin wordt beschreven hoe je een website kan inrichten zodat Windows H
 
 ---
 
-## Help deze documentatie te verbeteren
+## Over deze richtlijnen
 
-Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun je een wijziging voorstellen via Github.
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-## Vragen
-
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.

--- a/docs/richtlijnen/stijl/ruimte.md
+++ b/docs/richtlijnen/stijl/ruimte.md
@@ -195,10 +195,8 @@ Artikel, en video, waarin duidelijk wordt waarom het van belang is om voldoende 
 
 ---
 
-## Help deze documentatie te verbeteren
+## Over deze richtlijnen
 
-Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun je een wijziging voorstellen via [Github](https://github.com/nl-design-system/documentatie).
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-## Vragen
-
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.

--- a/docs/richtlijnen/stijl/typografie.md
+++ b/docs/richtlijnen/stijl/typografie.md
@@ -316,10 +316,8 @@ Artikel over de weergave van bold teksten.
 
 ---
 
-## Help deze documentatie te verbeteren
+## Over deze richtlijnen
 
-Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun je een wijziging voorstellen via Github.
+Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-## Vragen
-
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.


### PR DESCRIPTION
Related issue: https://github.com/nl-design-system/documentatie/issues/751
URL: https://documentatie-git-guidelines-add-beta-st-693ace-nl-design-system.vercel.app/richtlijnen/introductie

Voor de stijl-pagina's heb ik de tekst in de pagina's zelf gezet, in plaats van een include gemaakt. Dit is even een quick fix, omdat deze pagina's toch qua indeling op de schop gaan.
