### PR TITLE
build: use actions/deploy-pages for GH Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
       - name: Install pnpm package manager
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
@@ -45,6 +48,11 @@ jobs:
           name: website
           path: build/
           retention-days: 1
+
+      - name: "Retain build artifact for GitHub Pages: website"
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: build/
 
   e2e-test:
     runs-on: ubuntu-latest
@@ -108,21 +116,18 @@ jobs:
     needs: continuous-integration
     if: github.ref == 'refs/heads/main'
 
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-pages.outputs.page_url }}
+
     steps:
-      - name: Checkout release branch
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
-      - name: "Restore build artifact: website"
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          name: website
-          path: build/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@5c6e9e9f3672ce8fd37b9856193d2a537941e66c # v4.6.1
-        with:
-          branch: gh-pages
-          folder: build/
+      - name: Deploy
+        id: deploy-pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use GitHub's own actions to deploy the site to GitHub Pages.