### PR TITLE
Richtlijnen: Voorbeeld title bij foutmeldingen gelijktrekken met Figma voorbeeld

### DIFF
--- a/docs/richtlijnen/formulieren/_errors-feedback.md
+++ b/docs/richtlijnen/formulieren/_errors-feedback.md
@@ -47,7 +47,7 @@ Bijvoorbeeld:
 
 ```html
 <head>
-  <title>Fout: Stap 1 van 4: Uw vraag - Gemeente Voorbeeld</title>
+  <title>2 foutmeldingen - Stap 1 van 4 - Uw vraag - Gemeente Voorbeeld</title>
   [...]
 </head>
 ```

--- a/docs/richtlijnen/formulieren/_errors-feedback.md
+++ b/docs/richtlijnen/formulieren/_errors-feedback.md
@@ -47,7 +47,7 @@ Bijvoorbeeld:
 
 ```html
 <head>
-  <title>2 foutmeldingen - Stap 1 van 4 - Uw vraag - Gemeente Voorbeeld</title>
+  <title>2 foutmeldingen - Stap 1 van 4: Uw vraag - Gemeente Voorbeeld</title>
   [...]
 </head>
 ```


### PR DESCRIPTION
Issue: https://github.com/nl-design-system/documentatie/issues/809
URL: https://documentatie-git-guidelines-example-sam-f58e10-nl-design-system.vercel.app/richtlijnen/formulieren/foutmeldingen#update-het-title-element-in-de-head