### PR TITLE
Update _help-wanted-stappenplan.mdx

### DIFF
--- a/docs/componenten/_help-wanted-stappenplan.mdx
+++ b/docs/componenten/_help-wanted-stappenplan.mdx
@@ -307,7 +307,7 @@ We gebruiken 'Issues' in de [Github 'Backlog' repository van NL Design System](h
 
 Selecteer bij 'Projects' de volgende projecten:
 
-- Components - 1 - Help Wanted
+- Components - 1 - Help wanted
 - Components - 2 - Community
 - Components - 3 - Candidate
 - Components - 4 - Hall of fame
@@ -318,7 +318,7 @@ Selecteer bij 'Projects' de volgende projecten:
 
 Doel: Voortgang van component inzichtelijk maken.
 
-Door de vorige stap is het component toegevoegd aan het [Help Wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1). Je kunt nu de reeds behaalde checkpoints afvinken door per kolom de juiste waarde te selecteren.
+Door de vorige stap is het component toegevoegd aan het [Help wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1). Je kunt nu de reeds behaalde checkpoints afvinken door per kolom de juiste waarde te selecteren.
 
 ## Bevestiging door kernteam
 
@@ -331,11 +331,11 @@ Stuur dit bericht naar #nl-design-system op Slack:
 ```md
 Hiep hoi!
 
-Het is zo ver, de {naam-component} is helemaal klaar voor een Help Wanted stempel.
-Er is nog 1 stap over, namelijk verwachten we dat deze in de Hall of Fame zou kunnen komen?,
+Het is zo ver, de {naam-component} is helemaal klaar voor een Help wanted stempel.
+Er is nog 1 stap over, namelijk verwachten we dat deze in de Hall of fame zou kunnen komen?,
 
 🤩 Top, doen! (hetzelfde als niets zeggen).
-😭 Nee, deze moet nooit naar de Hall of Fame.
+😭 Nee, deze moet nooit naar de Hall of fame.
 🤨 Ik snap de naam of het nut niet.
 ```
 
@@ -349,7 +349,7 @@ Het kernteam bespreekt het component aan het eind van de eerstvolgende weekly. E
 
 #### Akkoord?
 
-Ga verder bij [Discussion updaten naar Help Wanted](#discussion-updaten-naar-help-wanted).
+Ga verder bij [Discussion updaten naar Help wanted](#discussion-updaten-naar-help-wanted).
 
 #### Niet akkoord?
 
@@ -358,25 +358,25 @@ Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
 ```md
 ❌ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn, maar niet voldoende nuttig is voor meerdere organisaties.
 
-Dit hoeft niet te betekenen dat {naam-component} nooit de Help Wanted status krijgt. De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
+Dit hoeft niet te betekenen dat {naam-component} nooit de Help wanted status krijgt. De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
 ```
 
 **🚩 Checkpoint**: Nut van component is door het kernteam bevestigd.
 
-## Status naar Help Wanted
+## Status naar Help wanted
 
 Doel: iedereen kan zien dat het component nu richting Candidate wil.
 
 Deze stap kan enkel worden uitgevoerd door het kernteam.
 
-- Voeg het 'Help Wanted' label toe aan het backlog issue.
-- Voeg het 'Help Wanted' label toe aan de discussion.
+- Voeg het 'Help wanted' label toe aan het backlog issue.
+- Voeg het 'Help wanted' label toe aan de discussion.
 - Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op het component door op `Component: {naam-component}` te zoeken.
 - Kopieer de url na het filteren.
 - Voeg onderstaande opmerking toe als comment aan de discussion.
 
 ```md
-## ✨ Dit component is nu Help Wanted ✨
+## ✨ Dit component is nu Help wanted ✨
 
 Help je mee hem door de Community stappen te krijgen?
 [{naam-component} op het Community bord]({url-community-bord})
@@ -387,7 +387,7 @@ Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
 ```md
 ✅ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn en het component algemeen nuttig is voor meerdere organisaties.
 
-✨ **Dit component is nu Help Wanted** ✨
+✨ **Dit component is nu Help wanted** ✨
 
 Help je mee hem door de Community stappen te krijgen?
 [{naam-component} op het Community bord]({url-community-bord})
@@ -395,7 +395,7 @@ Help je mee hem door de Community stappen te krijgen?
 De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
 ```
 
-**🚩 Checkpoint**: Status bijgewerkt naar Help Wanted.
+**🚩 Checkpoint**: Status bijgewerkt naar Help wanted.
 
 ## Toevoegen aan documentatie website
 

--- a/docs/componenten/_help-wanted-stappenplan.mdx
+++ b/docs/componenten/_help-wanted-stappenplan.mdx
@@ -167,9 +167,11 @@ Vooralsnog houden we deze set aan organisaties aan. Hiermee hebben we een mooie 
 - [Github](https://github.com/dso-toolkit/dso-toolkit) [CSS componenten](https://github.com/dso-toolkit/dso-toolkit/tree/master/packages/dso-toolkit/src/components)
 
 #### DUO
+
 [Documentatie website](https://uno.dfront.rijkscloud.nl/)
 
 #### Open Formulieren
+
 [Storybook](https://open-formulieren.github.io/open-forms-sdk/?path=/docs/introduction--docs)
 
 #### OpenGemeenten
@@ -243,7 +245,8 @@ Screenshot
   - etc.
 
 **🚩 Checkpoint**:
-- Bewijs verzameld dat het component algemeen bruikbaar is.  
+
+- Bewijs verzameld dat het component algemeen bruikbaar is.
 - Link beschikbaar naar component in Figma of Storybook met alle belangrijke states en varianten.
 
 ## Varianten vastgeleggen
@@ -303,6 +306,7 @@ We gebruiken 'Issues' in de [Github 'Backlog' repository van NL Design System](h
 ```
 
 Selecteer bij 'Projects' de volgende projecten:
+
 - Components - 1 - Help Wanted
 - Components - 2 - Community
 - Components - 3 - Candidate
@@ -344,6 +348,7 @@ Iedereen mag wat vinden, maar de verschillende specialismes uit het kernteam moe
 Het kernteam bespreekt het component aan het eind van de eerstvolgende weekly. Eventueel benodigde acties worden ter plekke doorgevoerd of voor een volgende sprint vastgelegd.
 
 #### Akkoord?
+
 Ga verder bij [Discussion updaten naar Help Wanted](#discussion-updaten-naar-help-wanted).
 
 #### Niet akkoord?
@@ -389,6 +394,7 @@ Help je mee hem door de Community stappen te krijgen?
 
 De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
 ```
+
 **🚩 Checkpoint**: Status bijgewerkt naar Help Wanted.
 
 ## Toevoegen aan documentatie website

--- a/docs/componenten/_help-wanted-stappenplan.mdx
+++ b/docs/componenten/_help-wanted-stappenplan.mdx
@@ -1,6 +1,6 @@
-# Stappenplan kernteam: Help wanted
+# Stappenplan: Help wanted
 
-Volg dit stappenplan om een component van alle checks te voorzien die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done).
+Volg dit stappenplan om een component van alle checkpoints 🚩 te voorzien die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done).
 
 ## Naam bepalen
 
@@ -16,9 +16,7 @@ Kijk voor inspiratie bij:
 
 Zijn er meerdere namen voor het component? Kies de meest gangbare. De andere namen kun je later toevoegen aan de documentatie.
 
-**🚩 Checkpoint**
-
-✅ Naam bepaald op basis van NL Design System naamgeving.
+**🚩 Checkpoint**: Naam bepaald op basis van NL Design System naamgeving.
 
 ## Doel bepalen
 
@@ -34,11 +32,9 @@ Kijk ter inspiratie bij:
 - https://carbondesignsystem.com
 - https://cedar.rei.com
 
-We proberen de schrijfwijze van het doel zoveel mogelijk te beginnen met een werkwoord en de term 'gebruiker' te vermijden. Bekijk bestaande [Discussions](https://github.com/orgs/nl-design-system/discussions/categories/component-suggestions) als voorbeeld.
+We proberen de schrijfwijze van het doel zoveel mogelijk te beginnen met een werkwoord en de term 'gebruiker' te vermijden. Bekijk bestaande [discussions](https://github.com/orgs/nl-design-system/discussions/categories/component-suggestions) als voorbeeld.
 
-**🚩 Checkpoint**
-
-✅ Doel van component is in één zin beschreven.
+**🚩 Checkpoint**: Doel van component is in één zin beschreven.
 
 ## Afbeelding maken
 
@@ -46,9 +42,7 @@ Doel: Het component is visueel duidelijk
 
 Om de community letterlijk een beeld te geven van het component voegen we een afbeelding toe. Deze kun je maken in het [Figma 'Schetsboek'](https://www.figma.com/file/fy08SZpZmqx6ljLwvA3Woe/NLDS---Schetsboek?type=design&node-id=439-969&mode=design).
 
-**🚩 Checkpoint**
-
-✅ Afbeelding gemaakt om het component visueel duidelijk te maken.
+**🚩 Checkpoint**: Afbeelding gemaakt om het component visueel duidelijk te maken.
 
 ## Discussion starten
 
@@ -56,9 +50,9 @@ Doel: Een plek om input te verzamelen.
 
 We gebruiken [Github 'Discussions' van NL Design System](https://github.com/orgs/nl-design-system/discussions) om input te verzamelen.
 
-- Start een [Discussion](https://github.com/orgs/nl-design-system/discussions/new?category=component-suggestions) voor het component.
+- Start een [discussion](https://github.com/orgs/nl-design-system/discussions/new?category=component-suggestions) voor het component.
 - Vul als titel in: `Component: {naam-component}`.
-- Vul als beschrijving onderstaande template in en start de Discussion.
+- Vul als beschrijving onderstaande template in en start de discussion.
 
 ```md
 ## Naam
@@ -90,9 +84,7 @@ Het kan voorkomen dat andere componenten sterk gerelateerd zijn aan dit componen
 X, Y, of Z.
 ```
 
-**🚩Checkpoint**
-
-✅ Aangemaakt als een [discussion](https://github.com/orgs/nl-design-system/discussions).
+**🚩Checkpoint**: Aangemaakt als een [discussion](https://github.com/orgs/nl-design-system/discussions).
 
 ## Input verzamelen
 
@@ -100,22 +92,22 @@ Doel: Bewijs verzameld dat het component algemeen bruikbaar is.
 
 ### Community om hulp vragen
 
-Om meer te leren over het component vragen we de community om hulp. Deze oproep doen we via de Discussion en Slack.
+Om meer te leren over het component vragen we de community om hulp. Deze oproep doen we via de discussion en Slack.
 
-#### Oproep via Discussion
+#### Oproep via discussion
 
-Start de beschrijving van de Discussion met de onderstaande oproep.
+Start de beschrijving van de discussion met de onderstaande oproep.
 
 - Voeg de afbeelding toe.
 - Wijzig de 'alt text' die automatisch door Github wordt toegevoegd. Bijvoorbeeld:
   - `verschillende vormen van het {naam-component} component`
   - `visuele weergave van het {naam-component} component`
-- Voeg onderstaande tekst toe, vul aan waar nodig en 'Update' de Discussion.
+- Voeg onderstaande tekst toe, vul aan waar nodig en 'Update' de discussion.
 
 ```md
 We willen graag meer leren over het {naam-component} component. In welke vorm, of vormen, wordt deze momenteel ingezet en toegepast binnen jouw organisatie?
 
-Deel hieronder een link naar Figma, Storybook of screenshots. Met deze informatie kunnen we bewijzen dat het component onderdeel moet worden van de NL Design System component library.
+Deel hieronder een link naar Figma, Storybook, Github of screenshots. Met deze informatie kunnen we bewijzen dat het component onderdeel moet worden van de NL Design System component library.
 
 Daarnaast wordt het delen van onderzoek gewaardeerd. Dus heb je zelf onderzoek gedaan en zijn er inzichten voor dit component? Dan horen we dit ook graag!
 
@@ -123,7 +115,7 @@ Daarnaast wordt het delen van onderzoek gewaardeerd. Dus heb je zelf onderzoek g
 
 ---
 
-{bestaande Discussion beschrijving}
+{bestaande discussion beschrijving}
 ```
 
 #### Oproep via Slack
@@ -139,77 +131,85 @@ Hey community 👋
 
 We willen graag meer leren over het {naam-component} component. In welke vorm, of vormen, wordt deze momenteel ingezet en toegepast binnen jouw organisatie?
 
-Deel een link naar Figma, Storybook of screenshots in de [Github Discussion voor het {naam-component} component]({link-naar-discussion}), of in een thread onder dit bericht. Met deze informatie kunnen we bewijzen dat het component onderdeel moet worden van de NL Design System component library.
+Deel een link naar Figma, Storybook, Github of screenshots in de [Github discussion voor het {naam-component} component]({link-naar-discussion}), of in een thread onder dit bericht. Met deze informatie kunnen we bewijzen dat het component onderdeel moet worden van de NL Design System component library.
 
 Daarnaast wordt het delen van onderzoek gewaardeerd. Dus heb je zelf onderzoek gedaan en zijn er inzichten voor dit component? Dan horen we dit ook graag!
 ```
 
-Vergeet niet de link naar het Slack bericht toe te voegen aan de oproep in de Discussion.
+Vergeet niet de link naar het Slack bericht toe te voegen aan de oproep in de discussion.
 
 ### Zelf op onderzoek uit
 
-Niet elke organisatie zal op de oproep reageren. Ga daarom ook zelf op onderzoek uit. Duik in Figma, Storybook en documentatie omgevingen voor een 'Screenshot-Safari 📸'. Maak screenshots van het component, varianten en states. Het gaat om bewijs verzamelen dat het component bestaat en in welke vorm, of vormen, deze wordt toegepast.
+Niet elke organisatie zal op de oproep reageren. Ga daarom ook zelf op onderzoek uit. Duik in Figma, Storybook, Github en documentatie omgevingen voor een 'Screenshot-Safari 📸'. Maak screenshots van het component, varianten en states. Het gaat om bewijs verzamelen dat het component bestaat en in welke vorm, of vormen, deze wordt toegepast.
 
-Kom je het component maar op 1 plek tegen, zorg dan voor een uitgebreide beschrijving van het doel.
+- Kom je het component maar op 1 plek tegen? Zorg dan voor een uitgebreide beschrijving van het doel.
+- Kom je het component niet tegen in Figma, Storybook, Github of documentatie omgevingen? Dan zou je ook de website van de organisatie kunnen bekijken.
 
 Vooralsnog houden we deze set aan organisaties aan. Hiermee hebben we een mooie mix te pakken van gemeentes, leveranciers en overige overheidsorganisaties.
 
-**Amsterdam**
+#### Amsterdam
 
 - [Storybook](https://amsterdam.github.io/design-system/?path=/docs/docs-intro--docs)
 - [Figma](https://www.figma.com/file/9IGm6IdPUYizBNGsUnueBd/Standaard-Design-Library---Desktop?type=design&node-id=1222%3A39437&t=nLmwomuRhjnfhbCa-1)
+- [Github](https://github.com/amsterdam/design-system) ([CSS componenten](https://github.com/Amsterdam/design-system/tree/develop/packages/css/src/components))
 
-**Den Haag**
+#### Den Haag
 
 - [Storybook](https://nl-design-system.github.io/denhaag/?path=/story/den-haag-introduction--page)
 - [Figma - Huidig](https://www.figma.com/file/JpoY3waVoQGlLQzQXTL9nn/)
 - [Figma - WIP](https://www.figma.com/file/x4RkF6BIdrNZbh7D53NTzB/%F0%9F%92%A0-NLDS---Den-Haag---Bibliotheek?type=design&node-id=197%3A664&mode=design&t=F9Lon3x3TsDbzI9q-1)
+- [Github](https://github.com/nl-design-system/denhaag) ([CSS componenten](https://github.com/nl-design-system/denhaag/tree/main/components))
 
-**DSO**
+#### DSO
 
 - [Documentatie website](https://dso-toolkit.nl/62.8.4/intro/)
 - [Storybook](https://storybook.dso-toolkit.nl/62.8.4/?path=/docs/html-css-accordion--docs)
+- [Github](https://github.com/dso-toolkit/dso-toolkit) [CSS componenten](https://github.com/dso-toolkit/dso-toolkit/tree/master/packages/dso-toolkit/src/components)
 
-**DUO**
-[Documentatie website](https://uno.dfront.rijkscloud.nl/#/)
+#### DUO
+[Documentatie website](https://uno.dfront.rijkscloud.nl/)
 
-**Open Formulieren**
+#### Open Formulieren
 [Storybook](https://open-formulieren.github.io/open-forms-sdk/?path=/docs/introduction--docs)
 
-**OpenGemeenten**
+#### OpenGemeenten
 
 - [Documentatie website](https://componenten.lenteveld.nl/)
 - [Patternlab](https://patternlab.lenteveld.nl/index.html)
 
 Gebruik in Patternlab het linkadres van de `h2` of `h3` om naar een specifiek onderdeel te linken.
 
-**Rotterdam**
+#### Rotterdam
 
 - [Storybook](https://nl-design-system.github.io/rotterdam/?path=/docs/rotterdam-rotterdam-design-system--docs)
 - [Figma](https://www.figma.com/file/ZWSC4gCrOXRUR9UX3aoZ8x/Gemeente-Rotterdam-Design-System?type=design&node-id=413%3A13001&mode=design&t=8rW24O9QRoIbb8Ry-1)
+- [Github](https://github.com/nl-design-system/rotterdam) ([CSS componenten](https://github.com/nl-design-system/rotterdam/tree/main/packages/components-css))
 
-**RVO**
+#### RVO
 
 - [Documentatie website](https://nl-design-system.github.io/rvo/docs/)
 - [Storybook](https://nl-design-system.github.io/rvo/?path=/docs/introductie--docs)
 - [Figma](<https://www.figma.com/file/Sj6myBL1Fvot5M1qGxzvEo/ROOS-(RVO-Design-System)?type=design&node-id=484-13305&t=vZTjQBvAiufxd5Qs-0>)
+- [Github](https://github.com/nl-design-system/rvo) ([CSS componenten](https://github.com/nl-design-system/rvo/tree/master/components))
 
-**Utrecht**
+#### Utrecht
 
 - [Documentatie website](https://nl-design-system.github.io/utrecht/)
 - [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/utrecht-readme--docs)
 - [Figma](https://www.figma.com/file/UXIHcIurAD8hyoBWx4hDBV/NLDS---Gemeente-Utrecht---Bibliotheek?type=design&node-id=197%3A664&mode=design&t=QPCkq0xOt8SFquC4-1)
+- [Github](https://github.com/nl-design-system/utrecht) ([CSS componenten](https://github.com/nl-design-system/utrecht/tree/main/components))
 
 ### Bevindingen vastleggen
 
 Voeg per organisatie onderstaande tekst toe.
 
 ```md
-## {Naam organisatie}
+## {Naam-organisatie}
 
-- [Documentatie website](link-naar-component-in-documentatie-website)
+- [Documentatie website]({link-naar-component-in-documentatie-website})
 - [Storybook]({link-naar-component-in-storybook})
 - [Figma]({link-naar-component-in-storybook})
+- [Github]({link-naar-component-in-github})
 
 ---
 
@@ -242,10 +242,9 @@ Screenshot
   - Is er onderzoek beschikbaar?
   - etc.
 
-**🚩 Checkpoint**
-
-✅ Bewijs verzameld dat het component algemeen bruikbaar is.
-✅ Link beschikbaar naar component in Figma of Storybook met alle belangrijke states en varianten.
+**🚩 Checkpoint**:
+- Bewijs verzameld dat het component algemeen bruikbaar is.  
+- Link beschikbaar naar component in Figma of Storybook met alle belangrijke states en varianten.
 
 ## Varianten vastgeleggen
 
@@ -253,9 +252,7 @@ Doel: Alleen varianten die algemeen nut hebben zijn vastgelegd. Daarnaast is het
 
 De varianten kun je baseren op de screenshots van de stap hierboven. Beschijf de naam en het doel van de algemeen nuttige varianten. Als je twijfelt over de rationale van een variant kun je de betreffende organisatie eventueel om aanvullende toelichting vragen.
 
-**🚩 Checkpoint**
-
-✅ Naam en doel van benodigde varianten beschreven.
+**🚩 Checkpoint**: Naam en doel van benodigde varianten beschreven.
 
 ## Onderzoek toevoegen
 
@@ -270,7 +267,7 @@ Kijk bijvoorbeeld bij:
 - [baymard.com](https://baymard.com/)
 - [GOV.UK - Discussions](https://github.com/orgs/alphagov/projects/43/views/1)
 
-Plaats verwijzingen naar onderzoek onderaan in de beschrijving van de Discussion. Noteer deze als volgt:
+Plaats verwijzingen naar onderzoek onderaan in de beschrijving van de discussion. Noteer deze als volgt:
 
 ```md
 ## Onderzoek
@@ -285,9 +282,7 @@ Korte beschrijving
 Korte beschrijving
 ```
 
-**🚩 Checkpoint**
-
-✅ Nut van component is onderbouwd door gebruikersonderzoek.
+**🚩 Checkpoint**: Nut van component is onderbouwd door gebruikersonderzoek.
 
 ## Toevoegen aan Backlog
 
@@ -304,46 +299,97 @@ We gebruiken 'Issues' in de [Github 'Backlog' repository van NL Design System](h
 
 {naam-component}
 
-[Link naar Discussion]({link-naar-Discussion})
+[Link naar discussion]({link-naar-discussion})
 ```
 
-**🚩 Checkpoint**
+Selecteer bij 'Projects' de volgende projecten:
+- Components - 1 - Help Wanted
+- Components - 2 - Community
+- Components - 3 - Candidate
+- Components - 4 - Hall of fame
 
-✅ Staat in de [publieke Backlog van NL Design System](https://github.com/nl-design-system/backlog/issues).
+**🚩 Checkpoint**: Staat in de [publieke backlog van NL Design System](https://github.com/nl-design-system/backlog/issues).
 
-## Toevoegen aan Help Wanted bord
+## Checkpoints afvinken
 
 Doel: Voortgang van component inzichtelijk maken.
 
-- Voeg het issue toe aan het [Help Wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1).
-- Geef per kolom de juiste waarde aan (afvinken van behaalde Checkpoints).
+Door de vorige stap is het component toegevoegd aan het [Help Wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1). Je kunt nu de reeds behaalde checkpoints afvinken door per kolom de juiste waarde te selecteren.
 
 ## Bevestiging door kernteam
 
 Doel: kernteam verwacht dat dit component tot hall-of-fame kan komen.
 
-Dit is het moment om het component in zijn geheel nog eens af te stemmen met het kernteam. Deel een link naar de Discussion met het kernteam via Slack. Na akkoord voert het kernteam de laatste stap uit.
+Dit is het moment om het component in zijn geheel nog eens af te stemmen met het kernteam. Deel een link naar de discussion met het kernteam via Slack. Na akkoord voert het kernteam de laatste stap uit.
 
-Stuur de volgende tekst naar #nl-design-system op Slack:
+Stuur dit bericht naar #nl-design-system op Slack:
 
 ```md
 Hiep hoi!
 
-Het is zo ver, de {component naam} is helemaal klaar voor een Help Wanted stempel.
+Het is zo ver, de {naam-component} is helemaal klaar voor een Help Wanted stempel.
 Er is nog 1 stap over, namelijk verwachten we dat deze in de Hall of Fame zou kunnen komen?,
 
-🤩 Top, doen! (hetzelfde als niets zeggen)
-😭 Nee, deze moet nooit naar de Hall of Fame
-🤨 Ik snap de naam of het nut niet
+🤩 Top, doen! (hetzelfde als niets zeggen).
+😭 Nee, deze moet nooit naar de Hall of Fame.
+🤨 Ik snap de naam of het nut niet.
 ```
 
-Iedereen mag wat vinden, maar de verschillende specialismes uit kernteam moeten wat vinden. Dus post een linkje in het #nl-design-system-kernteam kanaal waar je `@here` toevoegt om iedereen even wakker te schudden.
+### Kernteam hakt knoop door
 
-In de eerstvolgende weekly 🔨 klap erop.
+Deze stap kan enkel worden uitgevoerd door het kernteam.
 
-**🚩 Checkpoint**
+Iedereen mag wat vinden, maar de verschillende specialismes uit het kernteam moeten wat vinden. Dus post een linkje naar het 'Hiep hoi' bericht in het #nl-design-system-kernteam kanaal. Je kan `@here` gebruiken om iedereen even wakker te schudden.
 
-✅ Nut van component is door het kernteam bevestigd.
+Het kernteam bespreekt het component aan het eind van de eerstvolgende weekly. Eventueel benodigde acties worden ter plekke doorgevoerd of voor een volgende sprint vastgelegd.
+
+#### Akkoord?
+Ga verder bij [Discussion updaten naar Help Wanted](#discussion-updaten-naar-help-wanted).
+
+#### Niet akkoord?
+
+Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
+
+```md
+❌ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn, maar niet voldoende nuttig is voor meerdere organisaties.
+
+Dit hoeft niet te betekenen dat {naam-component} nooit de Help Wanted status krijgt. De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
+```
+
+**🚩 Checkpoint**: Nut van component is door het kernteam bevestigd.
+
+## Status naar Help Wanted
+
+Doel: iedereen kan zien dat het component nu richting Candidate wil.
+
+Deze stap kan enkel worden uitgevoerd door het kernteam.
+
+- Voeg het 'Help Wanted' label toe aan het backlog issue.
+- Voeg het 'Help Wanted' label toe aan de discussion.
+- Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op het component door op `Component: {naam-component}` te zoeken.
+- Kopieer de url na het filteren.
+- Voeg onderstaande opmerking toe als comment aan de discussion.
+
+```md
+## ✨ Dit component is nu Help Wanted ✨
+
+Help je mee hem door de Community stappen te krijgen?
+[{naam-component} op het Community bord]({url-community-bord})
+```
+
+Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
+
+```md
+✅ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn en het component algemeen nuttig is voor meerdere organisaties.
+
+✨ **Dit component is nu Help Wanted** ✨
+
+Help je mee hem door de Community stappen te krijgen?
+[{naam-component} op het Community bord]({url-community-bord})
+
+De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
+```
+**🚩 Checkpoint**: Status bijgewerkt naar Help Wanted.
 
 ## Toevoegen aan documentatie website
 
@@ -355,35 +401,8 @@ Deze stap kan enkel worden uitgevoerd door het kernteam.
 - Informatie van component toegevoegd aan [Component index](https://github.com/nl-design-system/index/blob/main/packages/component-index/src/index.ts).
 - Website updaten.
 
-**🚩 Checkpoint**
+**🚩 Checkpoint**: Vindbaar op de NL Design System website.
 
-✅ Vindbaar op de NL Design System website.
+## 🏁 Finish
 
-## Discussion updaten naar Help Wanted
-
-Doel: iedereen kan zien dat het component nu richting Candidate wil.
-
-Deze stap kan enkel worden uitgevoerd door het kernteam.
-
-- Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op het component door op `Component: {naam van component}` te zoeken.
-- Kopieer de url na het filteren
-- Voeg onderstaande opmerking toe als comment aan de discussion
-
-```md
-## ✨ Dit component is nu Help Wanted ✨
-
-Help je mee hem door de Community stappen te krijgen?
-[{naam van component} op het Community bord]({plak de url})
-```
-
-- Zet het `Help Wanted` label op de discussion
-
-**🚩 Checkpoint**
-
-✅ Discussion bijgewerkt naar Help Wanted status.
-
-## Finish
-
-Zo wat een werk! Je hebt alle stappen genomen en zo alle checks kunnen afvinken die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). Het component gaat nu door voor de 'Community' status.
-
-🎉 Stappen voor Help Wanted zijn afgevinkt op [het projectbord voor de Help wanted componenten](https://github.com/orgs/nl-design-system/projects/27)
+Zo wat een werk! Je hebt alle stappen genomen en zo alle checkpoints behaald die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). Het component gaat nu door voor de 'Community' status.

--- a/docs/componenten/_help-wanted-stappenplan.mdx
+++ b/docs/componenten/_help-wanted-stappenplan.mdx
@@ -1,6 +1,6 @@
-# Stappenplan: Help wanted
+# Stappenplan: Help Wanted
 
-Volg dit stappenplan om een component van alle checkpoints 🚩 te voorzien die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done).
+Volg dit stappenplan om een component van alle checkpoints 🚩 te voorzien die nodig zijn voor de ['Help Wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done).
 
 ## Naam bepalen
 
@@ -307,10 +307,10 @@ We gebruiken 'Issues' in de [Github 'Backlog' repository van NL Design System](h
 
 Selecteer bij 'Projects' de volgende projecten:
 
-- Components - 1 - Help wanted
+- Components - 1 - Help Wanted
 - Components - 2 - Community
 - Components - 3 - Candidate
-- Components - 4 - Hall of fame
+- Components - 4 - Hall of Fame
 
 **🚩 Checkpoint**: Staat in de [publieke backlog van NL Design System](https://github.com/nl-design-system/backlog/issues).
 
@@ -318,11 +318,11 @@ Selecteer bij 'Projects' de volgende projecten:
 
 Doel: Voortgang van component inzichtelijk maken.
 
-Door de vorige stap is het component toegevoegd aan het [Help wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1). Je kunt nu de reeds behaalde checkpoints afvinken door per kolom de juiste waarde te selecteren.
+Door de vorige stap is het component toegevoegd aan het [Help Wanted bord](https://github.com/orgs/nl-design-system/projects/27/views/1). Je kunt nu de reeds behaalde checkpoints afvinken door per kolom de juiste waarde te selecteren.
 
 ## Bevestiging door kernteam
 
-Doel: kernteam verwacht dat dit component tot hall-of-fame kan komen.
+Doel: kernteam verwacht dat dit component tot Hall of Fame kan komen.
 
 Dit is het moment om het component in zijn geheel nog eens af te stemmen met het kernteam. Deel een link naar de discussion met het kernteam via Slack. Na akkoord voert het kernteam de laatste stap uit.
 
@@ -331,11 +331,11 @@ Stuur dit bericht naar #nl-design-system op Slack:
 ```md
 Hiep hoi!
 
-Het is zo ver, de {naam-component} is helemaal klaar voor een Help wanted stempel.
-Er is nog 1 stap over, namelijk verwachten we dat deze in de Hall of fame zou kunnen komen?,
+Het is zo ver, de {naam-component} is helemaal klaar voor een Help Wanted stempel.
+Er is nog 1 stap over, namelijk verwachten we dat deze in de Hall of Fame zou kunnen komen?,
 
 🤩 Top, doen! (hetzelfde als niets zeggen).
-😭 Nee, deze moet nooit naar de Hall of fame.
+😭 Nee, deze moet nooit naar de Hall of Fame.
 🤨 Ik snap de naam of het nut niet.
 ```
 
@@ -349,7 +349,7 @@ Het kernteam bespreekt het component aan het eind van de eerstvolgende weekly. E
 
 #### Akkoord?
 
-Ga verder bij [Discussion updaten naar Help wanted](#discussion-updaten-naar-help-wanted).
+Ga verder bij [Discussion updaten naar Help Wanted](#discussion-updaten-naar-help-wanted).
 
 #### Niet akkoord?
 
@@ -358,25 +358,25 @@ Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
 ```md
 ❌ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn, maar niet voldoende nuttig is voor meerdere organisaties.
 
-Dit hoeft niet te betekenen dat {naam-component} nooit de Help wanted status krijgt. De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
+Dit hoeft niet te betekenen dat {naam-component} nooit de Help Wanted status krijgt. De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
 ```
 
 **🚩 Checkpoint**: Nut van component is door het kernteam bevestigd.
 
-## Status naar Help wanted
+## Status naar Help Wanted
 
 Doel: iedereen kan zien dat het component nu richting Candidate wil.
 
 Deze stap kan enkel worden uitgevoerd door het kernteam.
 
-- Voeg het 'Help wanted' label toe aan het backlog issue.
-- Voeg het 'Help wanted' label toe aan de discussion.
+- Voeg het 'Help Wanted' label toe aan het backlog issue.
+- Voeg het 'Help Wanted' label toe aan de discussion.
 - Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op het component door op `Component: {naam-component}` te zoeken.
 - Kopieer de url na het filteren.
 - Voeg onderstaande opmerking toe als comment aan de discussion.
 
 ```md
-## ✨ Dit component is nu Help wanted ✨
+## ✨ Dit component is nu Help Wanted ✨
 
 Help je mee hem door de Community stappen te krijgen?
 [{naam-component} op het Community bord]({url-community-bord})
@@ -387,7 +387,7 @@ Plaats deze tekst in de 'thread' van het 'Hiep hoi' bericht, vul aan waar nodig.
 ```md
 ✅ Het kernteam heeft besloten dat de naam en het doel van dit component duidelijk zijn en het component algemeen nuttig is voor meerdere organisaties.
 
-✨ **Dit component is nu Help wanted** ✨
+✨ **Dit component is nu Help Wanted** ✨
 
 Help je mee hem door de Community stappen te krijgen?
 [{naam-component} op het Community bord]({url-community-bord})
@@ -395,7 +395,7 @@ Help je mee hem door de Community stappen te krijgen?
 De [GitHub discussion voor het {naam-component} component]({link-naar-discussion}) blijft beschikbaar voor het delen van voorbeelden, varianten en gebruikersonderzoek.
 ```
 
-**🚩 Checkpoint**: Status bijgewerkt naar Help wanted.
+**🚩 Checkpoint**: Status bijgewerkt naar Help Wanted.
 
 ## Toevoegen aan documentatie website
 
@@ -411,4 +411,4 @@ Deze stap kan enkel worden uitgevoerd door het kernteam.
 
 ## 🏁 Finish
 
-Zo wat een werk! Je hebt alle stappen genomen en zo alle checkpoints behaald die nodig zijn voor de ['Help wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). Het component gaat nu door voor de 'Community' status.
+Zo wat een werk! Je hebt alle stappen genomen en zo alle checkpoints behaald die nodig zijn voor de ['Help Wanted' status](https://github.com/orgs/nl-design-system/projects/27/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). Het component gaat nu door voor de 'Community' status.


### PR DESCRIPTION
- Github linkjes toegevoegd aan 'input verzamelen'.
- Kernteam bevestiging aangevuld.
- Extra stappen voor toevoegen aan backlog.
- Aangegeven welke stappen enkel door kernteam kunnen worden gedaan.
- Headings in plaats van bold tekst voor organisaties. 
- Backlog en Discussion overal zonder hoofdletter in lopende tekst.
- Overal 'checkpoint' toegepast.
- Overal Help Wanted en Hall of Fame.