### PR TITLE
Volgorde Candidate item in sidebar gewijzigd

### DIFF
--- a/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
@@ -3,7 +3,7 @@ title: Candidate stappenplan
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Candidate
-sidebar_position: 3
+sidebar_position: 4
 pagination_label: Candidate
 description: Stappen voor de Candidate fase van Definition of Done
 keywords:


### PR DESCRIPTION
De stap 'Community' vindt eerder plaats dan 'Candidate'. Daarom heb ik de volgorde aangepast.