### PR TITLE
Richtlijnen en WCAG-pagina's: check en aanpassen interne links en links naar WCAG na refactoring pagina's

### DIFF
--- a/docs/richtlijnen/formulieren/button/1-keyboard/_guideline.md
+++ b/docs/richtlijnen/formulieren/button/1-keyboard/_guideline.md
@@ -6,6 +6,6 @@ Veel gebruikers navigeren door een formulier met hun Tab-toets om van focusable 
 
 Krijgt een button de toetsenbordfocus, dan kan die met “enter” of “spatiebalk” worden geactiveerd. Zorg ervoor dat deze functionaliteit blijft werken als je een webcomponent bouwt, dit is standaard en verwacht gedrag van een button.
 
-Een consistente toetsenbordbediening is nodig om te voldoen aan het WCAG-succescriterium [2.1.1 Toetsenbord](/wcag/2.1.1) (niveau A).
+Een consistente toetsenbordbediening is nodig om te voldoen aan het [WCAG-succescriterium 2.1.1 Toetsenbord](/wcag/2.1.1) (niveau A).
 
-En ook volg je dan de WCAG-richtlijn [3.2 Voorspelbaar](https://www.w3.org/WAI/WCAG22/Understanding/predictable.html): maak het uiterlijk en de bediening van webpagina's voorspelbaar.
+En ook volg je dan de [WCAG-richtlijn 3.2 Voorspelbaar](https://www.w3.org/WAI/WCAG22/Understanding/predictable.html): maak het uiterlijk en de bediening van webpagina's voorspelbaar.

--- a/docs/richtlijnen/formulieren/button/2-submit/_guideline.md
+++ b/docs/richtlijnen/formulieren/button/2-submit/_guideline.md
@@ -10,4 +10,4 @@ Let wel: het gaat hier om het daadwerkelijk versturen van het formulier. Dus als
 
 Het updaten van bijvoorbeeld zoekresultaten waarbij alleen de **content** verandert valt hier niet onder. Bijvoorbeeld: alleen het aantal zoekresultaten verandert, maar je blijft op dezelfde pagina.
 
-Een formulier niet onverwacht versturen is nodig om te voldoen aan het WCAG-succescriterium [3.2.2 Bij Input](/wcag/3.2.2/) (niveau A).
+Een formulier niet onverwacht versturen is nodig om te voldoen aan het [WCAG-succescriterium 3.2.2 Bij Input](/wcag/3.2.2/) (niveau A).

--- a/docs/richtlijnen/formulieren/description/README.mdx
+++ b/docs/richtlijnen/formulieren/description/README.mdx
@@ -24,7 +24,7 @@ import FormFooterInfo from "../_form_footer_info.md";
 
 Bij een formulierveld kun je extra informatie plaatsen, met bijvoorbeeld uitleg over hoe een veld in te vullen, de eisen voor een wachtwoord, foutmeldingen of waarschuwingen.
 
-We geven deze extra informatie hier de verzamelnaam "descriptions", om aan te sluiten bij de term [“accessible description”](https://www.w3.org/TR/wai-aria-1.2/#dfn-accessible-description), die in toegankelijkheidsstandaarden wordt gebruikt.
+We geven deze extra informatie hier de verzamelnaam "descriptions", om aan te sluiten bij de term ["accessible description"](https://www.w3.org/TR/wai-aria-1.2/#dfn-accessible-description), die in toegankelijkheidsstandaarden wordt gebruikt.
 
 <OverviewPage excludeDocIDs={["richtlijnen/formulieren/description/README"]} />
 

--- a/docs/richtlijnen/formulieren/error/4-location/_guideline.md
+++ b/docs/richtlijnen/formulieren/error/4-location/_guideline.md
@@ -4,4 +4,4 @@
 
 Voor foutmeldingen geldt hetzelfde als voor descriptions: de beste locatie is boven het formulierveld. Bovendien moet de foutmelding `aria-describedby` gekoppeld zijn aan het formulierveld.
 
-Hoe dit te doen is beschreven bij de [richtlijnen over descriptions](/richtlijnen/formulieren/descriptions).
+Hoe dit te doen is beschreven bij de richtlijn [Plaats descriptions tussen label en formulierveld](/richtlijnen/formulieren/descriptions/plaatsing).

--- a/docs/richtlijnen/formulieren/error/5-no-native-validation/_guideline.md
+++ b/docs/richtlijnen/formulieren/error/5-no-native-validation/_guideline.md
@@ -16,7 +16,7 @@ Wanneer er voldoende tijd en kennis is, heeft het de voorkeur om zelf client-sid
 
 Om specifiek aan hulptechnologieën te communiceren dat een veld verplicht is, kan `aria-required` worden gebruikt. Als je alleen `aria-required` gebruikt, zal de browser niet zelf valideren of feedback geven.
 
-Het toegankelijk maken van foutmeldingen is nodig om te voldoen aan het WCAG-succescriterium [3.3.1 Foutidentificatie](/wcag/3.3.1/) (niveau A).
+Het toegankelijk maken van foutmeldingen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.1 Foutidentificatie](/wcag/3.3.1/) (niveau A).
 
 ### Progressive enhancement
 

--- a/docs/richtlijnen/formulieren/error/6-summary/_guideline.md
+++ b/docs/richtlijnen/formulieren/error/6-summary/_guideline.md
@@ -19,4 +19,4 @@ De constructie is als volgt:
 
 GOV.UK geeft hiervan enkele duidelijke voorbeelden op [<span lang="en">Components Error summary</span>](https://design-system.service.gov.uk/components/error-summary/).
 
-Duidelijke foutmeldingen zijn nodig om te voldoen aan het WCAG-succescriterium [3.3.1 Foutidentificatie](/wcag/3.3.1/) (niveau A).
+Duidelijke foutmeldingen zijn nodig om te voldoen aan het [WCAG-succescriterium 3.3.1 Foutidentificatie](/wcag/3.3.1/) (niveau A).

--- a/docs/richtlijnen/formulieren/error/7-feedback/_guideline.md
+++ b/docs/richtlijnen/formulieren/error/7-feedback/_guideline.md
@@ -66,4 +66,4 @@ Of:
 </head>
 ```
 
-Het geven van een beschrijvend `<title>`-element is nodig om te voldoen aan het WCAG-succescriterium [2.4.2 Paginatitel](/wcag/2.4.2) (niveau A).
+Het geven van een beschrijvend `<title>`-element is nodig om te voldoen aan het [WCAG-succescriterium 2.4.2 Paginatitel](/wcag/2.4.2) (niveau A).

--- a/docs/richtlijnen/formulieren/error/README.mdx
+++ b/docs/richtlijnen/formulieren/error/README.mdx
@@ -24,6 +24,8 @@ import FormFooterInfo from "../_form_footer_info.md";
 
 Gebruik duidelijke en goed getimede foutmeldingen en logische validatieregels. Als een veld niet goed is ingevuld, moet voor iedereen duidelijk zijn wat er niet klopt. Hoe help je de gebruiker het beste als deze onjuiste of onvolledige informatie invult?
 
+Lees ook onze blogpost [Toegankelijke foutmeldingen in formulieren](/blog/toegankelijke-foutmeldingen-formulieren), die stap voor stap ingaat op het voorkomen, aanduiden en het geven van hulp bij foutmeldingen in een formulier voor verschillende soorten gebruikers.
+
 <OverviewPage excludeDocIDs={["richtlijnen/formulieren/error/README"]} />
 
 ## Deze documentatie heeft nu een eigen pagina

--- a/docs/richtlijnen/formulieren/help/5-autocomplete/_guideline.md
+++ b/docs/richtlijnen/formulieren/help/5-autocomplete/_guideline.md
@@ -14,8 +14,8 @@ WCAG bevat een volledige [lijst van waarden voor autocomplete](https://www.w3.or
 
 Jules Ernst van 200 OK heeft van deze lijst een [Nederlandse interpretatie](https://www.200ok.nl/tips/autocomplete/) gemaakt.
 
-Belangrijk bij het gebruik van autocomplete is dat het label altijd zichtbaar moet blijven, de gebruiker moet weten of de juiste waarde in het juiste veld is ingevoerd. Zie hiervoor de [richtlijnen over labels](/richtlijnen/formulieren/labels).
+Belangrijk bij het gebruik van autocomplete is dat het label altijd zichtbaar moet blijven, de gebruiker moet weten of de juiste waarde in het juiste veld is ingevoerd. Zie hiervoor de richtlijn [Zorg ervoor dat het label altijd zichtbaar is](/richtlijnen/formulieren/labels/altijd-zichtbaar).
 
-Het gebruik van het juiste `autocomplete`-attribuut is nodig om te voldoen aan het WCAG-succescriterium [1.3.5 Identificeer het doel van de input](/wcag/1.3.5/) (niveau AA).
+Het gebruik van het juiste `autocomplete`-attribuut is nodig om te voldoen aan het [WCAG-succescriterium 1.3.5 Identificeer het doel van de input](/wcag/1.3.5/) (niveau AA).
 
 **Let op**: [aria-autocomplete](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) heeft een ander doel en ander gebruik dan autocomplete bij formuliervelden. `aria-autocomplete` wordt gebruikt in webcomponenten, bijvoorbeeld om aan te geven dat er suggesties zijn bij zoekresultaten.

--- a/docs/richtlijnen/formulieren/help/6-autofill/_guideline.md
+++ b/docs/richtlijnen/formulieren/help/6-autofill/_guideline.md
@@ -11,4 +11,4 @@ Het HTML-attribuut `autocomplete` maakt het voor de gebruiker makkelijker om al 
 
 Sommige waarden zijn onduidelijk of ontbreken voor Nederlandse toepassingen. Jules Ernst van 200 OK heeft een overzicht gemaakt van de beste manier om [autocomplete in Nederlandse formulieren](https://www.200ok.nl/tips/autocomplete/#dutch) toe te passen.
 
-Toevoegen van autocomplete aan de formuliervelden is nodig om te voldoen aan het WCAG-Succescriterium [1.3.5 Identificeer het doel van de input](/wcag/1.3.5/) (niveau AA).
+Toevoegen van autocomplete aan de formuliervelden is nodig om te voldoen aan het [WCAG-Succescriterium 1.3.5 Identificeer het doel van de input](/wcag/1.3.5/) (niveau AA).

--- a/docs/richtlijnen/formulieren/help/7-error-prevention/_guideline.md
+++ b/docs/richtlijnen/formulieren/help/7-error-prevention/_guideline.md
@@ -26,7 +26,7 @@ Bijvoorbeeld:
 
 Controleer tijdens het invullen de gegevens op invoerfouten en geef de gebruiker de mogelijkheid de gegevens te verbeteren.
 
-Een goede foutafhandeling tijdens het invullen van een formulier helpt de gebruiker fouten te voorkomen en te corrigeren. Lees hiervoor ook de [richtlijnen over foutmeldingen](/richtlijnen/formulieren/foutmeldingen/).
+Een goede foutafhandeling tijdens het invullen van een formulier helpt de gebruiker fouten te voorkomen en te corrigeren. Lees hiervoor ook de [richtlijnen over foutmeldingen](/richtlijnen/formulieren/foutmeldingen/) en onze blogpost [Toegankelijke foutmeldingen in formulieren](/blog/toegankelijke-foutmeldingen-formulieren).
 
 ## Bevestigd
 
@@ -34,7 +34,7 @@ Geef de gebruiker, voor inzending, de mogelijkheid om de ingevulde gegevens te l
 
 Bij een complex formulier en als er juridische, financiële of persoonlijke gegevens worden uitgevraagd, is het essentieel dat de gebruiker kan controleren of alles goed is ingevuld voor verzenden.
 
-Alles op een rij in de laatste stap van het formulier, met de mogelijkheid om nog correcties te maken. Dit staat uitgebreider beschreven in [Meerdere stappen in een formulier](https://nldesignsystem.nl/richtlijnen/formulieren/meerdere-stappen).
+Alles op een rij in de laatste stap van het formulier, met de mogelijkheid om nog correcties te maken. Dit staat uitgebreider beschreven in de richtlijn [Bied als laatste stap een opsomming aan van alle ingevoerde gegevens](/richtlijnen/formulieren/meerdere-stappen/samenvatting).
 
 Gebruikersonderzoek voor het [Contactformulier voor WMEBV](https://gebruikersonderzoeken.nl/docs/onderzoek-bekijken/wmebv/vng-online-formulieren) laat goed zien hoe belangrijk deze laatste stap is.
 
@@ -46,4 +46,4 @@ Voorbeelden van patronen in het NL Design System:
 - [Controlepagina](https://nldesignsystem.nl/voorbeelden/patronen/formulieren/controlepagina)
 - [Foutmeldingen](https://nldesignsystem.nl/voorbeelden/patronen/formulieren/foutmeldingen)
 
-Omkeerbaarheid, controle of bevestiging bij een formulier waarin om juridische, financiële of persoonlijke gegevens wordt gevraagd, is nodig om te voldoen aan het WCAG-succescriterium [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](/wcag/3.3.4/) (niveau AA).
+Omkeerbaarheid, controle of bevestiging bij een formulier waarin om juridische, financiële of persoonlijke gegevens wordt gevraagd, is nodig om te voldoen aan het [WCAG-succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](/wcag/3.3.4/) (niveau AA).

--- a/docs/richtlijnen/formulieren/label/1-accessible-name/README.mdx
+++ b/docs/richtlijnen/formulieren/label/1-accessible-name/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: Geef een formulierveld toegankelijke naam met een label | Labels in een formulier | Richtlijnen
+title: Geef een formulierveld een toegankelijke naam met een label | Labels in een formulier | Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Toegankelijke naam label

--- a/docs/richtlijnen/formulieren/label/1-accessible-name/_guideline.md
+++ b/docs/richtlijnen/formulieren/label/1-accessible-name/_guideline.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-# Geef een formulierveld toegankelijke naam met een label
+# Geef een formulierveld een toegankelijke naam met een label
 
 Elk formulierveld heeft een label nodig dat gekoppeld is aan het formulierveld met een `for`/`id` relatie. De labeltekst wordt dan de zogenaamde "toegankelijke naam" van het formulierveld.
 

--- a/docs/richtlijnen/formulieren/label/4-always-visible/_guideline.md
+++ b/docs/richtlijnen/formulieren/label/4-always-visible/_guideline.md
@@ -6,10 +6,10 @@ Waarom? Als het label verdwijnt bij het typen kan er verwarring ontstaan: wat mo
 
 De placeholder kan ook voor verwarring zorgen bij gebruikers. Is het al veld ingevuld? Zie het onderzoek [<span lang="en">Placeholders in Form Fields Are Harmful</span>](https://www.nngroup.com/articles/form-design-placeholders/) van de Nielsen Norman Group.
 
-Een label vertelt **wat** je moet invullen en een placeholder **hoe** je een formulierveld moet invullen. Voor een e-mailveld kan het label bijvoorbeeld “Jouw e-mailadres” zijn en de placeholder “naam@voorbeeld.com”.
+Een label vertelt **wat** je moet invullen en een placeholder **hoe** je een formulierveld moet invullen. Voor een e-mailveld kan het label bijvoorbeeld "Jouw e-mailadres" zijn en de placeholder "naam@voorbeeld.com".
 
 De **hoe** informatie kan ook in een description worden opgenomen, dan blijft deze informatie ook zichtbaar tijdens het invullen.
 
 Een andere reden om een label niet te verbergen is om beter te kunnen controleren of alles goed is ingevuld met autocomplete.
 
-Namen, adressen en telefoonnummers kunnen automatisch vooraf worden ingevuld door de browser. Wanneer het label verborgen is, moet de gebruiker controleren of elke waarde juist is ingevuld bij het goede formulierveld. Dat is veel gemakkelijker als het label altijd zichtbaar is.
+Namen, adressen en telefoonnummers kunnen automatisch vooraf worden ingevuld door de browser. Wanneer het label verborgen is, moet de gebruiker controleren of elke waarde juist is ingevuld bij het goede formulierveld. Dat is veel gemakkelijker, als het label altijd zichtbaar is.

--- a/docs/richtlijnen/formulieren/link/2-not-in-label/_guideline.md
+++ b/docs/richtlijnen/formulieren/link/2-not-in-label/_guideline.md
@@ -6,8 +6,8 @@ Een link in een label wordt vaak gebruikt bij het accepteren van bijvoorbeeld he
 
 Dit is om twee redenen geen goede constructie:
 
-- Een label kan [geen links of buttons elementen](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#accessibility_concerns) bevatten. Lees hierover meer in de [richtlijnen over Labels](/richtlijnen/formulieren/labels).
-- Screenreaders kunnen struikelen over de combinatie “label en link” en lezen daardoor het label niet goed voor.
+- Een label kan [geen links of buttons elementen](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#accessibility_concerns) bevatten. Lees hierover meer in de richtlijn [Zet alleen tekst in het label](/richtlijnen/formulieren/labels/alleen-tekst).
+- Screenreaders kunnen struikelen over de combinatie "label en link" en lezen daardoor het label niet goed voor.
 
 Bijvoorbeeld:
 Een checkbox met in het label "Ik ga akkoord met het privacybeleid", en de tekst privacybeleid is ook een link.

--- a/docs/richtlijnen/formulieren/link/3-in-new-tab/_guideline.md
+++ b/docs/richtlijnen/formulieren/link/3-in-new-tab/_guideline.md
@@ -14,7 +14,7 @@ Het aangeven kan op verschillende manieren: via een icoontje, via tekst en via e
 
 Zorg dat de informatie over het openen van een nieuwe tab in de linktekst zelf is opgenomen. Dan wordt deze voorgelezen zodra de link focus krijgt. Als de tekst buiten (achter) de link staat bestaat de kans dat een screenreadergebruiker deze info mist.
 
-Hiermee volg je de WCAG-richtlijn [3.2 Voorspelbaar](https://www.w3.org/Translations/WCAG22-nl/#voorspelbaar): maak het uiterlijk en de bediening van webpagina's voorspelbaar.
+Hiermee volg je de [WCAG-richtlijn 3.2 Voorspelbaar](https://www.w3.org/Translations/WCAG22-nl/#voorspelbaar): maak het uiterlijk en de bediening van webpagina's voorspelbaar.
 
 ## Technieken voor een link openen in een nieuwe tab of venster
 

--- a/docs/richtlijnen/formulieren/multistep/2-location/_guideline.md
+++ b/docs/richtlijnen/formulieren/multistep/2-location/_guideline.md
@@ -2,7 +2,7 @@
 
 # Plaats de informatie over waar de gebruiker is in de stappen boven het formulier
 
-Plaats tekst en uitleg die hoort bij het formulier buiten het `<form>` element. Dus zet informatie over de stappen **boven** en niet **binnen** het `<form>` element. Dan is de kans dat screenreadergebruikers deze informatie missen het kleinst. Het waarom staat uitgelegd bij de [richtlijnen over descriptions](/richtlijnen/formulieren/alle-richtlijnen/descriptions).
+Plaats tekst en uitleg die hoort bij het formulier buiten het `<form>` element. Dus zet informatie over de stappen **boven** en niet **binnen** het `<form>` element. Dan is de kans dat screenreadergebruikers deze informatie missen het kleinst. Het waarom staat uitgelegd bij de richtlijn [Koppel een description aan het formulierveld](/richtlijnen/formulieren/descriptions/koppelen).
 
 Het voordeel van een formulier in meer stappen is, dat je makkelijker uitgebreide informatie per stap kunt toevoegen **boven** het formulier. Dat scheelt de complexiteit van eventueel gebruik van ARIA om tekst te laten voorlezen bij een formulierveld.
 

--- a/docs/richtlijnen/formulieren/placeholder/1-label/_guideline.md
+++ b/docs/richtlijnen/formulieren/placeholder/1-label/_guideline.md
@@ -8,4 +8,4 @@ Gebruik dus niet enkel de placeholder om aan te geven wat een gebruiker moet inv
 
 Een ander probleem met placeholders is dat bij inzoomen lange tekst te groot kan worden voor het formulierveld en daardoor afhakt en onleesbaar wordt.
 
-Het permanent goed zichtbaar tonen van het label is nodig om te voldoen aan het [WCAG-succescriterium 3.3.2 Labels of instructies](/wcag/3.3.2) (niveau A). Meer hierover bij de [richtlijnen over labels](/richtlijnen/formulieren/links).
+Het permanent goed zichtbaar tonen van het label is nodig om te voldoen aan het [WCAG-succescriterium 3.3.2 Labels of instructies](/wcag/3.3.2) (niveau A). Meer hierover bij de richtlijn [Zorg ervoor dat het label altijd zichtbaar is](/richtlijnen/formulieren/placeholders/niet-als-label).

--- a/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
+++ b/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
@@ -9,4 +9,4 @@ Als het essentieel is dat de informatie correct is, zijn er deze alternatieven:
 - toon dan voor het verzenden nog eens de invoer, bijvoorbeeld op een controlepagina;
 - (als het om een e-mailadres gaat) stuur een e-mail ter bevestiging om de juistheid van het e-mailadres te controleren.
 
-Gegevens niet meerdere keren binnen een formulier uit vragen is nodig om te voldoen aan het [WCAG-succescriterium [3.3.7 Overbodige Invoer](wcag/3.3.7) (niveau A).
+Gegevens niet meerdere keren binnen een formulier uit vragen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.7 Overbodige Invoer](wcag/3.3.7) (niveau A).

--- a/docs/richtlijnen/formulieren/visual-design/1-field-contrast/_guideline.md
+++ b/docs/richtlijnen/formulieren/visual-design/1-field-contrast/_guideline.md
@@ -6,4 +6,4 @@ Gebruikers moeten herkennen waar en hoe groot het invoerveld, radiobutton of che
 
 Het kleurcontrast van de randen (borders) ten opzichte van de achtergrondkleur moet daarom 3:1 of hoger zijn.
 
-Het duidelijk aangeven van een invoerveld is nodig om te voldoen aan het WCAG-succescriterium [1.1.1 Niet-tekstuele content](/wcag/1.1.1/) (niveau AA).
+Het duidelijk aangeven van een invoerveld is nodig om te voldoen aan het [WCAG-succescriterium 1.1.1 Niet-tekstuele content](/wcag/1.1.1/) (niveau AA).

--- a/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/_guideline.md
+++ b/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/_guideline.md
@@ -4,4 +4,4 @@
 
 Ook het kleurcontrast van de tekst van placeholders ten opzichte van de achtergrondkleur moet 4.5:1 of hoger zijn.
 
-**Let op**: sommige browsers geven een placeholder lichter weer dan in de CSS is bepaald. Dit wordt verder uitgelegd bij de [richtlijnen over placeholders](/richtlijnen/formulieren/placeholders).
+**Let op**: sommige browsers geven een placeholder lichter weer dan in de CSS is bepaald. Dit wordt verder uitgelegd bij de richtlijn [Zorg voor een goed kleurcontrast van de placeholdertekst](/richtlijnen/formulieren/placeholders/kleurcontrast).

--- a/docs/richtlijnen/formulieren/visual-design/7-no-image-buttons/_guideline.md
+++ b/docs/richtlijnen/formulieren/visual-design/7-no-image-buttons/_guideline.md
@@ -6,4 +6,4 @@ Zorg ervoor dat tekst in buttons goed meeschaalt als de gebruiker inzoomt. Een g
 
 Gebruik daarom liever geen jpg-, gif- of png-bestanden voor buttontekst maar stijl tekst met CSS.
 
-Deze richtlijn is verder beschreven bij de richtlijnen over [Buttons](/richtlijnen/formulieren/buttons).
+Deze richtlijn is verder beschreven bij [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button).

--- a/docs/richtlijnen/formulieren/visual-design/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/README.mdx
@@ -22,6 +22,8 @@ import FormFooterInfo from "../_form_footer_info.md";
 
 # Visueel ontwerp van een formulier
 
+Waarmee moet je als (UX-)designer rekening houden bij het ontwerpen van een toegankelijk en gebruikersvriendelijke formulier.
+
 <OverviewPage excludeDocIDs={["richtlijnen/formulieren/visual-design/README"]} />
 
 ## Deze documentatie heeft nu een eigen pagina

--- a/docs/wcag/1.1.01.mdx
+++ b/docs/wcag/1.1.01.mdx
@@ -32,7 +32,7 @@ import Summary from "./summaries/_1.1.1-summary.md";
 ## Gerelateerde NL Design System-richtlijnen
 
 - Stijl: [Iconen](/richtlijnen/stijl/iconen).
-- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/alle-richtlijnen/buttons).
+- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam).
 
 ## Bronnen
 

--- a/docs/wcag/1.3.01.mdx
+++ b/docs/wcag/1.3.01.mdx
@@ -33,7 +33,7 @@ Bijvoorbeeld:
 
 - Als tekst er uitziet als een kopje, moet dit ook in de HTML een kopje (heading) zijn en geen vet gemaakte tekst. Het kopjesniveau wordt voorgelezen door screenreaders.
 - Als informatie in een tabel staat, moet de informatie begrijpbaar zijn voor screenreadersgebruikers, door het gebruik van table headings (th’s). De table heading wordt voorgelezen bij de waarde van een bijbehorende table cell.
-- In een formulier moeten invoervelden en labels aan elkaar gekoppeld zijn met een [for/id-relatie](https://nldesignsystem.nl/richtlijnen/formulieren/labels#geef-een-formulierveld-toegankelijke-naam-met-een-label). Dan wordt het label voorgelezen als het invoerveld de focus krijgt.
+- In een formulier moeten invoervelden en labels aan elkaar gekoppeld zijn met een [for/id-relatie](/richtlijnen/formulieren/labels/toegankelijke-naam). Dan wordt het label voorgelezen als het invoerveld de focus krijgt.
 - Staan gegevens in een lijst, gebruik dan ook in de HTML een lijst (ul) en niet alleen streepjes voor de items. Een screenreader leest dan voor dat het een lijst is, hoeveel items er zijn in de lijst en bij welk item de lezer zich op dat moment bevindt.
 - Gebruik je een afbeelding om informatie te geven, zorg er dan voor dat de alternatieve tekst van de afbeelding de juiste informatie bevat, of voeg de informatie vlakbij de afbeelding in tekst toe.
 
@@ -41,10 +41,10 @@ Geef via de juiste HTML of alternatieve teksten betekenis aan structuur, relatie
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons#de-toegankelijke-naam-van-een-button).
-- Formulieren - Labels: [Geef een formulierveld toegankelijke naam met een label](/richtlijnen/formulieren/labels#geef-een-formulierveld-toegankelijke-naam-met-een-label).
-- Formulieren - Foutmeldingen: [Schrijf een foutmelding uit in tekst](/richtlijnen/formulieren/foutmeldingen#schrijf-een-foutmelding-uit-in-tekst).
-- Formulieren - Bevestigingspagina: [Maak de succesmelding toegankelijk voor alle gebruikers](https://nldesignsystem.nl/richtlijnen/formulieren/bevestigingspagina/#maak-de-succesmelding-toegankelijk-voor-alle-gebruikers).
+- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam).
+- Formulieren - Labels: [Geef een formulierveld toegankelijke naam met een label](/richtlijnen/formulieren/labels/toegankelijke-naam).
+- Formulieren - Foutmeldingen: [Schrijf een foutmelding uit in tekst](/richtlijnen/formulieren/foutmeldingen/beschrijven).
+- Formulieren - Bevestigingspagina: [Maak de succesmelding toegankelijk voor alle gebruikers](/richtlijnen/formulieren/bevestigingspagina/toegankelijke-succesmelding).
 
 ## Gebruikersonderzoek
 

--- a/docs/wcag/1.3.05.mdx
+++ b/docs/wcag/1.3.05.mdx
@@ -29,9 +29,9 @@ import Summary from "./summaries/_1.3.5-summary.md";
 
 <Summary />
 
-## Gerelateerde NL Design System-richtlijnen
+## Gerelateerde NL Design System-richtlijn
 
-- Formulieren: [Autocomplete](/richtlijnen/formulieren/autocomplete).
+Formulieren - Voorkom fouten: [Autocomplete](/richtlijnen/formulieren/voorkom-fouten/autocomplete).
 
 ## Bronnen
 

--- a/docs/wcag/2.1.01.mdx
+++ b/docs/wcag/2.1.01.mdx
@@ -32,12 +32,12 @@ import Summary from "./summaries/_2.1.1-summary.md";
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Toetsenbord: [Zorg dat het formulier werkt met een toetsenbord](/richtlijnen/formulieren/alle-richtlijnen/toetsenbord).
-- Formulieren - Toetsenbord: [Gebruik geen positieve tabindex](/richtlijnen/formulieren/alle-richtlijnen/toetsenbord).
-- Formulieren - Buttons: [Toetsenbordbediening van een button](/richtlijnen/formulieren/alle-richtlijnen/buttons).
-- Formulieren - Buttons: [Disabled submitbuttons](/richtlijnen/formulieren/alle-richtlijnen/buttons).
-- Formulieren - Foutmeldingen: [Zet een samenvatting van de foutmeldingen boven het formulier](/richtlijnen/formulieren/alle-richtlijnen/foutmeldingen).
-- Formulieren - Wanneer gebruik je welk formulierelement: [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](/richtlijnen/formulieren/alle-richtlijnen/wanneer-welk-form-element).
+- Formulieren - Toetsenbord: [Zorg dat het formulier werkt met een toetsenbord](/richtlijnen/formulieren/toetsenbord/).
+- Formulieren - Toetsenbord: [Gebruik geen positieve tabindex](/richtlijnen/formulieren/toetsenbord/tabindex).
+- Formulieren - Buttons: [Toetsenbordbediening van een button](/richtlijnen/formulieren/buttons/toetsenbordbediening).
+- Formulieren - Buttons: [Disabled submitbuttons](/richtlijnen/formulieren/buttons/disabled-submitbuttons).
+- Formulieren - Foutmeldingen: [Zet een samenvatting van de foutmeldingen boven het formulier](/richtlijnen/formulieren/foutmeldingen/samenvatting).
+- Formulieren - Wanneer gebruik je welk formulierelement: [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](/richtlijnen/formulieren/wanneer-welk-form-element/iedereen-kan-invullen).
 
 ## Bronnen
 

--- a/docs/wcag/2.4.02.mdx
+++ b/docs/wcag/2.4.02.mdx
@@ -45,9 +45,9 @@ Voorbeelden van goede titels:
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Meerdere stappen: [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](/richtlijnen/formulieren/meerdere-stappen#geef-duidelijk-aan-wanneer-het-formulier-verzonden-gaat-worden).
-- Formulieren - Foutmeldingen: [Geef feedback aan screenreadergebruikers](/richtlijnen/formulieren/foutmeldingen#geef-feedback-aan-screenreadergebruikers).
-- Formulieren - Bevestigingspagina: [Maak de succesmelding toegankelijk voor alle gebruikers](/richtlijnen/formulieren/bevestigingspagina#maak-de-succesmelding-toegankelijk-voor-alle-gebruikers).
+- Formulieren - Meerdere stappen: [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](/richtlijnen/formulieren/meerdere-stappen/voortgang-tonen).
+- Formulieren - Foutmeldingen: [Geef feedback aan screenreadergebruikers](/richtlijnen/formulieren/foutmeldingen/screenreaderfeedback).
+- Formulieren - Bevestigingspagina: [Maak de succesmelding toegankelijk voor alle gebruikers](/richtlijnen/formulieren/bevestigingspagina/toegankelijke-succesmelding).
 
 ## Gebruikersonderzoek
 

--- a/docs/wcag/2.4.06.mdx
+++ b/docs/wcag/2.4.06.mdx
@@ -60,8 +60,8 @@ De richtlijnen over [Labels](/richtlijnen/formulieren/labels) en [Voorkom fouten
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - [Labels](/richtlijnen/formulieren/labels)
-- Formulieren - [Voorkom fouten](/richtlijnen/formulieren/voorkom-fouten)
+- Formulieren: [Labels](/richtlijnen/formulieren/labels).
+- Formulieren: [Voorkom fouten](/richtlijnen/formulieren/voorkom-fouten).
 
 ## Bronnen
 

--- a/docs/wcag/2.4.07.mdx
+++ b/docs/wcag/2.4.07.mdx
@@ -32,9 +32,9 @@ import Summary from "./summaries/_2.4.7-summary.md";
 
 **Let op**: voor het NL Design System willen we ook voldoen aan het WCAG-succescriterium [2.4.13 Focusweergave](/wcag/2.4.13) (niveau AAA), dat eisen stelt aan de weergave en het kleurcontrast van de focusring. Dit staat beschreven bij de richtlijn [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren//visueel-ontwerp/#maak-toetsenbord-focus-goed-zichtbaar). Het [intact houden van de browser-outline](https://www.w3.org/WAI/WCAG22/Techniques/general/G149.html) is voldoende voor WCAG-succescriterium 2.4.7 (versie 2.2 niveau AA) maar in de praktijk is die focusring niet voldoende duidelijk in alle situaties.
 
-## Gerelateerde NL Design System-richtlijnen
+## Gerelateerde NL Design System-richtlijn
 
-Formulieren - Visueel Ontwerp: [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren//visueel-ontwerp/#maak-toetsenbord-focus-goed-zichtbaar).
+Formulieren - Visueel Ontwerp: [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar).
 
 ## Bronnen
 

--- a/docs/wcag/2.4.10.mdx
+++ b/docs/wcag/2.4.10.mdx
@@ -84,8 +84,8 @@ In het artikel [<span lang="en">Accessible heading structure</span>](https://www
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Foutmeldingen: [Zet een samenvatting van de foutmeldingen boven het formulier](https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen#zet-een-samenvatting-van-de-foutmeldingen-boven-het-formulier).
-- Formulieren - Meer stappen: [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](https://nldesignsystem.nl/richtlijnen/formulieren/meerdere-stappen#geef-aan-hoeveel-stappen-er-zijn-en-in-welke-stap-de-gebruiker-zich-bevindt).
+- Formulieren - Foutmeldingen: [Zet een samenvatting van de foutmeldingen boven het formulier](/richtlijnen/formulieren/foutmeldingen/samenvatting).
+- Formulieren - Meer stappen: [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](/richtlijnen/formulieren/meerdere-stappen/voortgang-tonen).
 
 ## Bronnen
 

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -35,8 +35,8 @@ Het intact laten van de standaard outline die door een browser wordt geleverd is
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Visueel ontwerp: [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp).
-- Formulieren- Toetsenbord: [Zorg dat het formulier werkt met een toetsenbord](/richtlijnen/formulieren/visueel-ontwerp#maak-toetsenbord-focus-goed-zichtbaar).
+- Formulieren - Visueel ontwerp: [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar).
+- Formulieren- Toetsenbord: [Zorg dat het formulier werkt met een toetsenbord](/richtlijnen/formulieren/toetsenbord).
 
 ## Bronnen
 

--- a/docs/wcag/3.2.02.mdx
+++ b/docs/wcag/3.2.02.mdx
@@ -32,7 +32,7 @@ import Summary from "./summaries/_3.2.2-summary.md";
 ## Gerelateerde NL Design System-richtlijn
 
 Formulieren - Buttons:
-[Verstuur een formulier niet automatisch na het wijzigen of invullen van een formulierveld](/richtlijnen/formulieren/buttons/verstuur-een-formulier-niet-automatisch-na-het-wijzigen-of-invullen-van-een-formulierveld)
+[Verstuur een formulier niet automatisch na het wijzigen of invullen van een formulierveld](/richtlijnen/formulieren/buttons/niet-automatisch-versturen).
 
 ## Gebruikersonderzoek
 

--- a/docs/wcag/3.3.01.mdx
+++ b/docs/wcag/3.3.01.mdx
@@ -31,8 +31,8 @@ import Summary from "./summaries/_3.3.1-summary.md";
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- [Foutmeldingen](https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen).
-- [Descriptions](https://nldesignsystem.nl/richtlijnen/formulieren/descriptions): Meerdere descriptions koppelen.
+- Formulieren: [Foutmeldingen](/richtlijnen/formulieren/foutmeldingen).
+- Formulieren: [Descriptions](/richtlijnen/formulieren/descriptions).
 
 ## Bronnen
 
@@ -45,6 +45,7 @@ Op GOV.UK:
 
 Overige bronnen:
 
+- [Toegankelijke foutmeldingen in formulieren](/blog/toegankelijke-foutmeldingen-formulieren), op het blog van het NL Design System.
 - [<span lang="en">The problem with live validation and what to do instead van Adam Silver</span>](https://adamsilver.io/blog/the-problem-with-live-validation-and-what-to-do-instead/) van Adam Silver.
 - [<span lang="en">Avoid Default Field Validation</span>](https://adrianroselli.com/2019/02/avoid-default-field-validation.html) van Adrian Roselli.
 
@@ -57,7 +58,7 @@ Overige bronnen:
 
 ## Hoe te testen
 
-Dit is een samenvatting van [Foutmeldingen in een formulier](https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen).
+Dit is een samenvatting van de richtlijnen in [Foutmeldingen in een formulier](/richtlijnen/formulieren/foutmeldingen).
 
 Controleer het formulier op foutmeldingen:
 

--- a/docs/wcag/3.3.03.mdx
+++ b/docs/wcag/3.3.03.mdx
@@ -31,8 +31,8 @@ import Summary from "./summaries/_3.3.3-summary.md";
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- [Foutmeldingen](https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen).
-- [Descriptions](https://nldesignsystem.nl/richtlijnen/formulieren/descriptions): Meerdere descriptions koppelen.
+- Formulieren: [Foutmeldingen](/richtlijnen/formulieren/foutmeldingen).
+- Formulieren: [Descriptions](/richtlijnen/formulieren/descriptions).
 
 ## Bronnen
 
@@ -44,6 +44,7 @@ Op GOV.UK:
 
 Overige bronnen:
 
+- [Toegankelijke foutmeldingen in formulieren](/blog/toegankelijke-foutmeldingen-formulieren), op het blog van het NL Design System.
 - [<span lang="en">Error-Message Guidelines</span>](https://www.nngroup.com/articles/error-message-guidelines/) van de Nielsen Norman Group.
 
 ## Gebruikersonderzoek

--- a/docs/wcag/3.3.04.mdx
+++ b/docs/wcag/3.3.04.mdx
@@ -29,9 +29,9 @@ import Summary from "./summaries/_3.3.4-summary.md";
 
 <Summary />
 
-## Gerelateerde NL Design System-richtlijnen
+## Gerelateerde NL Design System-richtlijn
 
-- [Foutmeldingen](https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen).
+Foutmeldingen: [Foutmeldingen](/richtlijnen/formulieren/foutmeldingen).
 
 ## Bronnen
 

--- a/docs/wcag/4.1.02.mdx
+++ b/docs/wcag/4.1.02.mdx
@@ -126,7 +126,7 @@ Bijvoorbeeld bij het menu, als de huidige pagina voor de contactpagina is, in co
 </ul>
 ```
 
-En om aan te geven in welke stap de gebruiker is in een .
+En om aan te geven in welke stap de gebruiker is in een meerstappenformulier:
 
 ```html
 <ul>
@@ -137,7 +137,7 @@ En om aan te geven in welke stap de gebruiker is in een .
 ```
 
 Het voordeel hiervan is ook dat je CSS aan aria-current states kunt toekennen.
-Je hebt dan geen speciale 'active" CSS-class meer nodig.
+Je hebt dan geen speciale "active" CSS-class meer nodig.
 
 In CSS:
 
@@ -151,9 +151,9 @@ Dus in plaats van alleen visueel de state aan te geven met bijvoorbeeld `class="
 
 ## Gerelateerde NL Design System-richtlijnen
 
-- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons#de-toegankelijke-naam-van-een-button).
-- Formulieren - Labels: [Geef een formulierveld toegankelijke naam met een label](/richtlijnen/formulieren/labels#geef-een-formulierveld-toegankelijke-naam-met-een-label).
-- Formulieren - Wanneer gebruik je welk formulierelement: [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](/richtlijnen/formulieren//wanneer-welk-form-element#zorg-dat-iedereen-een-formulierelement-kan-bedienen-of-geef-een-alternatief)
+- Formulieren - Buttons: [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam).
+- Formulieren - Labels: [Geef een formulierveld toegankelijke naam met een label](/richtlijnen/formulieren/labels/toegankelijke-naam).
+- Formulieren - Wanneer gebruik je welk formulierelement: [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](/richtlijnen/formulieren/wanneer-welk-form-element/iedereen-kan-invullen).
 
 ## Gebruikersonderzoek
 


### PR DESCRIPTION
- Interne links rechtstreeks naar een richtlijn aangepast.
- De linktekst naar de WCAG-pagina's bevat nu ook de tekst WCAG-succescriterium.
