### PR TITLE
Voeg developer open hour toe en tweak die van designers

### DIFF
--- a/docs/community/events/design-open-hour/aanmelden.mdx
+++ b/docs/community/events/design-open-hour/aanmelden.mdx
@@ -11,9 +11,7 @@ import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
 
 # Meld je aan voor het Design Open Hour
 
-Design Open Hours zijn publiek toegankelijk. Laat je emailadres achter om op de hoogte te worden gehouden van toekomstige events.
-
-We nodigen je op dit emailadres dan ook uit voor de daadwerkelijke meeting.
+Design Open Hours zijn publiek toegankelijk via Slack. Laat je emailadres achter om op de hoogte te blijven.
 
 <NewsletterSignUp
   listId="iklwgql4w2"

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -34,9 +34,17 @@ Esther Erken & Aline van Thoor, designers bij PRA-Project, ICTU.
 
 Nico Druif, designer bij Gemeente Amsterdam.
 
-## Aanmelden
+## Ben je erbij?
 
-Deze sessies zijn publiek toegankelijk. [Meld je aan](/events/design-open-hour/aanmelden).
+Iedereen kan aansluiten!
+
+Het Design Open Hour vindt plaats in het `#nl-design-system-designers`-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
+
+Nog geen account in de Slack van Code for NL? [Meld je aan](https://praatmee.codefor.nl/).
+
+## Op de hoogte blijven
+
+[Laat je gegevens achter](/events/design-open-hour/aanmelden) om op de hoogte te blijven van Design Open Hours.
 
 ## Vragen of ideeën
 

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -16,7 +16,7 @@ slug: /events/design-open-hour
 
 Wees welkom bij het 2-wekelijkse (online) ‘Design Open Hour’. Een moment om kennis te delen door design gerelateerde vraagstukken met elkaar te bespreken. Maar ook het delen van work-in-progress, tips of interessante inzichten uit gebruikersonderzoek wordt gewaardeerd!
 
-In principe is er vooraf geen agenda. Deze stellen we aan het begin gezamenlijk op. Iedereen kan iets inbrengen. Soms staat het Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
+In principe is er vooraf geen agenda. Deze stellen we aan het begin gezamenlijk op (zie de [Canvas in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F07AVE99NU9)). Iedereen kan iets inbrengen. Soms staat het Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
 
 Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Design Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
 

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -44,7 +44,7 @@ Nog geen account in de Slack van Code for NL? [Meld je aan](https://praatmee.cod
 
 ## Op de hoogte blijven
 
-[Laat je gegevens achter](/events/design-open-hour/aanmelden) om op de hoogte te blijven van Design Open Hours.
+[Laat je gegevens achter](/events/design-open-hour/aanmelden) om op de hoogte te blijven van Design Open Hours. Je ontvangt dan ook direct een kalenderbestandje, zodat je het Design Open Hour makkelijk aan je agenda kan toevoegen.
 
 ## Vragen of ideeën
 

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -38,7 +38,7 @@ Nico Druif, designer bij Gemeente Amsterdam.
 
 Iedereen kan aansluiten!
 
-Het Design Open Hour vindt plaats in het `#nl-design-system-designers`-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
+Het Design Open Hour vindt plaats in het `[#nl-design-system-designers](https://codefornl.slack.com/archives/C01D78C2E4E)`-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
 
 Nog geen account in de Slack van Code for NL? [Meld je aan](https://praatmee.codefor.nl/).
 

--- a/docs/community/events/developer-open-hour/aanmelden-success.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden-success.mdx
@@ -1,0 +1,18 @@
+---
+title: Bedankt voor je aanmelding
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Aanmelden
+pagination_label: In het Developer Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+slug: /events/developer-open-hour/aanmelden/bedankt
+unlisted: true
+---
+
+# Bedankt!
+
+Je bent nu aangemeld voor onze wekelijkse Developer Open Hour.
+
+We hebben aparte events voor even weken (11:00 uur) en oneven weken (13:00 uur):
+
+- [Voeg even weken toe aan je kalender (.ics)](/developer-open-hour/developer-open-hour-even.ics)
+- [Voeg oneven weken toe aan je kalender (.ics)](/developer-open-hour/developer-open-hour-oneven.ics)

--- a/docs/community/events/developer-open-hour/aanmelden.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden.mdx
@@ -1,0 +1,22 @@
+---
+title: Aanmelden voor de Developer Open Hour
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Aanmelden
+pagination_label: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
+slug: /events/developer-open-hour/aanmelden
+---
+
+import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
+
+# Meld je aan voor het Developer Open Hour
+
+Developer Open Hours zijn publiek toegankelijk via Slack. Laat je emailadres achter om op de hoogte te blijven.
+
+<NewsletterSignUp
+  listId="p3jpgjmp4x"
+  emailFieldId="Cx3tegsyt2"
+  firstNameFieldId="QUBgX4085P"
+  thanksPage="https://nldesignsystem.nl/events/developer-open-hour/aanmelden/bedankt"
+  laPostaId="iyihtuzpiq"
+/>

--- a/docs/community/events/developer-open-hour/developer-open-hour.mdx
+++ b/docs/community/events/developer-open-hour/developer-open-hour.mdx
@@ -1,0 +1,35 @@
+---
+title: Developer Open Hour
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Developer Open Hour
+pagination_label: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
+description: Wat is Developer Open Hour?
+slug: /events/developer-open-hour
+---
+
+# Developer Open Hour
+
+## Over het Developer Open Hour
+
+Voor developers is er elke donderdag een Developer Open Hour. Op even weken is dit op 11:00 uur, op oneven weken om 13:00 uur.
+
+In principe is er vooraf geen agenda. Deze stellen we aan het begin gezamenlijk op. Iedereen kan iets inbrengen.
+
+Anders dan de [Heartbeat](../heartbeat/heartbeat), worden Developer Open Hours niet opgenomen.
+
+## Ben je erbij?
+
+Iedereen kan aansluiten! Wekelijks, of incidenteel, wanneer je vragen hebt of iets wilt bespreken.
+
+Het Developer Open Hour vindt plaats in het `#nl-design-system-developers`-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
+
+Nog geen account in de Code for NL Slack? [Meld je aan](https://praatmee.codefor.nl/).
+
+## Op de hoogte blijven
+
+[Laat je gegevens achter](/events/developer-open-hour/aanmelden) om op de hoogte te blijven van Developer Open Hours.
+
+## Vragen of ideeën
+
+Heb je vragen of ideeën voor het Developer Open Hour? Stuur ons dan een mailtje op <a href="mailto:kernteam@nldesignsystem.nl">kernteam@nldesignsystem.nl</a>

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -284,6 +284,21 @@ const sidebars: SidebarsConfig = {
                 { type: 'doc', id: 'community/events/design-open-hour/aanmelden' },
               ],
             },
+            {
+              type: 'category',
+              label: 'Developer Open Hour',
+              description:
+                'Tijdens het (online) Developer Open Hour delen developers van verschillende organisaties kennis.',
+              link: {
+                type: 'generated-index',
+                title: 'Developer Open Hour',
+                slug: '/events/developer-open-hour/overzicht',
+              },
+              items: [
+                { type: 'doc', id: 'community/events/developer-open-hour/developer-open-hour' },
+                { type: 'doc', id: 'community/events/developer-open-hour/aanmelden' },
+              ],
+            },
             { type: 'doc', id: 'community/events/design-open-dag' },
             { type: 'doc', id: 'community/events/estafettemodeldag' },
           ],


### PR DESCRIPTION
Deze PR voegt één nieuwe pagina toe: 

- [Developer Open Hour](https://documentatie-git-add-dev-open-hour-nl-design-system.vercel.app/events/developer-open-hour) met [subpagina voor aanmelden](https://documentatie-git-add-dev-open-hour-nl-design-system.vercel.app/events/developer-open-hour/aanmelden)

Deze PR wijzigt één pagina: 

- [Design Open Hour](https://documentatie-git-add-dev-open-hour-nl-design-system.vercel.app/events/design-open-hour): refereert nu aan Slack, legt uit hoe je op Slack komt, spreekt niet meer van toevoegen aan calender invites