### PR TITLE
WCAG-pagina's: WCAG Succescriterium veranderen in WCAG-succescriterium

### DIFF
--- a/docs/wcag/1.1.1.mdx
+++ b/docs/wcag/1.1.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 1.1.1 Niet-tekstuele content
+title: WCAG-succescriterium 1.1.1 Niet-tekstuele content
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.1.1 Niet-tekstuele content
-pagination_label: WCAG Succescriterium 1.1.1 Niet-tekstuele content
+pagination_label: WCAG-succescriterium 1.1.1 Niet-tekstuele content
 description: Zorg bij niet-tekstuele content voor een tekstalternatief.
 slug: 1.1.1
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 1.1.1 Niet-tekstuele content
+# WCAG-succescriterium 1.1.1 Niet-tekstuele content
 
 ## W3C referenties
 

--- a/docs/wcag/1.3.1.mdx
+++ b/docs/wcag/1.3.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 1.3.1 Info en relaties
+title: WCAG-succescriterium 1.3.1 Info en relaties
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.3.1 Info en relaties
-pagination_label: WCAG Succescriterium 1.3.1 Info en relaties
+pagination_label: WCAG-succescriterium 1.3.1 Info en relaties
 description: Alle gebruikers moeten over dezelfde informatie kunnen beschikken.
 slug: 1.3.1
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 1.3.1 Info en relaties
+# WCAG-succescriterium 1.3.1 Info en relaties
 
 ## W3C referenties
 

--- a/docs/wcag/1.3.5.mdx
+++ b/docs/wcag/1.3.5.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 1.3.5 Identificeer het doel van de input
+title: WCAG-succescriterium 1.3.5 Identificeer het doel van de input
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.3.5 Identificeer het doel van de input
-pagination_label: WCAG Succescriterium 1.3.5 Identificeer het doel van de input
+pagination_label: WCAG-succescriterium 1.3.5 Identificeer het doel van de input
 description: Zorg dat de browser kan begrijpen wat een gebruiker moet invoeren, zodat die kan helpen en het makkelijker kan maken.
 slug: 1.3.5
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 1.3.5 Identificeer het doel van de input
+# WCAG-succescriterium 1.3.5 Identificeer het doel van de input
 
 ## W3C referenties
 

--- a/docs/wcag/2.1.1.mdx
+++ b/docs/wcag/2.1.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 2.1.1 Toetsenbord
+title: WCAG-succescriterium 2.1.1 Toetsenbord
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.1.1 Toetsenbord
-pagination_label: WCAG Succescriterium 2.1.1 Toetsenbord
+pagination_label: WCAG-succescriterium 2.1.1 Toetsenbord
 description: Zorg dat alle functionaliteit met een toetsenbord te bedienen is.
 slug: 2.1.1
 keywords:
@@ -16,7 +16,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 2.1.1 Toetsenbord
+# WCAG-succescriterium 2.1.1 Toetsenbord
 
 ## W3C referenties
 

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -1,5 +1,5 @@
 ---
-title: WCAG Succescriterium 2.4.13 Focusweergave
+title: WCAG-succescriterium 2.4.13 Focusweergave
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.13 Focusweergave
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 2.4.13 Focusweergave
+# WCAG-succescriterium 2.4.13 Focusweergave
 
 ## W3C referenties
 

--- a/docs/wcag/2.4.2.mdx
+++ b/docs/wcag/2.4.2.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 2.4.2 Paginatitel
+title: WCAG-succescriterium 2.4.2 Paginatitel
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.2 Paginatitel
-pagination_label: WCAG Succescriterium 2.4.2 Paginatitel
+pagination_label: WCAG-succescriterium 2.4.2 Paginatitel
 description: Webpagina's hebben titels die het onderwerp of doel beschrijven.
 slug: 2.4.2
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 2.4.2 Paginatitel
+# WCAG-succescriterium 2.4.2 Paginatitel
 
 ## W3C referenties
 

--- a/docs/wcag/2.4.4.mdx
+++ b/docs/wcag/2.4.4.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 2.4.4 Linkdoel (in context)
+title: WCAG-succescriterium 2.4.4 Linkdoel (in context)
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.4 Linkdoel (in context)
-pagination_label: WCAG Succescriterium 2.4.4 Linkdoel (in context)
+pagination_label: WCAG-succescriterium 2.4.4 Linkdoel (in context)
 description: De linktekst vertelt aan de gebruiker waar de link naar toe gaat (het linkdoel).
 slug: 2.4.4
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 2.4.4 Linkdoel (in context)
+# WCAG-succescriterium 2.4.4 Linkdoel (in context)
 
 ## W3C referenties
 

--- a/docs/wcag/2.4.7.mdx
+++ b/docs/wcag/2.4.7.mdx
@@ -1,5 +1,5 @@
 ---
-title: WCAG Succescriterium 2.4.7 Focus zichtbaar
+title: WCAG-succescriterium 2.4.7 Focus zichtbaar
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.7 Focus zichtbaar
@@ -16,7 +16,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 2.4.7 Focus zichtbaar
+# WCAG-succescriterium 2.4.7 Focus zichtbaar
 
 ## W3C referenties
 

--- a/docs/wcag/3.2.1.mdx
+++ b/docs/wcag/3.2.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 3.2.1 Bij focus
+title: WCAG-succescriterium 3.2.1 Bij focus
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.1 Bij focus
-pagination_label: WCAG Succescriterium 3.2.1 Bij focus
+pagination_label: WCAG-succescriterium 3.2.1 Bij focus
 description: Beschrijving, documentatie, gerelateerde NLDS-richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
 slug: 3.2.1
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 3.2.1 Bij focus
+# WCAG-succescriterium 3.2.1 Bij focus
 
 ## W3C referenties
 

--- a/docs/wcag/3.2.2.mdx
+++ b/docs/wcag/3.2.2.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 3.2.2 Bij input
+title: WCAG-succescriterium 3.2.2 Bij input
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.2 Bij input
-pagination_label: WCAG Succescriterium 3.2.2 Bij input
+pagination_label: WCAG-succescriterium 3.2.2 Bij input
 description: Beschrijving, documentatie, gerelateerde NLDS-richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
 slug: 3.2.2
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 3.2.2 Bij input
+# WCAG-succescriterium 3.2.2 Bij input
 
 ## W3C referenties
 

--- a/docs/wcag/3.3.1.mdx
+++ b/docs/wcag/3.3.1.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 3.3.1 Foutidentificatie
+title: WCAG-succescriterium 3.3.1 Foutidentificatie
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.1 Foutidentificatie
-pagination_label: WCAG Succescriterium 3.3.1 Foutidentificatie
+pagination_label: WCAG-succescriterium 3.3.1 Foutidentificatie
 description: Laat een gebruiker weten als er fouten zijn bij het invullen van een formulier.
 slug: 3.3.1
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 3.3.1 Foutidentificatie
+# WCAG-succescriterium 3.3.1 Foutidentificatie
 
 ## W3C referenties
 

--- a/docs/wcag/3.3.3.mdx
+++ b/docs/wcag/3.3.3.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 3.3.3 Foutsuggestie
+title: WCAG-succescriterium 3.3.3 Foutsuggestie
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.3 Foutsuggestie
-pagination_label: WCAG Succescriterium 3.3.3 Foutsuggestie
+pagination_label: WCAG-succescriterium 3.3.3 Foutsuggestie
 description: Laat een gebruiker op een toegankelijke manier weten hoe een formulierveld goed in te vullen.
 slug: 3.3.3
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 3.3.3 Foutsuggestie
+# WCAG-succescriterium 3.3.3 Foutsuggestie
 
 ## W3C referenties
 

--- a/docs/wcag/3.3.4.mdx
+++ b/docs/wcag/3.3.4.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
+title: WCAG-succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
-pagination_label: WCAG Succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
+pagination_label: WCAG-succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
 description: Wanneer een gebruiker een formulier invult met juridische, financiële of persoonlijke gegevens, zorg er dan voor dat gebruiker de ingevulde gegevens kan controleren en corrigeren.
 slug: 3.3.4
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
+# WCAG-succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)
 
 ## W3C referenties
 

--- a/docs/wcag/4.1.3.mdx
+++ b/docs/wcag/4.1.3.mdx
@@ -1,9 +1,9 @@
 ---
-title: WCAG Succescriterium 4.1.3 Statusberichten
+title: WCAG-succescriterium 4.1.3 Statusberichten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: 4.1.3 Statusberichten
-pagination_label: WCAG Succescriterium 4.1.3 Statusberichten
+pagination_label: WCAG-succescriterium 4.1.3 Statusberichten
 description: Je kunt updates met belangrijke informatie met de gebruiker delen via een statusbericht. Zorg er dan voor dat gebruikers die de melding niet zien, deze informatie toch meekrijgen.
 slug: 4.1.3
 keywords:
@@ -15,7 +15,7 @@ keywords:
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 
-# WCAG Succescriterium 4.1.3 Statusberichten
+# WCAG-succescriterium 4.1.3 Statusberichten
 
 ## W3C referenties
 


### PR DESCRIPTION
In de titels van de WCAG-pagina's staat
`WCAG Succescriterium`
En bij links gebruiken we
`WCAG-succescriterium`
Deze PR trekt dit gelijk  door het streepje ook in de titles op te nemen.