### PR TITLE
build: skip Vercel for `assets` branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "assets": false
+    }
+  }
+}


### PR DESCRIPTION
Pushes to the assets branch should not trigger a Vercel deploy

See https://vercel.com/docs/projects/project-configuration/git-configuration#git.deploymentenabled