### PR TITLE
fix: correct backlog link and illustration for Unordered list

### DIFF
--- a/docs/componenten/unordered-list/index.mdx
+++ b/docs/componenten/unordered-list/index.mdx
@@ -7,7 +7,7 @@ pagination_label: Unordered list
 description: Toont een lijst met items waarvan de volgorde geen betekenis heeft.
 slug: /unordered-list
 sidebar_custom_props:
-  illustration: OrderedListSketch
+  illustration: UnorderedListSketch
 ---
 
 {/* @license CC0-1.0 */}
@@ -19,7 +19,7 @@ import { Backlog, DefinitionOfDone, Implementations, Introduction } from "../../
 export const title = "Unordered list";
 export const description = "Toont een lijst met items waarvan de volgorde geen betekenis heeft.";
 export const illustration = "UnorderedListSketch";
-export const issueNumber = 50;
+export const issueNumber = 116;
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 


### PR DESCRIPTION
Johan Groenen merkte op in Slack:
> Ik zag dat "Unordered list" een afbeelding heeft van een ordered list, en dat de link erbij verwijst naar "Tooltip"