### PR TITLE
fix: links to stijl richtlijnen

### DIFF
--- a/docs/handboek/designer/README.md
+++ b/docs/handboek/designer/README.md
@@ -60,7 +60,7 @@ Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen onderste
 
 Zoals aangegeven kan iedere organisatie zijn eigen huisstijl toepassen. En toch bieden we vanuit het NL Design System documentatie aan rondom stijl. Hier vind je richtlijnen en tips die je kunt meenemen bij het toepassen van je eigen huisstijl.
 
-[Bekijk de stijl documentatie](../../richtlijnen/stijl/README.md)
+[Bekijk de stijl documentatie](/richtlijnen/stijl/overzicht)
 
 ### Voorbeeld thema
 

--- a/docs/handboek/designer/voorbeeld-thema.md
+++ b/docs/handboek/designer/voorbeeld-thema.md
@@ -26,7 +26,7 @@ Hieronder leggen we uit welke keuzes we gemaakt hebben voor het Voorbeeld thema.
 
 ![Visuale weergave van het lettertypes Source Serif Pro en Fira Sans.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_designers_voorbeeld-thema_typografie.png)
 
-In het Voorbeeld thema maken we gebruik van de lettertypes ‘Source Serif Pro’ en ‘Fira Sans’. Beide lettertypes zijn Open Source te gebruiken en voldoen aan de richtlijnen die we voor [Typografie](../../richtlijnen/stijl/README.md) hebben beschreven. Daarnaast zijn beide lettertypes standaard onderdeel van Figma. Hierdoor hoef je ze niet apart te installeren om te starten met de NL Design System bibliotheek.
+In het Voorbeeld thema maken we gebruik van de lettertypes ‘Source Serif Pro’ en ‘Fira Sans’. Beide lettertypes zijn Open Source te gebruiken en voldoen aan de richtlijnen die we voor [Typografie](../../richtlijnen/stijl/typografie.md) hebben beschreven. Daarnaast zijn beide lettertypes standaard onderdeel van Figma. Hierdoor hoef je ze niet apart te installeren om te starten met de NL Design System bibliotheek.
 
 ## Kleuren
 


### PR DESCRIPTION
Ik kreeg een melding bij `build` dat er twee linkjes dood waren.