### PR TITLE
wcag: adds disclaimer

### DIFF
--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -18,6 +18,8 @@ In deze pagina's vind je [<span lang="en">Web Content Accessibility Guidelines</
 
 Het doel is om WCAG begrijpelijk uit te leggen en daardoor makkelijker toepasbaar te maken. Daarnaast staat beschreven hoe je webpagina's voor de verschillende succescriteria kunt testen.
 
+**Let op**: Dit is een uitleg van WCAG 2.2 niveau AA. Het vervangt niet de officiële WCAG 2.2-richtlijnen, die een volledige beschrijving geven van alle principes en vereisten.
+
 ## Opzet
 
 Elk WCAG-succescriterium heeft een eigen pagina waarin is opgenomen:


### PR DESCRIPTION
Voegt een disclaimer toe aan de intro pagina:

**Let op**: Dit is een uitleg van WCAG 2.2 niveau AA. Het vervangt niet de officiële WCAG 2.2-richtlijnen, die een volledige beschrijving geven van alle principes en vereisten.