### PR TITLE
fix: lint-staged

### DIFF
--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   // Automatically add Prettier fixes to the commit as long as there are no errors
   '*': ['prettier --write'],
-  '*.{js,cjs,mjs,jsx,ts,tsx,mdx}': ['eslint'],
-  'package.json': ['npmPkgJsonLint'],
+  '*.{js,cjs,mjs,jsx,ts,tsx,mdx}': ['eslint --no-error-on-unmatched-pattern'],
+  'package.json': ['npmPkgJsonLint --allowEmptyTargets'],
 };


### PR DESCRIPTION
Make sure eslint and npm-pkg-json-lint still work if files that are commit are ignored by .eslintignore or .npmpkgjsonlintignore