### PR TITLE
docs: add open source licenses we use

### DIFF
--- a/docs/footer/colofon.mdx
+++ b/docs/footer/colofon.mdx
@@ -17,3 +17,10 @@ De website wordt gemaakt en onderhouden door het kernteam en is nog volop in ont
 ## Iconen
 
 De toptaak iconen op onze homepage zijn gemaakt door <a href="https://www.opengemeenten.nl/producten/iconenset" target="_top">OpenGemeenten</a>. Deze iconenset is vrij te gebruiken en valt onder de CC BY-SA 4.0-licentie.
+
+## Open source
+
+De belangrijkste onderdelen van NL Design System zijn open source. We gebruiken voor twee open source licenties:
+
+- [EUPL 1.2](../open-source/eupl.md)
+- [CC0 1.0 Universeel](../open-source/cc0.md)

--- a/docs/open-source/cc0.md
+++ b/docs/open-source/cc0.md
@@ -1,0 +1,63 @@
+---
+title: Creative Commons 0 Universal licentie
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Creative Commons 0
+sidebar_position: 1
+pagination_label: Creative Commons
+description: NL Design System gebruikt de CC0-1.0 licentie voor documentatie.
+keywords:
+  - design system
+  - open source
+  - licentie
+  - creative commons
+---
+
+# CC0 1.0 Universeel
+
+Creative Commons Corporation is geen advocatenpraktijk en verleent geen juridische diensten. De verspreiding van deze licentie roept geen juridische relatie met Creative Commons in het leven. Creative Commons verspreidt deze informatie 'as-is'. Creative Commons staat niet in voor de inhoud van de verstrekte informatie en sluit alle aansprakelijkheid uit voor enigerlei schade voortvloeiend uit het gebruik van deze informatie indien en voorzover de wet niet anders bepaalt.
+
+## Doelverklaring
+
+In het recht van de meeste landen wordt het exclusieve Auteursrecht en Aanverwante Rechten (zoals hieronder omschreven) automatisch toegekend aan de maker en de opeenvolgende rechthebbende(n) (hierna gezamenlijk en afzonderlijk aangeduid als "rechthebbende") op een oorspronkelijk auteursrechtelijk beschermd werk en/of databank (hierna aangeduid als een "Werk").
+
+Sommige rechthebbenden wensen afstand te doen van hun rechten op een Werk om zo een bijdrage te leveren aan een gemeenschap van vrij toegankelijke creatieve, culturele en wetenschappelijke werken ("Commons"), dat iedereen kan bewerken, aanpassen, opnemen in andere werken, hergebruiken of herdistribueren, ongeacht het doel, inclusief (maar niet beperkt tot) voor commerciële doeleinden, zonder bang te hoeven zijn dat deze rechten worden geschonden. De rechthebbenden kunnen bijvoorbeeld hun Werk beschikbaar stellen aan de Commons om het idee van een vrije cultuur en de productie van creatieve, culturele en wetenschappelijke werken te promoten, of om grotere bekendheid te geven aan hun Werk of de verspreiding ervan bevorderen, deels door het gebruik en de inspanningen van anderen.
+
+Voor deze en/of andere doeleinden en redenen, en zonder aanspraak te maken op een aanvullende tegenprestatie of vergoeding, kiest degene die CC0 in verband brengt met een Werk (de "Bekrachtiger") er vrijwillig voor, voor zover hij of zij houder is van het Auteursrecht en Aanverwante Rechten op het Werk, om CC0 op het Werk van toepassing te verklaren en het Werk in het publieke domein te brengen, onder de voorwaarden van CC0, en met inachtneming van zijn of haar Auteursrecht en Aanverwante Rechten op het Werk en van de betekenis en desbetreffende juridische gevolgen van CC0 voor die rechten.
+
+## 1. Auteursrecht en Aanverwante Rechten.
+
+Op een Werk dat op grond van CC0 beschikbaar is gesteld, kunnen auteursrecht en aanverwante of naburige rechten rusten ("Auteursrecht en Aanverwante Rechten"). Auteursrecht en Aanverwante Rechten omvatten maar zijn niet beperkt tot:
+
+- <span>i.</span> het recht om een Werk te verveelvoudigen, bewerken, distribueren, uit te voeren, tentoon te spreiden, communiceren en vertalen;
+- <span>ii.</span> de door de oorspronkelijke auteur(s) en/of uitvoerder(s) behouden morele rechten;
+- <span>iii.</span> portretrecht en privacy rechten die verband houden met een in een Werk opgenomen beeltenis of gelijkenis van een persoon;
+- <span>iv.</span> rechten die bescherming bieden tegen oneerlijke concurrentie ten aanzien van een Werk, met inachtneming van de in onderstaand artikel 4 lid a, opgenomen beperkingen;
+- <span>v.</span> rechten die bescherming bieden tegen het opvragen, verspreiden, gebruiken en hergebruiken van in een Werk opgenomen gegevens;
+- <span>vi.</span> databankrechten (zoals die welke voortvloeien uit Richtlijn 96/9/EG van het Europees Parlement en de Raad van 11 maart 1996 betreffende de rechtsbescherming van databanken en uit nationaal recht krachtens de implementatie van de richtlijn daarin, inclusief de gewijzigde of opeenvolgende versie van die richtlijn); en
+- <span>vii.</span> overige vergelijkbare, gelijkwaardige, of overeenkomende rechten waar ook ter wereld, op basis van het toepasselijke recht of verdrag en de implementatie daarvan in nationaal recht.
+
+## 2. Afstandsverklaring.
+
+Voor zover dit is toegestaan onder en niet in strijd is met het toepasselijke recht, doet Bekrachtiger hierbij uitdrukkelijk, volledig, permanent, onherroepelijk en onvoorwaardelijk afstand van al zijn/haar Auteursrechten en Aanverwante Rechten en van alle daarmee verband houdende vorderingen en gerechtelijke procedures, hetzij bekend of onbekend (en zowel bestaande als toekomstige vorderingen en gerechtelijke procedures), op het Werk en geeft deze op (i) in alle rechtsgebieden ter wereld, (ii) voor de maximale duur toegestaan krachtens het toepasselijke recht of verdrag (inclusief toekomstige verlengingen daarvan), (iii) in elk bestaand of in de toekomst te ontwikkelen medium en ongeacht het aantal kopieën, en (iv) ongeacht het doeleinde, daaronder begrepen maar niet beperkt tot commerciële, reclame of promotionele doeleinden (de "Afstandsverklaring"). Bekrachtiger doet deze Afstandsverklaring ten behoeve van het publieke domein en ten nadele van zijn/haar erfgenamen en rechtsopvolgers, met de volledige intentie deze Afstandsverklaring niet te herroepen, ontbinden, annuleren of beëindigen, en verklaart dat met betrekking daartoe geen rechtsvordering of andere gerechtelijke actie zal worden ingesteld die het ongestoord genot van het Werk door het publiek, zoals overwogen in de expliciete Doelverklaring van Bekrachtiger, zou kunnen verstoren.
+
+## 3. Publieke Licentie.
+
+Als enig deel van de Afstandsverklaring onder het toepasselijke recht, om wat voor reden ook nietig of niet rechtsgeldig worden verklaard, dan blijft de Afstandsverklaring overigens zoveel mogelijk van kracht, met inachtneming van de expliciete Doelverklaring van Bekrachtiger. Daarnaast verleent Bekrachtiger, indien het bovenstaande met betrekking tot de Afstandsverklaring wordt verklaard, elke getroffen persoon een royaltyvrije, niet-overdraagbare, niet-sublicensieerbare, niet-exclusieve, onherroepelijke en onvoorwaardelijke licentie om het Auteursrecht en de Aanverwante Rechten van Bekrachtiger op het Werk uit te oefenen (i) in alle rechtsgebieden ter wereld, (ii) voor de maximale duur toegestaan krachtens het toepasselijke recht of verdrag (inclusief toekomstige verlengingen daarvan), (iii) in elk bestaand of in de toekomst te ontwikkelen medium en ongeacht het aantal kopieën, en (iv) ongeacht het doeleinde, daaronder begrepen maar niet beperkt tot commerciële, reclame of promotionele doeleinden (de "Licentie"). De Licentie wordt geacht van kracht te zijn met ingang van de datum waarop Bekrachtiger CC0 van toepassing heeft verklaard op het Werk. Als enig deel van de Licentie onder het toepasselijke recht om wat voor reden ook nietig of niet rechtsgeldig wordt verklaard, dan tast deze gedeeltelijke nietigheid of niet-rechtsgeldigheid de rest van de Licentie niet aan en in dat geval bevestigt Bekrachtiger hierbij dat hij/zij (i) zijn/haar rechten op het resterende Auteursrecht en Aanverwante Rechten op het Werk niet zal uitoefenen, of (ii) geen verwante rechtsvorderingen en gerechtelijke procedures met betrekking tot het Werk zal instellen, in beide gevallen in afwijking van de uitdrukkelijke Doelverklaring van Bekrachtiger.
+
+## 4. Beperkingen en Verklaringen.
+
+- a. Van geen enkel handelsmerk of octrooi van Bekrachtiger wordt afstand gedaan als gevolg van dit document, noch worden deze opgegeven, in licentie gegeven of anderszins aangetast.
+- b. Bekrachtiger biedt het Werk aan op “as-is” basis en doet geen enkele uitspraak en verstrekt geen enkele garantie met betrekking tot het Werk, expliciet, impliciet, wettelijk of anderszins, waaronder begrepen maar niet beperkt tot garantie van eigendom, verkoopbaarheid, geschiktheid voor een bepaald doel, niet-schending, of de afwezigheid van verborgen of andere gebreken, juistheid, of de aan- of afwezigheid van fouten, ongeacht of deze ontdekt kunnen worden, een en ander voor zover onder het toepasselijke recht is toegestaan.
+- c. Bekrachtiger is niet verantwoordelijk voor het vrijmaken van rechten van derden die op het Werk of het gebruik daarvan kunnen berusten, zoals maar niet beperkt tot het Auteursrecht en Aanverwante Rechten van derden op het Werk. Bekrachtiger is evenmin verantwoordelijk voor het verkrijgen van de voorgeschreven toestemmingen, vergunningen of andere rechten die vereist zijn voor het gebruik van het Werk.
+- d. Bekrachtiger erkent en verklaart dat Creative Commons geen partij is bij dit document en dat op haar geen enkele verplichting of plicht rust met betrekking tot deze CC0 of het gebruik van het Werk.
+
+---
+
+<aside class="utrecht-spotlight-section">
+  <p class="utrecht-paragraph">NL Design System gebruikt de CC0 Universal licentie voor documentatie. Onze bedoeling met deze licentie is dat je onze documentatie overal mag delen, dat je de teksten gratis voor eigen doeleinden mag gebruiken, dat je de documentatie mag doorontwikkelen zonder rekening te houden met copyright, en zodat je niet bij een klein stukje tekst altijd een grote lijst met mensen credit moet geven.</p>
+  <p class="utrecht-paragraph">Bovenin Markdown-bestanden is deze licentie aangegeven met:</p>
+  <pre class="utrecht-code-block"><code class="utrecht-code-block__content">&lt;!-- @license CC0-1.0 --></code></pre>
+  <p class="utrecht-paragraph">Bovenin MDX-bestanden is deze licentie aangegeven met: <code></code>.</p>
+  <pre class="utrecht-code-block"><code class="utrecht-code-block__content">\{/* @license CC0-1.0 */\}</code></pre>
+</aside>

--- a/docs/open-source/eupl.md
+++ b/docs/open-source/eupl.md
@@ -1,0 +1,155 @@
+---
+title: EUPL 1.2 licentie
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: EUPL 1.2
+sidebar_position: 1
+pagination_label: EUPL 1.2 licentie
+description: NL Design System gebruikt de EUPL-1.2 licentie voor code en design.
+keywords:
+  - design system
+  - open source
+  - licentie
+  - eupl
+---
+
+# Openbare licentie van de Europese Unie v. 1.2.
+
+EUPL © Europese Unie 2007, 2016
+
+Deze openbare licentie van de Europese Unie („EUPL”) is van toepassing op het werk (zoals hieronder gedefinieerd) dat onder de voorwaarden van deze licentie wordt verstrekt. Elk gebruik van het werk dat niet door deze licentie is toegestaan, is verboden (voor zover dit gebruik valt onder een recht van de houder van het auteursrecht op het werk). Het werk wordt verstrekt onder de voorwaarden van deze licentie wanneer de licentiegever (zoals hieronder gedefinieerd), direct volgend op de kennisgeving inzake het auteursrecht op het werk, de volgende kennisgeving opneemt:
+
+```
+In licentie gegeven krachtens de EUPL
+```
+
+of op een andere wijze zijn bereidheid te kennen heeft gegeven krachtens de EUPL in licentie te geven.
+
+## 1. Definities
+
+In deze licentie wordt verstaan onder:
+
+- „de licentie”: de onderhavige licentie;
+
+- „het oorspronkelijke werk”: het werk dat of de software die door de licentiegever krachtens deze licentie wordt verspreid of medegedeeld, en dat/die beschikbaar is als broncode en, in voorkomend geval, ook als uitvoerbare code;
+
+- „bewerkingen”:de werken of software die de licentiehouder kan creëren op grond van het oorspronkelijke werk of wijzigingen ervan. In deze licentie wordt niet gedefinieerd welke mate van wijziging of afhankelijkheid van het oorspronkelijke werk vereist is om een werk als een bewerking te kunnen aanmerken; dat wordt bepaald conform het auteursrecht dat van toepassing is in de in artikel 15 bedoelde staat;
+
+- „het werk”:het oorspronkelijke werk of de bewerkingen ervan;
+
+- „de broncode”:de voor mensen leesbare vorm van het werk, die het gemakkelijkste door mensen kan worden bestudeerd en gewijzigd;
+
+- „de uitvoerbare code”:elke code die over het algemeen is gecompileerd en is bedoeld om door een computer als een programma te worden uitgevoerd;
+
+- „de licentiegever”:de natuurlijke of rechtspersoon die het werk krachtens de licentie verspreidt of mededeelt;
+
+- „bewerker(s)”:elke natuurlijke of rechtspersoon die het werk krachtens de licentie wijzigt of op een andere wijze bijdraagt tot de totstandkoming van een bewerking;
+
+- „de licentiehouder” of „u”:elke natuurlijke of rechtspersoon die het werk onder de voorwaarden van de licentie gebruikt; — „verspreiding” of „mededeling”:het verkopen, geven, uitlenen, verhuren, verspreiden, mededelen, doorgeven, of op een andere wijze online of offline beschikbaar stellen van kopieën van het werk of het verlenen van toegang tot de essentiële functies ervan ten behoeve van andere natuurlijke of rechtspersonen.
+
+## 2. Draagwijdte van de uit hoofde van de licentie verleende rechten
+
+De licentiegever verleent u hierbij een wereldwijde, royaltyvrije, niet-exclusieve, voor een sublicentie in aanmerking komende licentie, om voor de duur van het aan het oorspronkelijke werk verbonden auteursrecht, het volgende te doen:
+
+- het werk in alle omstandigheden en voor ongeacht welk doel te gebruiken;
+- het werk te verveelvoudigen;
+- het werk te wijzigen en op grond van het werk bewerkingen te ontwikkelen;
+- het werk aan het publiek mede te delen, waaronder het recht om het werk of kopieën ervan aan het publiek ter beschikking te stellen of te vertonen, en het werk, in voorkomend geval, in het openbaar uit te voeren;
+- het werk of kopieën ervan te verspreiden;
+- het werk of kopieën ervan uit te lenen en te verhuren;
+- de rechten op het werk of op kopieën ervan in sublicentie te geven.
+
+Deze rechten kunnen worden uitgeoefend met gebruikmaking van alle thans bekende of nog uit te vinden media, dragers en formaten, voor zover het toepasselijke recht dit toestaat. In de landen waar immateriële rechten van toepassing zijn, doet de licentiegever afstand van zijn recht op uitoefening van zijn immateriële rechten in de mate die door het toepasselijke recht wordt toegestaan teneinde een doeltreffende uitoefening van de bovenvermelde in licentie gegeven economische rechten mogelijk te maken. De licentiegever verleent de licentiehouder een royaltyvrij, niet-exclusief gebruiksrecht op alle octrooien van de licentiegever, voor zover dit noodzakelijk is om de uit hoofde van deze licentie verleende rechten op het werk te gebruiken.
+
+## 3. Mededeling van de broncode
+
+De licentiegever kan het werk verstrekken in zijn broncode of als uitvoerbare code. Indien het werk als uitvoerbare code wordt verstrekt, verstrekt de licentiegever bij elke door hem verspreide kopie van het werk tevens een machinaal leesbare kopie van de broncode van het werk of geeft hij in een mededeling, volgende op de bij het werk gevoegde auteursrechtelijke kennisgeving, de plaats aan waar de broncode gemakkelijk en vrij toegankelijk is, zolang de licentiegever het werk blijft verspreiden of mededelen.
+
+## 4. Beperkingen van het auteursrecht
+
+Geen enkele bepaling in deze licentie heeft ten doel de licentiehouder het recht te ontnemen een beroep te doen op een uitzondering op of een beperking van de exclusieve rechten van de rechthebbenden op het werk, of op de uitputting van die rechten of andere toepasselijke beperkingen daarvan.
+
+## 5. Verplichtingen van de licentiehouder
+
+De verlening van de bovenvermelde rechten is onderworpen aan een aantal aan de licentiehouder opgelegde beperkingen en verplichtingen. Het gaat om de onderstaande verplichtingen.
+
+Attributierecht: de licentiehouder moet alle auteurs-, octrooi- of merkenrechtelijke kennisgevingen onverlet laten alsook alle kennisgevingen die naar de licentie en de afwijzing van garanties verwijzen. De licentiehouder moet een afschrift van deze kennisgevingen en een afschrift van de licentie bij elke kopie van het werk voegen die hij verspreidt of mededeelt. De licentiehouder moet in elke bewerking duidelijk aangeven dat het werk is gewijzigd, en eveneens de datum van wijziging vermelden.
+
+Copyleftclausule: wanneer de licentiehouder kopieën van het oorspronkelijke werk of bewerkingen verspreidt of mededeelt, geschiedt die verspreiding of mededeling onder de voorwaarden van deze licentie of van een latere versie van deze licentie, tenzij het oorspronkelijke werk uitdrukkelijk alleen onder deze versie van de licentie wordt verspreid — bijvoorbeeld door de mededeling „alleen EUPL v. 1.2”. De licentiehouder (die licentiegever wordt) kan met betrekking tot het werk of de bewerkingen geen aanvullende bepalingen of voorwaarden opleggen of stellen die de voorwaarden van de licentie wijzigen of beperken.
+
+Verenigbaarheidsclausule: wanneer de licentiehouder bewerkingen of kopieën ervan verspreidt of mededeelt die zijn gebaseerd op het werk en op een ander werk dat uit hoofde van een verenigbare licentie in licentie is gegeven, kan die verspreiding of mededeling geschieden onder de voorwaarden van deze verenigbare licentie. Voor de toepassing van deze clausule wordt onder „verenigbare licentie” verstaan, de licenties die in het aanhangsel bij deze licentie zijn opgesomd. Indien de verplichtingen van de licentiehouder uit hoofde van de verenigbare licentie in strijd zijn met diens verplichtingen uit hoofde van deze licentie, hebben de verplichtingen van de verenigbare licentie voorrang.
+
+Verstrekking van de broncode: bij de verspreiding of mededeling van kopieën van het werk verstrekt de licentiehouder een machinaal leesbare kopie van de broncode of geeft hij aan waar deze broncode gemakkelijk en vrij toegankelijk is, zolang de licentiehouder het werk blijft verspreiden of mededelen.
+
+Juridische bescherming: deze licentie verleent geen toestemming om handelsnamen, handelsmerken, dienstmerken of namen van de licentiegever te gebruiken, behalve wanneer dit op grond van een redelijk en normaal gebruik noodzakelijk is om de oorsprong van het werk te beschrijven en de inhoud van de auteursrechtelijke kennisgeving te herhalen.
+
+## 6. Auteursketen
+
+De oorspronkelijke licentiegever garandeert dat hij houder is van het hierbij verleende auteursrecht op het oorspronkelijke werk dan wel dat dit hem in licentie is gegeven en dat hij de bevoegdheid heeft de licentie te verlenen. Elke bewerker garandeert dat hij houder is van het auteursrecht op de door hem aan het werk aangebrachte wijzigingen dan wel dat dit hem in licentie is gegeven en dat hij de bevoegdheid heeft de licentie te verlenen. Telkens wanneer u de licentie aanvaardt, verlenen de oorspronkelijke licentiegever en de opeenvolgende bewerkers u een licentie op hun bijdragen aan het werk onder de voorwaarden van deze licentie.
+
+## 7. Uitsluiting van garantie
+
+Het werk is een werk in ontwikkeling, dat voortdurend door vele bewerkers wordt verbeterd. Het is een onvoltooid werk, dat bijgevolg nog tekortkomingen of programmeerfouten („bugs”) kan vertonen, die onlosmakelijk verbonden zijn met dit soort ontwikkeling. Om die reden wordt het werk op grond van de licentie verstrekt „zoals het is” en zonder enige garantie met betrekking tot het werk te geven, met inbegrip van, maar niet beperkt tot garanties met betrekking tot de verhandelbaarheid, de geschiktheid voor een specifiek doel, de afwezigheid van tekortkomingen of fouten, de nauwkeurigheid, de eerbiediging van andere intellectuele-eigendomsrechten dan het in artikel 6 van deze licentie bedoelde auteursrecht. Deze uitsluiting van garantie is een essentieel onderdeel van de licentie en een voorwaarde voor de verlening van rechten op het werk.
+
+## 8. Uitsluiting van aansprakelijkheid
+
+Behoudens in het geval van een opzettelijke fout of directe schade aan natuurlijke personen, is de licentiegever in geen enkel geval aansprakelijk voor ongeacht welke directe of indirecte, materiële of immateriële schade die voortvloeit uit de licentie of het gebruik van het werk, met inbegrip van, maar niet beperkt tot schade als gevolg van het verlies van goodwill, verloren werkuren, een computerdefect of computerfout, het verlies van gegevens, of enige andere commerciële schade, zelfs indien de licentiegever werd gewezen op de mogelijkheid van dergelijke schade. De licentiegever is echter aansprakelijk op grond van de wetgeving inzake productaansprakelijkheid, voor zover deze wetgeving op het werk van toepassing is.
+
+## 9. Aanvullende overeenkomsten
+
+Bij de verspreiding van het werk kunt u ervoor kiezen een aanvullende overeenkomst te sluiten, waarin de verplichtingen of diensten overeenkomstig deze licentie worden omschreven. Indien deze verplichtingen worden aanvaard, kunt u echter alleen in eigen naam en onder eigen verantwoordelijkheid handelen, en dus niet in naam van de oorspronkelijke licentiegever of een bewerker, en kunt u voorts alleen handelen indien u ermee instemt alle bewerkers schadeloos te stellen, te verdedigen of te vrijwaren met betrekking tot de aansprakelijkheid van of vorderingen tegen deze bewerkers op grond van het feit dat u een garantie of aanvullende aansprakelijkheid hebt aanvaard.
+
+## 10. Aanvaarding van de licentie
+
+De bepalingen van deze licentie kunnen worden aanvaard door te klikken op het pictogram „Ik ga akkoord”, dat zich bevindt onderaan het venster waarin de tekst van deze licentie is weergegeven, of door overeenkomstig de toepasselijke wetsbepalingen op een soortgelijke wijze met de licentie in te stemmen. Door op dat pictogram te klikken geeft u aan dat u deze licentie en alle voorwaarden ervan ondubbelzinnig en onherroepelijk aanvaardt. Evenzo aanvaardt u onherroepelijk deze licentie en alle voorwaarden ervan door uitoefening van de rechten die u in artikel 2 van deze licentie zijn verleend, zoals het gebruik van het werk, het creëren door u van een bewerking of de verspreiding of mededeling door u van het werk of kopieën ervan.
+
+## 11. Voorlichting van het publiek
+
+Indien u het werk verspreidt of mededeelt door middel van elektronische communicatiemiddelen (bijvoorbeeld door voor te stellen het werk op afstand te downloaden), moet het distributiekanaal of het medium (bijvoorbeeld een website) het publiek ten minste de gegevens verschaffen die door het toepasselijke recht zijn voorgeschreven met betrekking tot de licentiegever, de licentie en de wijze waarop deze kan worden geraadpleegd, gesloten, opgeslagen en gereproduceerd door de licentiehouder.
+
+## 12. Einde van de licentie
+
+De licentie en de uit hoofde daarvan verleende rechten eindigen automatisch bij elke inbreuk door de licentiehouder op de voorwaarden van de licentie. Dit einde beëindigt niet de licenties van personen die het werk van de licentiehouder krachtens de licentie hebben ontvangen, mits deze personen zich volledig aan de licentie houden.
+
+## 13. Overige
+
+Onverminderd artikel 9 vormt de licentie de gehele overeenkomst tussen de partijen met betrekking tot het werk. Indien een bepaling van de licentie volgens het toepasselijke recht ongeldig is of niet uitvoerbaar is, doet dit geen afbreuk aan de geldigheid of uitvoerbaarheid van de licentie in haar geheel. Deze bepaling dient zodanig te worden uitgelegd of gewijzigd dat zij geldig en uitvoerbaar wordt. De Europese Commissie kan, voor zover dit noodzakelijk en redelijk is, versies in andere talen of nieuwe versies van deze licentie of geactualiseerde versies van dit aanhangsel publiceren, zonder de draagwijdte van de uit hoofde van de licentie verleende rechten te beperken. Nieuwe versies van de licentie zullen worden gepubliceerd met een uniek versienummer. Alle door de Europese Commissie goedgekeurde taalversies van deze licentie hebben dezelfde waarde. De partijen kunnen zich beroepen op de taalversie van hun keuze.
+
+## 14. Bevoegd gerecht
+
+Onverminderd specifieke overeenkomsten tussen de partijen,
+
+- vallen alle geschillen tussen de instellingen, organen en instanties van de Europese Unie, als licentiegeefster, en een licentiehouder in verband met de uitlegging van deze licentie onder de bevoegdheid van het Hof van Justitie van de Europese Unie, conform artikel 272 van het Verdrag betreffende de werking van de Europese Unie,
+- vallen alle geschillen tussen andere partijen in verband met de uitlegging van deze licentie onder de uitsluitende bevoegdheid van het bevoegde gerecht van de plaats waar de licentiegever is gevestigd of zijn voornaamste activiteit uitoefent.
+
+## 15. Toepasselijk recht
+
+Onverminderd specifieke overeenkomsten tussen de partijen,
+
+- wordt deze licentie beheerst door het recht van de lidstaat van de Europese Unie waar de licentiegever zijn statutaire zetel, verblijfplaats of hoofdkantoor heeft,
+- wordt deze licentie beheerst door het Belgische recht indien de licentiegever geen statutaire zetel, verblijfplaats of hoofdkantoor heeft in een lidstaat van de Europese Unie.
+
+## Aanhangsel
+
+„Verenigbare licenties” in de zin van artikel 5 EUPL zijn:
+
+- GNU General Public License (GPL) v. 2, v. 3
+- GNU Affero General Public License (AGPL) v. 3
+- Open Software License (OSL) v. 2.1, v. 3.0
+- Eclipse Public License (EPL) v. 1.0
+- CeCILL v. 2.0, v. 2.1
+- Mozilla Public Licence (MPL) v. 2
+- GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3
+- Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) voor andere werken dan software
+- European Union Public Licence (EUPL) v. 1.1, v. 1.2
+- Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) of Strong Reciprocity (LiLiQ-R+).
+
+De Europese Commissie kan dit aanhangsel actualiseren in geval van latere versies van de bovengenoemde licenties zonder dat er een nieuwe EUPL-versie wordt ontwikkeld, zolang die versies de uit hoofde van artikel 2 van deze licentie verleende rechten verlenen en ze de betrokken broncode beschermen tegen exclusieve toe-eigening.
+Voor alle andere wijzigingen van of aanvullingen op dit aanhangsel is de ontwikkeling van een nieuwe EUPL-versie vereist.
+
+---
+
+<aside class="utrecht-spotlight-section">
+  <p class="utrecht-paragraph">NL Design System gebruikt de EUPL-1.2 licentie voor alle herbruikbare onderdelen, zoals code en ontwerpen. Elke Git repository heeft een `LICENSE`-bestand, waarin de EUPL tekst staat. Open source Figma-bestanden hebben een link naar de EUPL-licentie.</p>
+  <p class="utrecht-paragraph"><strong>Let op:</strong> sommige bestanden zijn uitgesloten van de open source licentie, zoals gegevens over de huisstijl. In de map `proprietary/` gebruiken we bijvoorbeeld altijd een andere `LICENSE`.</p>
+</aside>


### PR DESCRIPTION
Op de [Colofon pagina](https://documentatie-git-docs-licenses-nl-design-system.vercel.app/colofon) heb ik links naar de nieuwe [EUPL](https://documentatie-git-docs-licenses-nl-design-system.vercel.app/open-source/eupl) en [CC0](https://documentatie-git-docs-licenses-nl-design-system.vercel.app/open-source/cc0) pagina's toegevoegd.

Onderin de licentiepagina's staat wat uitleg in een `<aside>`, die zou ik later graag naar boven verplaatsen met een beter design van een "Spotlight section" component — maar daarvoor zijn nog geen tokens gekozen.