### PR TITLE
Update _help-wanted-stappenplan.mdx

### DIFF
--- a/docs/componenten/_help-wanted-stappenplan.mdx
+++ b/docs/componenten/_help-wanted-stappenplan.mdx
@@ -162,7 +162,7 @@ Vooralsnog houden we deze set aan organisaties aan. Hiermee hebben we een mooie 
 
 - [Documentatie website](https://dso-toolkit.nl/62.8.4/intro/)
 - [Storybook](https://storybook.dso-toolkit.nl/62.8.4/?path=/docs/html-css-accordion--docs)
-- [Github](https://github.com/dso-toolkit/dso-toolkit) [CSS componenten](https://github.com/dso-toolkit/dso-toolkit/tree/master/packages/dso-toolkit/src/components)
+- [Github](https://github.com/dso-toolkit/dso-toolkit) ([CSS componenten](https://github.com/dso-toolkit/dso-toolkit/tree/master/packages/dso-toolkit/src/components))
 
 #### DUO
 


### PR DESCRIPTION
DSO verwijzing naar CSS componenten tussen haakjes net zoals de andere verwijzingen.