### PR TITLE
Make checkboxes across sign up forms and component filter consistent

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,7 +37,6 @@
   --ifm-link-hover-color: currentColor;
   --utrecht-heading-2-margin-block-start: 32px;
   --utrecht-checkbox-size: 32px;
-  --utrecht-checkbox-checked-background-color: green;
   --utrecht-accordion-panel-padding-block-end: 24px;
   --utrecht-accordion-panel-padding-block-start: 0;
   --utrecht-accordion-panel-padding-inline-end: 16px;
@@ -157,8 +156,16 @@
   line-height: 1.4;
 }
 
-.utrecht-form-field--checkbox > p .utrecht-checkbox--custom.utrecht-checkbox--html-input:checked {
+.utrecht-form-field--checkbox > p input {
+  --utrecht-checkbox-size: 16px;
+  flex: none;
+}
+
+.utrecht-form-field--checkbox > p .utrecht-checkbox--custom.utrecht-checkbox--html-input:checked,
+.utrecht-form-field--checkbox > .utrecht-checkbox--custom.utrecht-checkbox--html-input:checked,
+.utrecht-custom-checkbox--html-input:checked {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='4' stroke-linecap='round' stroke-linejoin='round' %3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  background-size: 75%;
 }
 
 .utrecht-form-field--checkbox label {


### PR DESCRIPTION
(checkboxes on forms were stretched vertically because they were part of a flex context, this keeps them their original ratio, by removing their participation from the flex context)

with this PR, this is what the component filter checkboxes look like:

<img width="474" alt="Screenshot 2024-07-09 at 15 45 07" src="https://github.com/nl-design-system/documentatie/assets/178782/d5b14a8b-f1e2-4c5b-b566-b80d2451c84b">

and this is what the sign up form checkboxes look like:

<img width="191" alt="Screenshot 2024-07-09 at 15 46 08" src="https://github.com/nl-design-system/documentatie/assets/178782/b4655440-bcbe-46e7-abdc-485843f26740">
