### PR TITLE
WCAG-pagina: 3.1.2 Taal van onderdelen

### DIFF
--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -45,6 +45,7 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [2.4.7 Focus zichtbaar](/wcag/2.4.7)
 - [2.4.13 Focusweergave](/wcag/2.4.13)
 - [3.1.1 Taal van de pagina](/wcag/3.1.1)
+- [3.1.2 Taal van onderdelen](/wcag/3.1.2)
 - [3.2.1 Bij focus](/wcag/3.2.1)
 - [3.2.2 Bij input](/wcag/3.2.2)
 - [3.3.1 Foutidentificatie](/wcag/3.3.1)

--- a/docs/wcag/3.1.1.mdx
+++ b/docs/wcag/3.1.1.mdx
@@ -54,7 +54,7 @@ Voor Engels bijvoorbeeld:
 
 Of de software deze aangegeven taal ook echt goed voorleest, is ervan afhankelijk of deze taal beschikbaar is. De gebruiker kan verschillende talen (stemmen) downloaden en ervoor kiezen bijvoorbeeld alleen Brits-Engels te gebruiken. Een Amerikaans gelabelde website wordt dan toch in het Brits voorgelezen.
 
-**Let op**: dit succescriterium betreft de taal van de hele pagina. Wil je alleen een deel in een andere taal publiceren, gebruik dan het `lang`-attribuut op elementen in de andere taal binnen de pagina. Hoe dit te doen staat bij het WCAG-succescriterium [3.1.2 Taal van onderdelen](https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html).
+**Let op**: dit succescriterium betreft de taal van de hele pagina. Wil je alleen een deel in een andere taal publiceren, gebruik dan het `lang`-attribuut op elementen in de andere taal binnen de pagina. Hoe dit te doen staat bij het WCAG-succescriterium [3.1.2 Taal van onderdelen](/wcag/3.1.2).
 
 ## Bronnen
 

--- a/docs/wcag/3.1.2.mdx
+++ b/docs/wcag/3.1.2.mdx
@@ -1,0 +1,86 @@
+---
+title: WCAG-succescriterium 3.1.2 Taal van onderdelen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 3.1.2 Taal van onderdelen
+pagination_label: WCAG-succescriterium 3.1.2 Taal van onderdelen
+description: Geef wisseling van de menselijke taal waarin de tekst van elke passage of zin is geschreven aan. Dit kan door in het html-element waarbinnen de tekst staat het attribuut ‘lang’ mee te geven.
+slug: 3.1.2
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import { VideoPlayer } from "../../src/components/VideoPlayer";
+
+# WCAG-succescriterium 3.1.2 Taal van onderdelen
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.1.2 Language of Parts</span>](https://www.w3.org/TR/WCAG22/#language-of-parts).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.1.2 Taal van onderdelen](https://www.w3.org/Translations/WCAG21-nl/#taal-van-onderdelen).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.1.2 Language of Parts</span>](https://www.w3.org/WAI/WCAG22/quickref/#language-of-page).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 3.1.2: Language of Parts</span>](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page).
+
+## Uitleg
+
+Als er in de tekst woorden of zinnen voorkomen in een andere taal dan die van de webpagina is het fijn als deze tekst begrijpelijk wordt voorgelezen.
+
+Geef daarom wisseling van de menselijke taal waarin de tekst van elke passage of zin is geschreven aan. Dit kan door in het html-element waarbinnen deze tekst staat het attribuut ‘lang’ mee te geven.
+
+Er is een uitzondering voor eigennamen, technische termen, woorden van onbepaalde taal, en woorden of zinsdelen die deel uitmaken van het jargon van de omliggende tekst.
+
+Met het `lang`-attribuut vertel je aan een screenreader en andere voorleessoftware in welke taal de tekst van de pagina staat. Dan wordt deze tekst goed voorgelezen, afhankelijk van de instellingen van de voorleessoftware.
+
+Bijvoorbeeld `<p lang="en">Not all those who wander are lost.</p>` voor een zin in het Engels, in een verder Nederlandse tekst.
+
+Of voor een taalwisselmenu:
+
+```html
+<ul>
+  <li><a href="url" lang="nl">Nederlands</a></li>
+  <li><a href="url" lang="en">English</a></li>
+  <li><a href="url" lang="de">Deutsch</a></li>
+  <li><a href="url" lang="it">Italiano</a></li>
+  <li><a href="url" lang="fr">Français</a></li>
+</ul>
+```
+
+Bij het WCAG-succescriterium [3.1.1 Taal van de pagina](/wcag/3.1.1) staat uitgelegd hoe deze lang-code is samengesteld en wat geldige waarden zijn.
+
+### Demo taalwisseling met VoiceOver
+
+<VideoPlayer videoId="2UAjJ_5nxqw" />
+
+## Bronnen
+
+- [<span lang="en">The lang attribute: browsers telling lies, telling sweet little lies</span>](https://www.matuzo.at/blog/lang-attribute) van Manuel Matuzović over de problemen met het automatisch vertalen met Google Translate.
+- [<span lang="en">Language subtag lookup</span>](https://r12a.github.io/app-subtags/)
+- [<span lang="en">`lang`-attribuut op MDN</span>](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+- [<span lang="en">Language tags in HTML and XML</span>](https://www.w3.org/International/articles/language-tags/index.en) van de W3C.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+## Hoe te testen
+
+Lees de tekst van de pagina en bepaal of er tekst in een andere taal dan die van de webpagina aanwezig is.
+
+Inspecteer de gegenereerde HTML-code van die teksten, bijvoorbeeld met een [browser inspector](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Tools_and_setup/What_are_browser_developer_tools).
+Is het HTML-element, dat de tekst in een andere taal bevat, aangeduid met een `lang`-attribuut en heeft de taalcode een geldige waarde?
+
+Staat er op een website een taalwisselmenu? Controleer bij de verschillende talen of ook de waarde van het lang-attribuut goed is ingesteld.
+
+## Veelgemaakte fouten
+
+### Fout: Ontbrekend lang-attribuut
+
+Het kan zijn dat het CMS wat je gebruikt geen mogelijkheid geeft om een taalwisseling aan te geven. Dan zul je dit zelf in de HTML-code moeten aangeven.
+
+Zo biedt WordPress standaard geen taalwissel-optie aan voor onderdelen van tekst. Whodunit ontwikkelde daarom de plugin [Lang Attribute for the Block Editor](https://wordpress.org/plugins/lang-attribute/).
+
+<WCAGFooterInfo />

--- a/docs/wcag/3.1.2.mdx
+++ b/docs/wcag/3.1.2.mdx
@@ -27,9 +27,9 @@ import { VideoPlayer } from "../../src/components/VideoPlayer";
 
 ## Uitleg
 
-Geef wisseling van de taal aan waarin de tekst van elke passage of zin is geschreven. Dit kan door in het HTML-element waarbinnen deze tekst staat het attribuut ‘lang’ mee te geven.
+Geef wisseling van de taal aan waarin de tekst van elke passage of zin is geschreven. Als er in de tekst woorden of zinnen voorkomen in een andere taal dan die van de webpagina, brengt markering van die taal hulpmiddelen op de hoogte. Dit kan door in het HTML-element waarbinnen deze tekst staat het attribuut ‘lang’ mee te geven.
 
-Dan wordt tekst in die andere taal correct uitgesproken en daardoor beter te begrijpen voor gebruikers die de website laten voorlezen.
+Dan wordt tekst in die andere taal correct uitgesproken en daardoor beter te begrijpen voor gebruikers die de website laten voorlezen, bijvoorbeeld door screenreaders.
 
 Er is een uitzondering voor eigennamen, technische termen, woorden in een onbekende taal, en woorden of zinsdelen die deel uitmaken van het jargon van de omliggende tekst.
 

--- a/docs/wcag/3.1.2.mdx
+++ b/docs/wcag/3.1.2.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.1.2 Taal van onderdelen
 pagination_label: WCAG-succescriterium 3.1.2 Taal van onderdelen
-description: Geef wisseling van de menselijke taal waarin de tekst van elke passage of zin is geschreven aan. Dit kan door in het html-element waarbinnen de tekst staat het attribuut ‘lang’ mee te geven.
+description: Als je pagina tekst bevat in een andere taal dan de hoofdtaal, geef dit dan aan. Dit kan door in het html-element waarbinnen de tekst staat het attribuut ‘lang’ mee te geven.
 slug: 3.1.2
 keywords:
   - WCAG
@@ -27,13 +27,15 @@ import { VideoPlayer } from "../../src/components/VideoPlayer";
 
 ## Uitleg
 
-Als er in de tekst woorden of zinnen voorkomen in een andere taal dan die van de webpagina is het fijn als deze tekst begrijpelijk wordt voorgelezen.
+Geef wisseling van de taal aan waarin de tekst van elke passage of zin is geschreven. Dit kan door in het HTML-element waarbinnen deze tekst staat het attribuut ‘lang’ mee te geven.
 
-Geef daarom wisseling van de menselijke taal waarin de tekst van elke passage of zin is geschreven aan. Dit kan door in het html-element waarbinnen deze tekst staat het attribuut ‘lang’ mee te geven.
+Dan wordt tekst in die andere taal correct uitgesproken en daardoor beter te begrijpen voor gebruikers die de website laten voorlezen.
 
-Er is een uitzondering voor eigennamen, technische termen, woorden van onbepaalde taal, en woorden of zinsdelen die deel uitmaken van het jargon van de omliggende tekst.
+Er is een uitzondering voor eigennamen, technische termen, woorden in een onbekende taal, en woorden of zinsdelen die deel uitmaken van het jargon van de omliggende tekst.
 
-Met het `lang`-attribuut vertel je aan een screenreader en andere voorleessoftware in welke taal de tekst van de pagina staat. Dan wordt deze tekst goed voorgelezen, afhankelijk van de instellingen van de voorleessoftware.
+Met het `lang`-attribuut breng je over welke taal (een deel van) je tekst heeft. Dan kunnen hulptechnologieën als screenreaders of vertaalsoftware daarop handelen. In het geval van screenreaders bijvoorbeeld door de tekst met de juiste stem voor te lezen.
+
+Of de juiste stem ook echt wordt gebruikt is afhankelijk van de instellingen van de gebruikte screenreader of voorleessoftware.
 
 Bijvoorbeeld `<p lang="en">Not all those who wander are lost.</p>` voor een zin in het Engels, in een verder Nederlandse tekst.
 
@@ -53,6 +55,8 @@ Bij het WCAG-succescriterium [3.1.1 Taal van de pagina](/wcag/3.1.1) staat uitge
 
 ### Demo taalwisseling met VoiceOver
 
+In deze video hoor je hoe de screenreader VoiceOver wisselt van stem en taal voor teksten die met het `lang`-attribuut zijn gemarkeerd.
+
 <VideoPlayer videoId="2UAjJ_5nxqw" />
 
 ## Bronnen
@@ -60,7 +64,7 @@ Bij het WCAG-succescriterium [3.1.1 Taal van de pagina](/wcag/3.1.1) staat uitge
 - [<span lang="en">The lang attribute: browsers telling lies, telling sweet little lies</span>](https://www.matuzo.at/blog/lang-attribute) van Manuel Matuzović over de problemen met het automatisch vertalen met Google Translate.
 - [<span lang="en">Language subtag lookup</span>](https://r12a.github.io/app-subtags/)
 - [<span lang="en">`lang`-attribuut op MDN</span>](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
-- [<span lang="en">Language tags in HTML and XML</span>](https://www.w3.org/International/articles/language-tags/index.en) van de W3C.
+- [<span lang="en">Language tags in HTML and XML</span>](https://www.w3.org/International/articles/language-tags/index.en) van het W3C.
 
 ## Gebruikersonderzoek
 


### PR DESCRIPTION
Related issue: https://github.com/nl-design-system/documentatie/issues/666
Preview: https://documentatie-git-wcag-3-1-2-taal-van-on-2c10af-nl-design-system.vercel.app/wcag/3.1.2