### PR TITLE
style: disable incorrect font-smoothing from Docusaurus

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -940,6 +940,12 @@ pre {
   margin-top: 0 !important;
 }
 
+.utrecht-document {
+  /* reset `font-smoothing: antialiasing`, prefer automatic (`subpixel-antialiasing`) behavior for high-dpi screens */
+  -webkit-font-smoothing: auto !important;
+  -moz-osx-font-smoothing: auto !important;
+}
+
 /* HACK: Persoonlijke Regelingen Assistent DonutChart */
 .pra-donutchart {
   border: none !important;


### PR DESCRIPTION
This used to be part of `utrecht-document`, but it appears to have been removed — accidentally?