### PR TITLE
WCAG-pagina's: het kopje "Korte samenvatting" wordt "Uitleg".

### DIFF
--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -23,7 +23,7 @@ Het doel is om WCAG begrijpelijk uit te leggen en daardoor makkelijker toepasbaa
 Elk WCAG-succescriterium heeft een eigen pagina waarin is opgenomen:
 
 - De links naar de officiële richtlijnen en W3C-referenties.
-- Een korte samenvatting en uitleg.
+- Een uitleg.
 - Hoe voor een succescriterium zelf te testen op webpagina's.
 - Links naar gerelateerde NLDS-richtlijnen, zodat je weet hoe deze criteria toe te passen.
 - Bronnen over extra uitleg of voorbeelden.
@@ -31,7 +31,7 @@ Elk WCAG-succescriterium heeft een eigen pagina waarin is opgenomen:
 
 ## WCAG-pagina's
 
-Op dit moment zijn er 12 succescriteria beschreven, het doel is om eind van dit jaar de lijst compleet te hebben.
+Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind van dit jaar de lijst compleet te hebben.
 
 - [1.1.1 Niet-tekstuele content](/wcag/1.1.1.mdx)
 - [1.3.1 Info en relaties](/wcag/1.3.1.mdx)

--- a/docs/wcag/1.1.1.mdx
+++ b/docs/wcag/1.1.1.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.1.1 Non-text Content</span>](https://www.w3.org/WAI/WCAG22/quickref/#non-text-content).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.1.1: Non-text Content</span>](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html).
 
-## Korte samenvatting
+## Uitleg
 
 Alle niet-tekstuele content die aan de gebruiker wordt gepresenteerd, heeft een tekstalternatief dat een gelijkwaardig doel dient.
 

--- a/docs/wcag/1.3.1.mdx
+++ b/docs/wcag/1.3.1.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.3.1 Info and Relationships</span>](https://www.w3.org/WAI/WCAG22/quickref/#info-and-relationships).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.3.1 Info and Relationships</span>](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html).
 
-## Korte samenvatting
+## Uitleg
 
 Alle gebruikers moeten over dezelfde informatie kunnen beschikken.
 

--- a/docs/wcag/1.3.5.mdx
+++ b/docs/wcag/1.3.5.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/quickref/#identify-input-purpose).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html).
 
-## Korte samenvatting
+## Uitleg
 
 Zorg dat de browser (en andere software, zoals een password manager) kan begrijpen wat een gebruiker moet invoeren, zodat die kan helpen en het makkelijker kan maken.
 

--- a/docs/wcag/2.1.1.mdx
+++ b/docs/wcag/2.1.1.mdx
@@ -25,7 +25,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/quickref/#keyboard).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).
 
-## Korte samenvatting
+## Uitleg
 
 Alle functionaliteit is bedienbaar met een toetsenbord zonder dat afzonderlijke toetsaanslagen aan tijd gebonden zijn.
 

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.13 Focus Appearance</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.13: Focus Appearance</span>](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html).
 
-## Korte samenvatting
+## Uitleg
 
 Zorg dat het goed zichtbaar is welk element de toetsenbordfocus heeft, wanneer je door de website navigeert met een toetsenbord of vergelijkbare bediening. Het moet duidelijk te zien zijn waar de toetsenbordfocus zich bevindt.
 

--- a/docs/wcag/2.4.7.mdx
+++ b/docs/wcag/2.4.7.mdx
@@ -25,7 +25,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 12.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html).
 
-## Korte samenvatting
+## Uitleg
 
 Zorg dat het goed zichtbaar is welk element de toetsenbordfocus heeft, wanneer je door de website navigeert met een toetsenbord of vergelijkbare bediening. Dit kan bijvoorbeeld door het gebruik van een focusring (outline).
 

--- a/docs/wcag/3.2.1.mdx
+++ b/docs/wcag/3.2.1.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.2.1 On Focus</span>](https://www.w3.org/WAI/WCAG22/quickref/#on-focus).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.2.1: On Input</span>](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html).
 
-## Korte samenvatting
+## Uitleg
 
 Verras een gebruiker niet als die een interactief element focus geeft. Maak functionaliteit voorspelbaar en daardoor goed te begrijpen.
 

--- a/docs/wcag/3.2.2.mdx
+++ b/docs/wcag/3.2.2.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.2.2 On Input</span>](https://www.w3.org/WAI/WCAG22/quickref/#on-input).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.2.2: On Input</span>](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html).
 
-## Korte samenvatting
+## Uitleg
 
 Verras een gebruiker niet, maar maak functionaliteit voorspelbaar en daardoor goed te begrijpen.
 

--- a/docs/wcag/3.3.1.mdx
+++ b/docs/wcag/3.3.1.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.1 Error Identification</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-identification).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.1 Error Identification</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html).
 
-## Korte samenvatting
+## Uitleg
 
 Laat een gebruiker weten als er fouten zijn bij het invullen van een formulier. Vertel duidelijk en toegankelijk wanneer een formulierveld niet, of niet goed is ingevuld.
 

--- a/docs/wcag/3.3.3.mdx
+++ b/docs/wcag/3.3.3.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-suggestion).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html).
 
-## Korte samenvatting
+## Uitleg
 
 Laat een gebruiker op een toegankelijke manier weten hoe een formulierveld goed in te vullen. Geef hiervoor hints, suggesties en voorbeelden.
 

--- a/docs/wcag/3.3.4.mdx
+++ b/docs/wcag/3.3.4.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.4 Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-legal-financial-data).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.4:Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html).
 
-## Korte samenvatting
+## Uitleg
 
 Wanneer een gebruiker een formulier invult met juridische, financiële of persoonlijke gegevens, zorg er dan voor dat gebruiker de ingevulde gegevens kan controleren en corrigeren.
 Bied ten minste één van de volgende opties aan:

--- a/docs/wcag/4.1.3.mdx
+++ b/docs/wcag/4.1.3.mdx
@@ -24,7 +24,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 4.1.3 Status Messages</span>](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 4.1.3: Status Messages</span>](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html).
 
-## Korte samenvatting
+## Uitleg
 
 Je kunt updates met belangrijke informatie met de gebruiker delen via een statusbericht. Als dit bericht bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die de melding niet zien, deze informatie toch meekrijgen.
 


### PR DESCRIPTION
Related issue: #848 
URL: https://documentatie-git-wcag-uitleg-nl-design-system.vercel.app/wcag/introduction.

De Introductiepagina wordt nog uitgebreid met met info over de status van de uitleg, zie issue #892 