### PR TITLE
Update buttons.mdx

### DIFF
--- a/docs/richtlijnen/formulieren/_button-submit-code.mdx
+++ b/docs/richtlijnen/formulieren/_button-submit-code.mdx
@@ -3,7 +3,7 @@
 import { Canvas } from "@site/src/components/Canvas/Canvas";
 import { Guideline } from "@site/src/components/Guideline";
 
-<Guideline appearance="do" title="Het formulier wordt verzonden na het kiezen van de submitknop.">
+<Guideline appearance="do" title="Het formulier wordt verzonden na het kiezen van de submitbutton.">
   <Canvas language="html">
     {() => (
       <>

--- a/docs/richtlijnen/formulieren/_button-submit.md
+++ b/docs/richtlijnen/formulieren/_button-submit.md
@@ -1,6 +1,6 @@
 ## Verstuur een formulier niet automatisch na het wijzigen of invullen van een formulierveld
 
-Verstuur bij voorkeur alleen het formulier wanneer de gebruiker de verzendknop gebruikt, doe dit niet automatisch met een andere aanleiding. Is het echt noodzakelijk om het formulier op een ander moment te versturen, informeer de gebruiker dan duidelijk vooraf.
+Verstuur bij voorkeur alleen het formulier wanneer de gebruiker de submitbutton gebruikt, doe dit niet automatisch met een andere aanleiding. Is het echt noodzakelijk om het formulier op een ander moment te versturen, informeer de gebruiker dan duidelijk vooraf.
 
 Versturen na bijvoorbeeld het kiezen van een optie kan de gebruiker verrassen: wat gebeurt er, ik wilde nog even checken wat ik had ingevuld, heb ik nu het goede gekozen?
 

--- a/docs/richtlijnen/formulieren/buttons.mdx
+++ b/docs/richtlijnen/formulieren/buttons.mdx
@@ -34,12 +34,12 @@ import FormFooterInfo from "./_form_footer_info.md";
 # Buttons in een formulier
 
 Via een button verzend je een formulier of voer je aan andere actie uit, zoals het uploaden van een bestand.
-In deze documentatie gebruiken we de Engelse benaming voor het Nederlandse woord knop: “button”. Omdat `<button>` het HTML-element is waar deze richtlijnen over gaan.
+In deze documentatie gebruiken we de Engelse benaming voor het Nederlandse woord knop: 'button'. Omdat `<button>` het HTML-element is waar deze richtlijnen over gaan.
 
-Binnen een formulier bestaan er drie soorten knoppen:
+Binnen een formulier bestaan er drie soorten buttons:
 
 - `<button type="submit">`, om het formulier mee te verzenden (dit is de default waarde binnen een formulier);
-- `<button type="button">`, dit zijn knoppen die een andere functie hebben binnen een formulier, zoals het uploaden van documenten of openen van een modal;
+- `<button type="button">`, dit zijn buttons die een andere functie hebben binnen een formulier, zoals het uploaden van documenten of openen van een modal;
 - `<button type="reset">`, om alle ingevulde informatie binnen een formulier te wissen.
 
 De hier beschreven richtlijnen gelden voor al deze buttons.


### PR DESCRIPTION
Tekstuele wijzigingen om de nederlandse term 'knop' om te zetten naar 'button'.

Er is er nog 1, maar dit kan ik niet vinden. In het voorbeeld waar staat '[Het formulier wordt verzonden na het kiezen van de submitknop.](https://www.nldesignsystem.nl/richtlijnen/formulieren/buttons#disabled-submitbuttons:~:text=kiezen%20van%20de-,submitknop,-.)'

Dat zou ook submitbutton mogen zijn.