### PR TITLE
docs: Tweak meedoen als organisatie / niveaus

### DIFF
--- a/docs/handboek/organisatie/meedoen.md
+++ b/docs/handboek/organisatie/meedoen.md
@@ -13,56 +13,55 @@ description: Meedoen als organisatie
 
 # Meedoen als organisatie
 
-Je kunt op verschillende niveaus meedoen met NL Design System.
+Organisaties en hun leveranciers kunnen op verschillende niveaus meedoen met NL Design System.
 
-Wanneer je gebruik van NL Design System aan je leverancier vraagt is het dus mogelijk verstandig om aan te geven tot welk niveau je dat wenst.
+## Niveau 1. Online meedoen
 
-## Niveau 1. Doe on-line mee met de community in Slack en bij on-line events
+### Bewijs
 
-### Bewijs:
+- personen [schrijven zich in](/community/sluit-je-aan)) als lid van de community.
+- personen zijn af en toe aanwezig bij de [NL Design System Heartbeat](/events/heartbeat).
+- designers zijn af en toe aanwezig bij de [Design Open Hour](/events/design-open-hour).
+- developers zijn af en toe aanwezig bij de Developer Open Hour.
+- developers en designers zijn aanwezig in Slack (kanaal `#nl-design-system` in de [CodeForNL Slack](https://praatmee.codefor.nl/)).
+- vragen worden gesteld in publieke chatkanalen of in GitHub.
+- werkzaamheden en plannen zijn publiek gedeeld in de NL Design System community.
 
-- schrijf je in als lid van de community: https://nldesignsystem.nl/community/sluit-je-aan
-- personen zijn af en toe aanwezig bij de NL Design System Heartbeat
-- designers zijn af en toe aanwezig bij de Design Open Hour
-- developers zijn af en toe aanwezig bij de Developer Open Hour
-- developers en designers zijn aanwezig in de Slack van #nl-design-system
-- vragen worden gedeeld in publieke chat-kanalen of in GitHub
-- werkzaamheden en plannen zijn publiek in de NL Design System community gedeeld
+## Niveau 2. Richtlijnen gebruiken
 
-## Niveau 2. Richtlijnen gebruiken van https://nldesignsystem.nl/richtlijnen/introductie
+Onder [Richtlijnen](/richtlijnen/introductie) verzamelen we richtlijnen voor het maken van digitale diensten, bijvoorbeeld voor het maken van formulieren.
 
-### Bewijs:
+### Bewijs
 
-Gebruik van richtlijnen is niet goed te bewijzen, richtlijnen moeten in de werkwijze van de leverancier zitten. Je kan de leverancier hierom vragen.
+Het opgeleverde werk voldoet aan de richtlijnen van NL Design System. Vraag de leverancier dit mee te nemen en ga achteraf zo goed mogelijk na of dit is gebeurd. Vraag om uitleg als er is afgeweken.
 
 ## Niveau 3. Eigen NL Design System thema maken en onderhouden
 
-Design Tokens vastleggen voor de componenten die je gebruikt, oftewel een eigen thema.
+NL Design System thema's bestaan uit organisatiespecifieke ontwerpbeslissingen, die zijn vastgelegd als [Design Tokens](/handboek/design-tokens/).
 
-### Bewijs:
+### Bewijs
 
-Er staat een thema voor jouw organisatie op https://nl-design-system.github.io/themes/ en de leverancier heeft in de werkwijze opgenomen om hier gebruik van te maken en waar nodig uit te breiden.
-Bekijk in de Thema Storybook of de gebruikte componenten in de huisstijl van jouw organisatie beschikbaar zijn.
+Er staat een thema voor jouw organisatie in de [Thema Storybook](https://nl-design-system.github.io/themes/). De leverancier heeft in hun werkwijze opgenomen om dit thema te gebruiken en waar nodig uit te breiden. Bekijk in de [Thema Storybook](https://nl-design-system.github.io/themes/) of de gebruikte componenten in de huisstijl van jouw organisatie beschikbaar zijn.
 
 ## Niveau 4. Componenten hergebruiken uit de community
 
-### Bewijs:
+### Bewijs
 
-Bij het maken van prototypes is gebruik gemaakt van de Figma bibliotheek van N Design System of zijn onderdelen community prototypes hergebruikt. In code worden zoveel mogelijk componenten met community+ status uit NL Design System hergebruikt.
+Bij het maken van prototypes is gebruik gemaakt van de Figma-bibliotheek van NL Design System, of er zijn onderdelen van community prototypes hergebruikt. In code worden zoveel mogelijk componenten met de status “Community” of hoger gebruikt.
 
 **Altijd**: je maakt voor zover mogelijk gebruik van “Community”, “Candidate” en “Hall of Fame” componenten.
 
 **Minimale optie**: Wanneer de component niet bruikbaar is, dan kies je een eigen weg.
 
-**Ideale optie**: Deel het met de community wanneer je een bestaande component niet kan hergebruiken, bijvoorbeeld in de GitHub Discussion over de component of door een GitHub Issue aan te maken bij de maker van de component.
+**Ideale optie**: Deel het met de community wanneer je een bestaande component niet kan hergebruiken. Dat kan bijvoorbeeld in de GitHub Discussion over de component, of door een GitHub Issue aan te maken bij de maker van de component.
 
-**Tip**: We raden de leverancier aan om deel te nemen aan designer en developer open hours zodat vragen gesteld kunnen worden en samengewerkt kan worden met de bestaande community.
+**Tip**: We raden leveranciers aan om deel te nemen aan designer en developer open hours zodat vragen gesteld kunnen worden en samengewerkt kan worden met de bestaande community.
 
 ## Niveau 5. Componenten verbeteren uit de community
 
-### Bewijs:
+### Bewijs
 
-Wanneer een component uit de community niet helemaal voldoet aan de eisen die het project stelt is gebruik gemaakt van bestaande code om op door te bouwen.
+Wanneer een component uit de community niet helemaal voldoet aan de eisen, is gebruik gemaakt van bestaande code om op door te bouwen.
 
 **Minimale optie**: De nieuwe component is zoveel mogelijk opgebouwd op dezelfde manier als de bestaande component en de community is van deze nieuwe variant op de hoogte gesteld.
 
@@ -70,23 +69,25 @@ Wanneer een component uit de community niet helemaal voldoet aan de eisen die he
 
 ## Niveau 6. Componenten bijdragen aan de community
 
-### Bewijs:
+### Bewijs
 
-Nieuw componenten die nodig zijn voor het project en waarvan waarschijnlijk is dat het bruikbaar is voor de rest van Nederland zijn opgeleverd volgens de NL Design System aanpak. Dat betekent:
+Nieuwe componenten zijn opgeleverd volgens de aanpak van NL Design System. Dat betekent:
 
-- De component is aangemaakt als GitHub Discussion voor Help Wanted
-- De eerste stappen voor “Community component” zijn gevolgd: https://nldesignsystem.nl/handboek/community-stappenplan
-- De component is gebouwd volgens de NL Design System architectuur
+- De component is aangemaakt als GitHub Discussion voor Help Wanted.
+- De [eerste stappen voor “Community component”](https://nldesignsystem.nl/handboek/community-stappenplan) zijn gevolgd.
+- De component is gebouwd volgens de NL Design System architectuur.
 - De component is beschikbaar gemaakt in de thema Storybook website van NL Design System.
 
-**Ideale optie**: De component is ook in Figma beschikbaar volgens de Figma architectuur
+Daarnaast is het van belang dat het doel van de component duidelijk is, en kan worden aangenomen dat het ook bruikbaar is voor de rest van Nederland.
+
+**Ideale optie**: De component is ook in Figma beschikbaar volgens de Figma architectuur.
 
 ## Niveau 7. Design System beschikbaar maken voor de community en documenteren met Storybook
 
-### Bewijs:
+### Bewijs
 
-Er is een Storybook website waarin de component en de verschillende varianten van de component zijn gedocumenteerd.
+Er is een Storybook website waarin de component, inclusief varianten, is gedocumenteerd.
 
-**Ideale optie**: De leverancier heeft een storybook omgeving opgeleverd waarin de pagina’s die nodig zijn voor de applicatie gedocumenteerd zijn en door anderen over te nemen. Een goed voorbeeld zijn de MijnZaken pagina’s van Den Haag https://nl-design-system.github.io/denhaag/?path=/story/templates-overview--overview die naast de componenten documentatie beschikbaar zijn gemaakt.
+**Ideale optie**: De leverancier heeft een Storybook-omgeving opgeleverd, waarin naast componenten ook de benodigde pagina's zijn gedocumenteerd op een manier die anderen kunnen overnemen. Een goed voorbeeld zijn de [MijnZaken pagina’s van Den Haag](https://nl-design-system.github.io/denhaag/?path=/story/templates-overview--overview), die naast de componentendocumentatie beschikbaar zijn gemaakt.
 
-**Ideale optie voor organisaties met meerdere ontwikkelteams**: In de eigen storybook zijn NL Design System “Community”, “Candidate” en “Hall-of-fame” componenten die in de organisatie gebruikt worden gedocumenteerd.
+**Ideale optie voor organisaties met meerdere ontwikkelteams**: In de eigen Storybook zijn NL Design System “Community”, “Candidate” en “Hall of Fame” componenten die in de organisatie gebruikt worden gedocumenteerd.


### PR DESCRIPTION
Omdat ik bezig was 'm in slides mee te nemen, heb ik gelijk geprobeerd deze pagina wat te verbeteren en consistenter te maken:

- af en toe herschreven om eenvoudiger / leesbaarder te maken,
- opsommingen die eindigen op een `.`, headings zonder `:` 
- Storybook consequent met hoofdletter
- links die alleen de URL waren zo aangepast dat het een logische linknaam heeft

Inhoudelijk begrijp ik de uitleg bij Niveau 2: Richtlijnen gebruiken, het is niet zo bewijsbaar als aanwezigheid van informatie op specifieke plekken. Maar het is wel na te gaan of er toegepast of uitgelegd is, mijn voorstel is dat op te nemen. Strenger dan dat niet logisch nu we nog geen geversioneerde richtlijnen hebben.
