### PR TITLE
fix: accessibility issues website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tmp/
  package-lock.json
  pnpm-lock.yaml
  !/pnpm-lock.yaml
+
+# IDE folders
+.idea/

--- a/packages/nlds-design-tokens/src/tokens.json
+++ b/packages/nlds-design-tokens/src/tokens.json
@@ -200,7 +200,8 @@
       "padding-block-end": { "value": "16px" },
       "padding-block-start": { "value": "16px" },
       "padding-inline-end": { "value": "16px" },
-      "padding-inline-start": { "value": "16px" }
+      "padding-inline-start": { "value": "16px" },
+      "margin-block-end": { "value": "16px" }
     },
     "color-sample": {
       "border-color": { "value": "#606060" },

--- a/src/components/SessionTable.tsx
+++ b/src/components/SessionTable.tsx
@@ -35,7 +35,7 @@ interface SessionTableProps extends HTMLTableAttributes<HTMLTableElement> {
 
 const SpeakerData = ({ name, organisation }: Speaker) => (
   <Paragraph className={clsx(style['session-table__speaker'], style['speaker'])}>
-    <Icon role="presentational" className={style['speaker__icon']}>
+    <Icon className={style['speaker__icon']}>
       <IconUser />
     </Icon>
     <span className={clsx(style['speaker__name'])}>{name}</span>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,7 +14,7 @@
   --utrecht-heading-4-line-height: 1.4;
   --nlds-blog-post-footer-background-color: #f2ebe4;
   --nlds-navbar-link-active-border-color: white;
-  --nlds-sidebar-menu-item-active-border-color: #148839;
+  --nlds-sidebar-menu-item-active-border-color: white;
   --nlds-code-block-background-color: #011627;
   --utrecht-space-around: 1;
   --utrecht-button-group-margin-block-start: 1em;
@@ -551,6 +551,7 @@ body:not(.navigation-with-keyboard) *:not(input):focus {
 @media (width >= 997px) {
   .nlds-theme {
     --docusaurus-announcement-bar-height: 80px;
+    --nlds-sidebar-menu-item-active-border-color: #148839;
   }
 }
 

--- a/src/theme/BlogPostItems/index.tsx
+++ b/src/theme/BlogPostItems/index.tsx
@@ -31,14 +31,14 @@ export default function BlogPostItems({ items }: Props): React.Element {
                       key={author.name}
                       className={clsx(style['blog-card__badge'], style['blog-card__badge--author'])}
                     >
-                      <Icon role="presentational">
+                      <Icon>
                         <IconUser />
                       </Icon>
                       <span className="visually-hidden">auteur:</span> {author.name}
                     </DataBadge>
                   ))}
                   <DataBadge className={clsx(style['blog-card__badge'], style['blog-card__badge--date'])}>
-                    <Icon role="presentational">
+                    <Icon>
                       <IconCalendar />
                     </Icon>
                     <span className="visually-hidden">publicatie datum:</span>{' '}

--- a/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
@@ -1,4 +1,3 @@
-import { translate } from '@docusaurus/Translate';
 import { useNavbarMobileSidebar } from '@docusaurus/theme-common/internal';
 import { Button } from '@utrecht/component-library-react/dist/css-module';
 import React from 'react';
@@ -9,11 +8,6 @@ export default function MobileSidebarToggle(): React.Element {
     <Button
       appearance="subtle-button"
       onClick={toggle}
-      aria-label={translate({
-        id: 'theme.docs.sidebar.toggleSidebarButtonAriaLabel',
-        message: 'Toggle navigation bar',
-        description: 'The ARIA label for hamburger menu button of mobile navigation',
-      })}
       aria-expanded={shown}
       className="navbar__toggle clean-btn"
       type="button"


### PR DESCRIPTION
Een aantal a11y fixes alvast.

Solves
- https://github.com/nl-design-system/documentatie/issues/410
- https://github.com/nl-design-system/documentatie/issues/408
  - Default voor `--nlds-sidebar-menu-item-active-border-color` is nu white. Omdat de sidenav css gedeeld wordt met de desktop sidenav heb `--nlds-sidebar-menu-item-active-border-color: #148839;` toegevoegd aan een bestaande breakpoint theme overwrite. Ik zou liever de CSS voor de `menu_link` op deze breakpoint aanpassen zodat er een mobile token kan zijn maar dit is meer in lijn met de bestaande CSS aanpak.
- https://github.com/nl-design-system/documentatie/issues/589
- https://github.com/nl-design-system/documentatie/issues/417