### PR TITLE
Description en title Table toegevoegd

### DIFF
--- a/docs/componenten/table/index.mdx
+++ b/docs/componenten/table/index.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Table
 pagination_label: Table
-description: UX richtlijnen voor Table component
+description: Toont en organiseert data in gestructureerde rijen en kolommen.
 slug: /table
 sidebar_custom_props:
   illustration: TableSketch
@@ -18,10 +18,10 @@ import { Backlog, DefinitionOfDone, Implementations, Introduction } from "../../
 import { Markdown } from "../../../src/components/Markdown";
 
 {/* Add name and description for the component */}
-export const title = "Paragraph";
-export const description = "Toont een alinea aan tekst.";
-export const illustration = "ParagraphSketch";
-export const issueNumber = 39;
+export const title = "Table";
+export const description = "Toont en organiseert data in gestructureerde rijen en kolommen.";
+export const illustration = "TableSketch";
+export const issueNumber = "";
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 


### PR DESCRIPTION
Blijkbaar stond er informatie over de Paragraph in de Table documentatie. Ik heb dit veranderd naar Table.

Het issueNumber moet alleen nog worden toegewezen. 