### PR TITLE
build: cancel workflows for new pushes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   continuous-integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
New pushes to a branch should cancel a running build as that is no longer relevant.