### PR TITLE
WCAG: Wanneer te testen voor skiplinks aangepast

### DIFF
--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -17,7 +17,7 @@ import { Backlog, DefinitionOfDone, Implementations, Introduction } from "../../
 
 {/* Add name and description for the component */}
 export const title = "Skip link";
-export const description = "e mogelijkheid om content over te slaan en direct naar een onderdeel binnen pagina te navigeren.";
+export const description = "Biedt de mogelijkheid om content over te slaan en direct naar een onderdeel binnen pagina te navigeren.";
 export const illustration = "SkipLinkSketch";
 export const issueNumber = 74;
 

--- a/docs/wcag/2.4.1.mdx
+++ b/docs/wcag/2.4.1.mdx
@@ -127,7 +127,9 @@ WebAIM publiceert elk jaar de [<span lang="en">Screen Reader User Survey</span>]
 
 Bepaal eerst of er een skiplink nodig is. Als er bijvoorbeeld geen navigatieblokken bovenaan de webpagina staan en de pagina meteen met de hoofdinhoud begint is een skiplink zinloos.
 
-Als een skiplink wel zin heeft op een webpagina:
+Dit succescriteria gaat specifiek over blokken content die op elke pagina worden herhaald. Bevat de website maar één pagina, dan is dit succescriterium niet van toepassing. Wat niet wegneemt dat gebruik van een skiplink ook in dat geval gebruikersvriendelijk kan zijn.
+
+Als een skiplink van toepassing is voor een webpagina:
 
 - Controleer of een skiplink niet verborgen wordt met de CSS `display: none;` De skiplink moet voor screenreadergebruikers ook zonder focus te herkennen zijn in de lijst met links.
 - Controleer of een verborgen skiplink zichtbaar wordt op toetsenbordfocus.

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -86,7 +86,7 @@ Mooie tools om het kleurcontrast te testen en zo nodig een alternatief te kiezen
 
 Additionele testen:
 
-- de [skip link](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-skip-link--docs) wordt zichtbaar als deze toetsenbord krijgt.
+- de [skip link](/wcag/2.4.1) wordt zichtbaar als deze toetsenbord krijgt.
 - de outline (of het alternatief) is goed zichtbaar bij componenten met verschillende achtergrondkleuren, zoals bij een Page-header of footer.
 - de outline (of het alternatief) is goed zichtbaar in dark- en light-mode, als deze optie aangeboden wordt op de webpagina.
 

--- a/docs/wcag/2.4.7.mdx
+++ b/docs/wcag/2.4.7.mdx
@@ -51,7 +51,7 @@ Als in de CSS de outline is verwijderd (`outline: none;`), moet er een alternati
 
 Additionele testen:
 
-- de [skip link](https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-skip-link--docs) wordt zichtbaar als deze toetsenbord krijgt.
+- de [skip link](/wcag/2.4.1) wordt zichtbaar als deze toetsenbord krijgt.
 - de outline (of het alternatief) is goed zichtbaar in dark- en in light-mode, als deze optie aangeboden wordt op de webpagina.
 
 <WCAGFooterInfo />


### PR DESCRIPTION
Gerelateerd issue: #1064 
Preview: https://documentatie-git-wcag-skiplink-correction-nl-design-system.vercel.app/wcag/2.4.1

Ook een typo in de componentdescription over skiplinks aangepast en interne links naar deze wecag pagina toegevoegd.