### PR TITLE
Richtlijnen: Link naar blogpost over foutmeldingen op de intro-pagina van de formulierrichtlijnen

### DIFF
--- a/docs/richtlijnen/formulieren/README.mdx
+++ b/docs/richtlijnen/formulieren/README.mdx
@@ -16,6 +16,8 @@ import FormFooterInfo from "./_form_footer_info.md";
 
 Het NL Design System geeft richtlijnen voor formulieren. Hierbij zijn we uitgegaan van toegankelijkheid, gebruikersvriendelijkheid en consistentie, ondersteund door gebruikersonderzoek.
 
+Deze richtlijnen staan gesorteerd op onderwerp en op alfabet. De aanvullende blogpost [Toegankelijke foutmeldingen in formulieren](/blog/toegankelijke-foutmeldingen-formulieren) vertelt in een lopend verhaal hoe foutmeldingen in formulieren op te zetten.
+
 ## Opzet
 
 De richtlijnen zijn onderverdeeld in een aantal pagina's per onderwerp:


### PR DESCRIPTION
Voegt link naar [blogpost over foutmeldingen](https://nldesignsystem.nl/blog/toegankelijke-foutmeldingen-formulieren) op de intro-pagina van de formulierrichtlijnen.

Preview: https://documentatie-git-crosslinken-blogposts-f779d1-nl-design-system.vercel.app/richtlijnen/formulieren/