### PR TITLE
build: make Vercel ignore Dependabot

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,9 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
       "assets": false
     }
-  }
+  },
+  "ignoreCommand": "[[ $(git log -1 --pretty=%an) == 'dependabot[bot]' ]]"
 }


### PR DESCRIPTION
Make sure that Vercel does not trigger builds for Dependabot PRs.

When the "ignoreCommand" exits with 0, the build is ignored. When it exits with 1, the build continues.