### PR TITLE
docs: remove sidebar from form overview pages

### DIFF
--- a/docs/richtlijnen/formulieren/button/README.mdx
+++ b/docs/richtlijnen/formulieren/button/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Buttons in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie Buttons
 sidebar_position: 1
 pagination_label: Buttons in een formulier

--- a/docs/richtlijnen/formulieren/confirmation/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bevestigingspagina van een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie bevestigingspagina
 sidebar_position: 3
 pagination_label: Bevestigingspagina

--- a/docs/richtlijnen/formulieren/description/README.mdx
+++ b/docs/richtlijnen/formulieren/description/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Descriptions in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie descriptions
 sidebar_position: 4
 pagination_label: Descriptions in een formulier

--- a/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
+++ b/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schrijf een duidelijke foutmelding | Foutmeldingen in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Duidelijke foutmeldingen
 pagination_label: Duidelijke foutmeldingen
 description: Richtlijnen voor duidelijke foutmeldingen in een formulier.

--- a/docs/richtlijnen/formulieren/help/README.mdx
+++ b/docs/richtlijnen/formulieren/help/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Voorkom fouten in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie voorkom fouten
 sidebar_position: 13
 pagination_label: Voorkom fouten in een formulier

--- a/docs/richtlijnen/formulieren/keyboard-behaviour/README.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Toetsenbordnavigatie in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie toetsenbordnavigatie
 sidebar_position: 10
 pagination_label: Zorg dat het formulier werkt met een toetsenbord

--- a/docs/richtlijnen/formulieren/label/2-visible-acccessible-name/README.mdx
+++ b/docs/richtlijnen/formulieren/label/2-visible-acccessible-name/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: De zichtbare naam moet overeenkomen met de toegankelijke naam | Labels in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Zichtbare naam label
 pagination_label: Zichtbare naam label
 description: Richtlijnen voor zichtbare naam gelijk maken aan toegankelijke naam van formuliervelden.

--- a/docs/richtlijnen/formulieren/link/README.mdx
+++ b/docs/richtlijnen/formulieren/link/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Links in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie links
 sidebar_position: 7
 pagination_label: Links in een formulier

--- a/docs/richtlijnen/formulieren/multistep/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Meerdere stappen in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie meerdere stappen
 sidebar_position: 8
 pagination_label: Meerdere stappen

--- a/docs/richtlijnen/formulieren/placeholder/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Placeholders in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie placeholders
 sidebar_position: 9
 pagination_label: Placeholders in een formulier

--- a/docs/richtlijnen/formulieren/questions/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Uit te vragen informatie in een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie uit te vragen informatie
 sidebar_position: 11
 pagination_label: Uit te vragen informatie in een formulier

--- a/docs/richtlijnen/formulieren/visual-design/4-focus-visible/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/4-focus-visible/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Maak toetsenbord focus goed zichtbaar | Visueel ontwerp van een formulier | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Focus goed zichtbaar
 pagination_label: Focus goed zichtbaar
 description: Richtlijnen om met contrast duidelijk aan te geven welke formulierveld focus heeft.

--- a/docs/richtlijnen/formulieren/when-which/README.mdx
+++ b/docs/richtlijnen/formulieren/when-which/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: Wanneer gebruik je welk formulierelement? | Richtlijnen
 hide_title: true
-hide_table_of_contents: false
+hide_table_of_contents: true
 sidebar_label: Introductie wanneer welk element?
 sidebar_position: 14
 pagination_label: Wanneer gebruik je welk formulierelement


### PR DESCRIPTION
Ik denk dat het op de overview pages voor formulier richtlijnen niet logisch is dat we ook nog een table-of-contents hebben rechts. Mijn voorstel is dus om deze uit te zetten.

## Van
<img width="1142" alt="Screenshot 2024-08-05 at 09 27 04" src="https://github.com/user-attachments/assets/d40d0580-60c8-4597-94f7-a55c7148a9a4">

## Naar
<img width="1191" alt="Screenshot 2024-08-05 at 09 27 47" src="https://github.com/user-attachments/assets/04383413-745b-43fa-9840-7ba8c78d576a">
