### PR TITLE
Richtlijnen: Voeg fallback voor progressive enhancement toe aan RL HTML-validatie

### DIFF
--- a/docs/richtlijnen/formulieren/_errors-no-native.md
+++ b/docs/richtlijnen/formulieren/_errors-no-native.md
@@ -15,3 +15,18 @@ Wanneer er voldoende tijd en kennis is, heeft het de voorkeur om zelf client-sid
 Om specifiek aan hulptechnologieën te communiceren dat een veld verplicht is, kan `aria-required` worden gebruikt. Als je alleen `aria-required` gebruikt, zal de browser niet zelf valideren of feedback geven.
 
 Het toegankelijk maken van foutmeldingen is nodig om te voldoen aan het WCAG-succescriterium [3.3.1 Foutidentificatie](/wcag/3.3.1/) (niveau A).
+
+### Progressive enhancement
+
+Alhoewel we HTML-formuliervalidatie afraden en niet als eindoplossing zien, kan het nuttig zijn om te gebruiken als fallback bij een slechte internetverbinding als er nog geen JavaScript beschikbaar is.
+
+Deze optie geldt alleen voor formulieren waarbij de foutmeldingen worden afgehandeld door JavaScript.
+
+De opzet is dan als volgt:
+
+- Bij de formuliervelden wordt het attribuut `required` gebruikt in plaats van 'aria-required`.
+- Zodra de JavaScript wordt ingeladen wordt meteen het attribuut `novalidate` toegevoegd aan het `<form>` element om de HTML-validatie uit te schakelen.
+
+Dan voorkom je dat gebruikers met een slechte internetverbinding niet op tijd worden geïnformeerd over fouten in het formulier.
+
+Dit is een optie en geen vereiste. Uiteindelijk is een op maat gemaakte server side eind-validatie van de formuliervelden het meest betrouwbaar en toegankelijk en daardoor de richtlijn.


### PR DESCRIPTION
URL: https://documentatie-git-guidelines-errors-prog-16038b-nl-design-system.vercel.app/richtlijnen/formulieren/foutmeldingen#gebruik-geen-html-formuliervalidatie

Deze PR komt voort uit de discussie bij het issue over de blogpost over foutmeldingen:
https://github.com/nl-design-system/documentatie/issues/613#issuecomment-1943450280

Robbert:
> Ik zou graag wel duidelijk maken dat het required attribuut niet verboden is voor websites die geen JavaScript gebruiken om het formulier te valideren.

Ik denk dat deze info toevoegen aan de richtlijn duidelijker en makkelijker vindbaar is dan het toevoegen aan een blogpost.
