### PR TITLE
chore: update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ charset = UTF-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Do not trim trailing whitespace in Markdown and MDX files. This results in the following examples working as intended in editors with a format-on-save feature such as Visual Studio Code.

This example with a paragraph with 1 trailing space:

```markdown

lorem ipsum dolor sit amet,<space>
```

will be turned into a paragraph with no trailing spaces:

```markdown

lorem ipsum dolor sit amet,
```

Whereas the next example with a paragraph with 2 (or more) trailing spaces:

```markdown

lorem ipsum dolor sit amet,<space><space>
consectetur adipiscing elit
```

will be left as is.