### PR TITLE
WCAG-pagina's: Voegt missende links op de intropagina toe en fixt inconsistentie in naamgeving 4.1.2

### DIFF
--- a/docs/richtlijnen/formulieren/_button-accessible-name.md
+++ b/docs/richtlijnen/formulieren/_button-accessible-name.md
@@ -66,4 +66,4 @@ Voor het toekennen van toegankelijke namen aan SVG's bestaan ook andere techniek
 Een toegankelijke naam voor de button, is nodig om te voldoen aan één van de voorwaarden voor de WCAG-succescriteria:
 
 - [1.3.1 Info en relaties](/wcag/1.3.1) (niveau A).
-- [4.1.2 Naam, rol en waarde](/wcag/4.1.2) (niveau A).
+- [4.1.2 Naam, rol, waarde](/wcag/4.1.2) (niveau A).

--- a/docs/richtlijnen/formulieren/_label-accessible-name.md
+++ b/docs/richtlijnen/formulieren/_label-accessible-name.md
@@ -47,4 +47,4 @@ Het geven van een goede toegankelijke naam aan formuliervelden is nodig om te vo
 - [1.3.1 Info en relaties](/wcag/1.3.1) (niveau A).
 - [2.4.6: Koppen en labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels) (niveau AA).
 - [3.3.2: Labels of instructies](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions) (niveau A).
-- [4.1.2 Naam, rol en waarde](/wcag/4.1.2) (niveau A).
+- [4.1.2 Naam, rol, waarde](/wcag/4.1.2) (niveau A).

--- a/docs/richtlijnen/formulieren/_when-which-compat.md
+++ b/docs/richtlijnen/formulieren/_when-which-compat.md
@@ -12,7 +12,7 @@ Ervoor zorgen dat iedereen een formulierelement kan bedienen en begrijpen is nod
 - [2.1.1 Toetsenbord](/wcag/2.1.1) (niveau A).
 - [2.4.6 Koppen en labels](https://www.w3.org/Translations/WCAG21-nl/#koppen-en-labels) (niveau AA).
 - [3.3.2 Labels of Instructies](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) (niveau A).
-- [4.1.2 Naam, rol en waarde](/wcag/4.1.2) (niveau A).
+- [4.1.2 Naam, rol, waarde](/wcag/4.1.2) (niveau A).
 
 ### Multiselect
 

--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -41,14 +41,16 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [1.3.5 Identificeer het doel van de input](/wcag/1.3.5)
 - [2.1.1 Toetsenbord](/wcag/2.1.1)
 - [2.4.2 Paginatitel](/wcag/2.4.2)
-- [2.4.13 Focusweergave](/wcag/2.4.13)
+- [2.4.4 Linkdoel (in context)](/wcag/2.4.4)
 - [2.4.7 Focus zichtbaar](/wcag/2.4.7)
+- [2.4.13 Focusweergave](/wcag/2.4.13)
 - [3.1.1 Taal van de pagina](/wcag/3.1.1)
 - [3.2.1 Bij focus](/wcag/3.2.1)
 - [3.2.2 Bij input](/wcag/3.2.2)
 - [3.3.1 Foutidentificatie](/wcag/3.3.1)
 - [3.3.3 Foutsuggestie](/wcag/3.3.3)
 - [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](/wcag/3.3.4)
+- [4.1.2 Naam, rol, waarde](/wcag/4.1.2)
 - [4.1.3 Statusberichten](/wcag/4.1.3)
 
 <FormFooterInfo />


### PR DESCRIPTION
Preview: https://documentatie-git-wcag-missing-link-nl-design-system.vercel.app/wcag/introduction