### PR TITLE
fix: make component examples work once more

### DIFF
--- a/src/_generate-component-pages/index.ts
+++ b/src/_generate-component-pages/index.ts
@@ -45,9 +45,7 @@ componentIndex.forEach(({ state, id, name, implementations, backlog }) => {
 
   const story = storyTemplate && {
     label: `https://nl-design-system.github.io/themes/`,
-    href: `https://nl-design-system.github.io/themes/?path=/docs/${id}--${storyTemplate.organisation
-      .replace(/\s/g, '-')
-      .toLowerCase()}`,
+    href: `https://nl-design-system.github.io/themes/iframe.html?viewMode=story&id=${id}--utrecht`,
   };
 
   //nl-design-system.github.io/themes/iframe.html?args=appearance:primary-action-button&id=button--gemeente-utrecht&viewMode=story


### PR DESCRIPTION
When generating component pages, hardcode Utrecht for now. The components "select" and "blockquote" are still broken but this should be fixed once they're added to the themes repository again.