### PR TITLE
fix: 301 redirect

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -19,7 +19,7 @@ RedirectMatch 301 "^/project/events(.*)$" "/community/events$1"
 Redirect 301 "/project/wie-doet-mee" "/community/wie-doet-mee"
 
 Redirect 301 "/onderzoek" "/voorbeelden/onderzoek"
-Redirect 301 "/events" "/community/events/overzicht"
+RedirectMatch 301 "^/events/?$" "/community/events/overzicht"
 
 # until we have multiple factsheets and turn /factsheets into an overview page
 RedirectMatch 302 "^/factsheets/?$" "/factsheets/managers"


### PR DESCRIPTION
only `/events` and `/events/` now link to `/community/events/overzicht`