### PR TITLE
refactor: move badge out of h1 of component page

### DIFF
--- a/src/components/ComponentPage.tsx
+++ b/src/components/ComponentPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardGroup } from './CardGroup';
 import style from './ComponentPage.module.css';
 import { ComponentProgress } from './ComponentProgress';
 import { EstafetteBadge } from './EstafetteBadge';
+import { InlineHeadingGroup } from './InlineHeadingGroup';
 import { TaskList, TaskListItem } from './TaskList';
 import { COMPONENT_STATES, getRelayBoardDescription, relayProjectIds, toKebabCase } from '../utils';
 
@@ -166,9 +167,9 @@ export const Introduction = ({ component, headingLevel, description }: Introduct
   return (
     component && (
       <>
-        <Heading level={headingLevel}>
-          {component.title} {relayStep && <EstafetteBadge state={relayStep} />}
-        </Heading>
+        <InlineHeadingGroup level={headingLevel} suffix={relayStep && <EstafetteBadge state={relayStep} />}>
+          {component.title}
+        </InlineHeadingGroup>
         <Paragraph lead>{description}</Paragraph>
       </>
     )

--- a/src/components/InlineHeadingGroup.module.css
+++ b/src/components/InlineHeadingGroup.module.css
@@ -1,0 +1,40 @@
+/* TODO: When SCSS is supported, use the mixins */
+/*
+@import "@utrecht/heading-1/src/mixin";
+@import "@utrecht/heading-2/src/mixin";
+@import "@utrecht/heading-3/src/mixin";
+@import "@utrecht/heading-4/src/mixin";
+@import "@utrecht/heading-5/src/mixin";
+@import "@utrecht/heading-6/src/mixin";
+
+.nlds-inline-heading-group--level-1 {
+   @include utrecht-heading-1
+}
+.nlds-inline-heading-group--level-2 {
+   @include utrecht-heading-2
+}
+.nlds-inline-heading-group--level-3 {
+   @include utrecht-heading-3
+}
+.nlds-inline-heading-group--level-4 {
+   @include utrecht-heading-4
+}
+.nlds-inline-heading-group--level-5 {
+   @include utrecht-heading-5
+}
+.nlds-inline-heading-group--level-6 {
+   @include utrecht-heading-6
+}
+*/
+
+.nlds-inline-heading-group__heading,
+.nlds-inline-heading-group__suffix {
+  display: inline;
+}
+
+.nlds-inline-heading-group__heading {
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  color: inherit;
+}

--- a/src/components/InlineHeadingGroup.tsx
+++ b/src/components/InlineHeadingGroup.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx';
+import React, { type PropsWithChildren, type ReactNode } from 'react';
+import style from './InlineHeadingGroup.module.css';
+
+export interface InlineHeadingGroupProps {
+  level?: number;
+  suffix?: ReactNode;
+}
+export const InlineHeadingGroup = ({ children, level = 1, suffix }: PropsWithChildren<InlineHeadingGroupProps>) => {
+  // TODO: When SCSS is supported, use style[`nlds-inline-heading-group--level-${level}`]
+  return (
+    <hgroup className={clsx(style['nlds-inline-heading-group'], `utrecht-heading-${level}`)}>
+      <h1 className={clsx(style['nlds-inline-heading-group__heading'])}>{children}</h1>
+      {suffix && (
+        <p className={clsx(style['nlds-inline-heading-group__suffix'])}>
+          {suffix ? ' ' : ''}
+          {suffix}
+        </p>
+      )}
+    </hgroup>
+  );
+};


### PR DESCRIPTION
<img width="384" alt="Screenshot 2024-07-09 at 22 50 14" src="https://github.com/nl-design-system/documentatie/assets/30694/f2f28e1f-640e-470f-bd4e-06d6f2a8af20">

refactor:

```html
<h1>Accordion <span>Todo</span></h1>
```

to:

```html
<hgroup>
  <h1>Accordion</h1>
  <p> <span>Todo</span></p>
</hgroup>
```