### PR TITLE
WCAG-pagina's: update links naar Nederlandse tekst WCAG naar versie 2.2

### DIFF
--- a/docs/componenten/_icon.md
+++ b/docs/componenten/_icon.md
@@ -44,7 +44,7 @@ Probeer zoveel mogelijk iconen van een tekstlabel te voorzien. Wanneer een (inte
 
 ### Contrast {#contrast}
 
-Zorg voor functionele iconen dat deze voldoende contrast hebben met de achtergrond en omliggende kleuren. Zie hiervoor [WCAG techniek G207](https://www.w3.org/WAI/WCAG21/Techniques/general/G207) en [succescriterium 1.4.11, contrast van niet-tekstuele content](https://www.w3.org/Translations/WCAG21-nl/#contrast-van-niet-tekstuele-content). Er dient een minimale contrastverhouding van 3:1 ten opzichte van onderliggende en aangrenzende kleuren te zijn.
+Zorg voor functionele iconen dat deze voldoende contrast hebben met de achtergrond en omliggende kleuren. Zie hiervoor [WCAG techniek G207](https://www.w3.org/WAI/WCAG21/Techniques/general/G207) en [succescriterium 1.4.11, contrast van niet-tekstuele content](https://www.w3.org/Translations/WCAG22-nl/#contrast-van-niet-tekstuele-content). Er dient een minimale contrastverhouding van 3:1 ten opzichte van onderliggende en aangrenzende kleuren te zijn.
 
 Puur decoratieve iconen hoeven niet aan deze eis te voldoen.
 

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -79,7 +79,7 @@ Voor vragen, design of development: meld je gerust in de [Slack-community van Co
 
 NL Design System helpt op dit moment op twee manieren bij de toegankelijkheidsopgave van organisaties:
 
-1. Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, voorbeelden waarmee je aan [WCAG](https://www.w3.org/Translations/WCAG21-nl/) kunt voldoen en tips die verder dan gaan de WCAG.
+1. Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, voorbeelden waarmee je aan [WCAG](https://www.w3.org/Translations/WCAG22-nl/) kunt voldoen en tips die verder dan gaan de WCAG.
 2. Onze componenten kunnen worden gebruikt om toegankelijke producten te maken. Als componenten de laatste fase hebben bereikt (Hall of Fame), garanderen we zelfs dat ze voldoen aan toegankelijkheidseisen én zijn ze in productie getest.
 
 ## Mijn leverancier heeft vragen over NL Design System. Naar wie van jullie kan ik hem verwijzen?

--- a/docs/project/over-nl-design-system.mdx
+++ b/docs/project/over-nl-design-system.mdx
@@ -59,7 +59,7 @@ Door zo'n uitgebreid stappenplan te doorlopen, zorgen we voor een aantal zekerhe
 
 NL Design System helpt op dit moment op twee manieren bij de toegankelijkheidsopgave van organisaties:
 
-- Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, uitleg van de [WCAG-criteria](https://www.w3.org/Translations/WCAG21-nl/) en tips die verder dan gaan de WCAG.
+- Onze richtlijnen worden gebruikt als kennisbank. Ze bevatten concrete adviezen over wat er nodig is en waarom. Er zijn do's en don'ts, uitleg van de [WCAG-criteria](https://www.w3.org/Translations/WCAG22-nl/) en tips die verder dan gaan de WCAG.
 - Onze componenten kunnen worden gebruikt om toegankelijke producten te maken. Als componenten de laatste fase hebben bereikt (Hall of Fame), garanderen we zelfs dat ze voldoen aan toegankelijkheidseisen én zijn ze in productie getest.
 
 ## Leveranciers

--- a/docs/richtlijnen/formulieren/_autocomplete-value.md
+++ b/docs/richtlijnen/formulieren/_autocomplete-value.md
@@ -1,6 +1,6 @@
 ## Gebruik autocomplete als er een waarde voor is gedefinieerd
 
-WCAG bevat een volledige [lijst van waarden voor autocomplete](https://www.w3.org/Translations/WCAG21-nl/#input-purposes). Gebruik altijd een autocomplete-attribuut als er een waarde voor een formulierveld gedefinieerd is in deze lijst.
+WCAG bevat een volledige [lijst van waarden voor autocomplete](https://www.w3.org/Translations/WCAG22-nl/#input-purposes). Gebruik altijd een autocomplete-attribuut als er een waarde voor een formulierveld gedefinieerd is in deze lijst.
 
 Jules Ernst van 200 OK heeft van deze lijst een [Nederlandse interpretatie](https://www.200ok.nl/tips/autocomplete/) gemaakt.
 

--- a/docs/richtlijnen/formulieren/_help-show-required-intro.md
+++ b/docs/richtlijnen/formulieren/_help-show-required-intro.md
@@ -15,4 +15,4 @@ Maak de markering ook onderdeel van de labeltekst.
 
 Screenreadergebruikers krijgen deze informatie daarnaast ook voorgelezen door `aria-required` of `required` in de code op te nemen bij de verplichte velden.
 
-Door te helpen fouten te voorkomen voldoe van aan WCAG-Succescriterium [3.3.2 Labels of instructies](https://www.w3.org/Translations/WCAG21-nl/#labels-of-instructies) (niveau A).
+Door te helpen fouten te voorkomen voldoe van aan WCAG-Succescriterium [3.3.2 Labels of instructies](https://www.w3.org/Translations/WCAG22-nl/#labels-of-instructies) (niveau A).

--- a/docs/richtlijnen/formulieren/_link-in-new-tab.md
+++ b/docs/richtlijnen/formulieren/_link-in-new-tab.md
@@ -14,7 +14,7 @@ Het aangeven kan op verschillende manieren: via een icoontje, via tekst en via e
 
 Zorg dat de informatie over het openen van een nieuwe tab in de linktekst zelf is opgenomen. Dan wordt deze voorgelezen zodra de link focus krijgt. Als de tekst buiten (achter) de link staat bestaat de kans dat een screenreadergebruiker deze info mist.
 
-Hiermee volg je de WCAG-richtlijn [3.2 Voorspelbaar](https://www.w3.org/Translations/WCAG21-nl/#voorspelbaar): maak het uiterlijk en de bediening van webpagina's voorspelbaar.
+Hiermee volg je de WCAG-richtlijn [3.2 Voorspelbaar](https://www.w3.org/Translations/WCAG22-nl/#voorspelbaar): maak het uiterlijk en de bediening van webpagina's voorspelbaar.
 
 ### Technieken voor een link openen in een nieuwe tab of venster
 

--- a/docs/richtlijnen/formulieren/_when-which-compat.md
+++ b/docs/richtlijnen/formulieren/_when-which-compat.md
@@ -8,9 +8,9 @@ De ontwikkeling van browsers gaat snel en het gebruik van HTML geeft niet altijd
 
 Ervoor zorgen dat iedereen een formulierelement kan bedienen en begrijpen is nodig om te voldoen aan de volgende WCAG-succescriteria:
 
-- [1.3.2 Betekenisvolle volgorde](https://www.w3.org/Translations/WCAG21-nl/#info-en-relaties) (niveau A).
+- [1.3.2 Betekenisvolle volgorde](https://www.w3.org/Translations/WCAG22-nl/#info-en-relaties) (niveau A).
 - [2.1.1 Toetsenbord](/wcag/2.1.1) (niveau A).
-- [2.4.6 Koppen en labels](https://www.w3.org/Translations/WCAG21-nl/#koppen-en-labels) (niveau AA).
+- [2.4.6 Koppen en labels](https://www.w3.org/Translations/WCAG22-nl/#koppen-en-labels) (niveau AA).
 - [3.3.2 Labels of Instructies](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html) (niveau A).
 - [4.1.2 Naam, rol, waarde](/wcag/4.1.2) (niveau A).
 

--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -14,7 +14,7 @@ import FormFooterInfo from "./_wcag_footer_info.md";
 
 # Introductie WCAG-pagina's
 
-In deze pagina's vind je [<span lang="en">Web Content Accessibility Guidelines</span>](https://www.w3.org/Translations/WCAG21-nl/) (WCAG) beschreven en uitgelegd.
+In deze pagina's vind je [<span lang="en">Web Content Accessibility Guidelines</span>](https://www.w3.org/Translations/WCAG22-nl/) (WCAG) beschreven en uitgelegd.
 
 Het doel is om WCAG begrijpelijk uit te leggen en daardoor makkelijker toepasbaar te maken. Daarnaast staat beschreven hoe je webpagina's voor de verschillende succescriteria kunt testen.
 

--- a/docs/wcag/1.1.1.mdx
+++ b/docs/wcag/1.1.1.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.1.1 Non-text Content</span>](https://www.w3.org/TR/WCAG22/#non-text-content).
-- Nederlandse vertaling van het WCAG-succescriterium: [1.1.1 Niet-tekstuele content](https://www.w3.org/Translations/WCAG21-nl/#tekstalternatieven).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.1.1 Niet-tekstuele content](https://www.w3.org/Translations/WCAG22-nl/#tekstalternatieven).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.1.1 Non-text Content</span>](https://www.w3.org/WAI/WCAG22/quickref/#non-text-content).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.1.1: Non-text Content</span>](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html).
 

--- a/docs/wcag/1.3.1.mdx
+++ b/docs/wcag/1.3.1.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.3.1 Info and Relationships</span>](https://www.w3.org/TR/WCAG22/#info-and-relationships).
-- Nederlandse vertaling van het WCAG-succescriterium: [1.3.1 Info en relaties](https://www.w3.org/Translations/WCAG21-nl//#info-en-relaties).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.3.1 Info en relaties](https://www.w3.org/Translations/WCAG22-nl//#info-en-relaties).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.3.1 Info and Relationships</span>](https://www.w3.org/WAI/WCAG22/quickref/#info-and-relationships).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.3.1 Info and Relationships</span>](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html).
 

--- a/docs/wcag/1.3.5.mdx
+++ b/docs/wcag/1.3.5.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.3.5 Identify Input Purpose</span>](https://www.w3.org/TR/WCAG22/#identify-input-purpose).
-- Nederlandse vertaling van het WCAG-succescriterium: [1.3.5 Identificeer het doel van de input](https://www.w3.org/Translations/WCAG21-nl/#niet-tekstuele-content).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.3.5 Identificeer het doel van de input](https://www.w3.org/Translations/WCAG22-nl/#niet-tekstuele-content).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/quickref/#identify-input-purpose).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.3.5 Identify Input Purpose</span>](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html).
 
@@ -36,7 +36,7 @@ Dit kan door gebruik te maken van het HTML-attribuut `autocomplete`.
 
 ## Bronnen
 
-- WCAG bevat een volledige lijst van [waarden voor autocomplete](https://www.w3.org/Translations/WCAG21-nl/#input-purposes).
+- WCAG bevat een volledige lijst van [waarden voor autocomplete](https://www.w3.org/Translations/WCAG22-nl/#input-purposes).
 - Jules Ernst van 200 OK heeft van deze lijst een [Nederlandse interpretatie van autocomplete](https://www.200ok.nl/tips/autocomplete/)gemaakt.
 
 ## Gebruikersonderzoek

--- a/docs/wcag/2.1.1.mdx
+++ b/docs/wcag/2.1.1.mdx
@@ -21,7 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.1.1 Keyboard</span>](https://www.w3.org/TR/WCAG22/#keyboard).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.1.1 Toetsenbord](https://www.w3.org/Translations/WCAG21-nl/#toetsenbord).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.1.1 Toetsenbord](https://www.w3.org/Translations/WCAG22-nl/#toetsenbord).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/quickref/#keyboard).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.1.1 Keyboard</span>](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).
 

--- a/docs/wcag/2.4.10.mdx
+++ b/docs/wcag/2.4.10.mdx
@@ -21,7 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.10
   Section Headings</span>](https://www.w3.org/TR/WCAG22/#section-headings).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.4.10 Paragraafkoppen](https://www.w3.org/Translations/WCAG21-nl/#paragraafkoppen).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.10 Paragraafkoppen](https://www.w3.org/Translations/WCAG22-nl/#paragraafkoppen).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.10
   Section Headings</span>](https://www.w3.org/WAI/WCAG22/quickref/#section-headings).
 - Engelstalige toelichting: [<span lang="en">Understanding SC: 2.4.10

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -76,7 +76,7 @@ Inspecteer in de gegenereerde HTML-code van de webpagina de elementen die de toe
 Is er geen outline, maar verandert de kleur van het hele element?
 
 - Controleer dan of er een kleurcontrast is van ten minste 3:1 tussen dezelfde pixels in de **gefocuste** en **niet-gefocuste** staat. Bijvoorbeeld voor een button die van kleur verandert bij toetsenbordfocus.
-- Controleer of de tekst in dit element aan de [richtlijnen voor contrast](https://www.w3.org/Translations/WCAG21-nl/#contrast-minimum) voldoet in gefocuste en niet-gefocuste staat.
+- Controleer of de tekst in dit element aan de [richtlijnen voor contrast](https://www.w3.org/Translations/WCAG22-nl/#contrast-minimum) voldoet in gefocuste en niet-gefocuste staat.
 
 Mooie tools om het kleurcontrast te testen en zo nodig een alternatief te kiezen zijn:
 

--- a/docs/wcag/2.4.2.mdx
+++ b/docs/wcag/2.4.2.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.2 Page Titled</span>](https://www.w3.org/TR/WCAG22/#page-titled).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.4.2 Paginatitel](https://www.w3.org/Translations/WCAG21-nl/#paginatitel).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.2 Paginatitel](https://www.w3.org/Translations/WCAG22-nl/#paginatitel).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.2 Page Titled</span>](https://www.w3.org/WAI/WCAG22/quickref/#page-titled).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.2 Page Titled</span>](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html).
 

--- a/docs/wcag/2.4.4.mdx
+++ b/docs/wcag/2.4.4.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.4 Link Purpose (In Context)</span>](https://www.w3.org/TR/WCAG22/#link-purpose-in-context).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.4.4 Linkdoel (in context)](https://www.w3.org/Translations/WCAG21-nl//#linkdoel-in-context).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.4 Linkdoel (in context)](https://www.w3.org/Translations/WCAG22-nl//#linkdoel-in-context).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.4 Link Purpose (In Context)</span>](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.4 Link Purpose (In Context)</span>](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html).
 

--- a/docs/wcag/2.4.7.mdx
+++ b/docs/wcag/2.4.7.mdx
@@ -21,7 +21,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.7 Focus Visible</span>](https://www.w3.org/TR/WCAG22/#focus-visible).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.4.7 Focus zichtbaar](https://www.w3.org/Translations/WCAG21-nl/#focus-zichtbaar).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.7 Focus zichtbaar](https://www.w3.org/Translations/WCAG22-nl/#focus-zichtbaar).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 12.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html).
 

--- a/docs/wcag/3.1.1.mdx
+++ b/docs/wcag/3.1.1.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.1.1 Language of Page</span>](https://www.w3.org/TR/WCAG22/#language-of-page).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.1.1 Taal van de pagina](https://www.w3.org/Translations/WCAG21-nl/#taal-van-de-pagina).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.1.1 Taal van de pagina](https://www.w3.org/Translations/WCAG22-nl/#taal-van-de-pagina).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.1.1 Language of Page</span>](https://www.w3.org/WAI/WCAG22/quickref/#language-of-page).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.1.1: Language of Page</span>](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html).
 

--- a/docs/wcag/3.1.2.mdx
+++ b/docs/wcag/3.1.2.mdx
@@ -21,7 +21,7 @@ import { VideoPlayer } from "../../src/components/VideoPlayer";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.1.2 Language of Parts</span>](https://www.w3.org/TR/WCAG22/#language-of-parts).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.1.2 Taal van onderdelen](https://www.w3.org/Translations/WCAG21-nl/#taal-van-onderdelen).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.1.2 Taal van onderdelen](https://www.w3.org/Translations/WCAG22-nl/#taal-van-onderdelen).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.1.2 Language of Parts</span>](https://www.w3.org/WAI/WCAG22/quickref/#language-of-page).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.1.2: Language of Parts</span>](https://www.w3.org/WAI/WCAG22/Understanding/language-of-page).
 

--- a/docs/wcag/3.2.1.mdx
+++ b/docs/wcag/3.2.1.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.2.1 On focus</span>](https://www.w3.org/TR/WCAG22/#on-focus)
-- Nederlandse vertaling van het WCAG-succescriterium: [3.2.2 Bij focus](https://www.w3.org/Translations/WCAG21-nl/#bij-focus).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.2.2 Bij focus](https://www.w3.org/Translations/WCAG22-nl/#bij-focus).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.2.1 On Focus</span>](https://www.w3.org/WAI/WCAG22/quickref/#on-focus).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.2.1: On Input</span>](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html).
 

--- a/docs/wcag/3.2.2.mdx
+++ b/docs/wcag/3.2.2.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.2.2: On Input</span>](https://www.w3.org/TR/WCAG22/#on-input).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.2.2 Bij input](https://www.w3.org/Translations/WCAG21-nl/#bij-input).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.2.2 Bij input](https://www.w3.org/Translations/WCAG22-nl/#bij-input).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.2.2 On Input</span>](https://www.w3.org/WAI/WCAG22/quickref/#on-input).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.2.2: On Input</span>](https://www.w3.org/WAI/WCAG21/Understanding/on-input.html).
 

--- a/docs/wcag/3.3.1.mdx
+++ b/docs/wcag/3.3.1.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.1 Error Identification</span>](https://www.w3.org/TR/WCAG22/#error-identification).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG21-nl/#foutidentificatie).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.3.1 Foutidentificatie](https://www.w3.org/Translations/WCAG22-nl/#foutidentificatie).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.1 Error Identification</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-identification).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.1 Error Identification</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html).
 

--- a/docs/wcag/3.3.3.mdx
+++ b/docs/wcag/3.3.3.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.3 Error Suggestion</span>](https://www.w3.org/TR/WCAG22/#error-suggestion).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.3.3 Foutsuggestie](https://www.w3.org/Translations/WCAG21-nl/#foutsuggestie).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.3.3 Foutsuggestie](https://www.w3.org/Translations/WCAG22-nl/#foutsuggestie).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-suggestion).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.3 Error Suggestion</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html).
 

--- a/docs/wcag/3.3.4.mdx
+++ b/docs/wcag/3.3.4.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.4 Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/TR/WCAG22/#error-prevention-legal-financial-data).
-- Nederlandse vertaling van het WCAG-succescriterium: [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](https://www.w3.org/Translations/WCAG21-nl/#foutpreventie-wettelijk-financieel-gegevens).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](https://www.w3.org/Translations/WCAG22-nl/#foutpreventie-wettelijk-financieel-gegevens).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.4 Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-legal-financial-data).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.4:Error Prevention (Legal, Financial, Data)</span>](https://www.w3.org/WAI/WCAG21/Understanding/error-prevention-legal-financial-data.html).
 

--- a/docs/wcag/4.1.2.mdx
+++ b/docs/wcag/4.1.2.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">4.1.2 Name, role, value</span>](https://www.w3.org/TR/WCAG22/#name-role-value).
-- Nederlandse vertaling van het WCAG-succescriterium: [4.1.2 Naam, rol, waarde](https://www.w3.org/Translations/WCAG21-nl/#naam-rol-waarde).
+- Nederlandse vertaling van het WCAG-succescriterium: [4.1.2 Naam, rol, waarde](https://www.w3.org/Translations/WCAG22-nl/#naam-rol-waarde).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 4.1.2 Name, role, value</span>](https://www.w3.org/WAI/WCAG22/quickref/#name-role-value).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 4.1.2 Name, role, value</span>](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html).
 
@@ -234,8 +234,8 @@ Typefouten zoals `aria-lable`, `treu`, `role="presenational"` zijn niet ongewoon
 Dit WCAG-succescriterium gaat over toegankelijke code voor onder andere de naam. Niet alle fouten in de naam zijn alleen een fout in de categorie "Naam, rol, waarde".
 Dit zijn bijvoorbeeld andere succescriteria die ook te maken hebben met de naam:
 
-- [2.4.4 Linkdoel (in context)](/wcag/2.4.4) en [2.4.9 Linkdoel (alleen doel)](https://www.w3.org/Translations/WCAG21-nl/#linkdoel-alleen-link): schrijf een duidelijke linktekst, dat is de toegankelijke naam van `link`-rol.
-- [2.4.6 Koppen en labels](https://www.w3.org/Translations/WCAG21-nl/#koppen-en-labels) zegt bijvoorbeeld dat alle formulier-elementen vindbaar moeten zijn met een label. Als er helemaal geen label is, dan is dit een ook fout voor succescriterium 2.4.6.
+- [2.4.4 Linkdoel (in context)](/wcag/2.4.4) en [2.4.9 Linkdoel (alleen doel)](https://www.w3.org/Translations/WCAG22-nl/#linkdoel-alleen-link): schrijf een duidelijke linktekst, dat is de toegankelijke naam van `link`-rol.
+- [2.4.6 Koppen en labels](https://www.w3.org/Translations/WCAG22-nl/#koppen-en-labels) zegt bijvoorbeeld dat alle formulier-elementen vindbaar moeten zijn met een label. Als er helemaal geen label is, dan is dit een ook fout voor succescriterium 2.4.6.
 
 ### Fout: aria-expanded toggle staat niet op de button, maar op het gerelateerde element
 

--- a/docs/wcag/4.1.3.mdx
+++ b/docs/wcag/4.1.3.mdx
@@ -20,7 +20,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">4.1.3 Status Messages</span>](https://www.w3.org/TR/WCAG22/#status-messages).
-- Nederlandse vertaling van het WCAG-succescriterium: [4.1.3 Statusberichten](https://www.w3.org/Translations/WCAG21-nl/#statusberichten).
+- Nederlandse vertaling van het WCAG-succescriterium: [4.1.3 Statusberichten](https://www.w3.org/Translations/WCAG22-nl/#statusberichten).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 4.1.3 Status Messages</span>](https://www.w3.org/WAI/WCAG22/quickref/#status-messages).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 4.1.3: Status Messages</span>](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html).
 


### PR DESCRIPTION
In alle pagina's binnen docs.

Behalve parsing, want die vervalt in 2.2

Issue: https://github.com/nl-design-system/documentatie/issues/811
Preview: https://documentatie-git-wcag-link-wcag-2-2-nl-nl-design-system.vercel.app/richtlijnen