### PR TITLE
WCAG-pagina's: Summary 1.4.8 Visuele weergave

### DIFF
--- a/.changeset/wcag-1.4.8-summary.md
+++ b/.changeset/wcag-1.4.8-summary.md
@@ -2,4 +2,4 @@
 "@nl-design-system-unstable/documentation": minor
 ---
 
-Samenvatting toegevoegd voor het [WCAG-succescriterium 1.4.8 Viseule weergave](/wcag/1.4.8).
+Samenvatting toegevoegd voor het [WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8).

--- a/.changeset/wcag-1.4.8-summary.md
+++ b/.changeset/wcag-1.4.8-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 1.4.8 Viseule weergave](/wcag/1.4.8).

--- a/docs/componenten/paragraph/_guidelines.md
+++ b/docs/componenten/paragraph/_guidelines.md
@@ -38,11 +38,11 @@ Voor de lead paragraph variant is het gebruikelijk de lettergrootte 10% á 20% g
 
 ### Regelhoogte {#regelhoogte}
 
-Stel de regelhoogte met `nl.paragraph.line-height` in voor voldoende afstand tussen tekstregels, dit verbetert de leesbaarheid. Standaard gebruiken browsers circa `1.2`, maar `1.5` is voor veel gebruikers beter leesbaar. Voor WCAG 1.4.8 is het ook belangrijk om `1.5` of groter aan te bieden.
+Stel de regelhoogte met `nl.paragraph.line-height` in voor voldoende afstand tussen tekstregels, dit verbetert de leesbaarheid. Standaard gebruiken browsers circa `1.2`, maar `1.5` is voor veel gebruikers beter leesbaar. Voor het [WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8) is het ook belangrijk om `1.5` of groter aan te bieden.
 
 ### Afstand tussen alinea's {#afstand-tussen-alineas}
 
-Kies voldoende afstand tussen alinea's, in elk geval 50% groter dan afstand tussen tekstregels. ([WCAG-succescriterium 1.4.8 Visuele weergave](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html)). Gebruik hiervoor de design tokens `nl.paragraph.margin-block-start` en `nl.paragraph.margin-block-end`.
+Kies voldoende afstand tussen alinea's, in elk geval 50% groter dan afstand tussen tekstregels. Gebruik hiervoor de design tokens `nl.paragraph.margin-block-start` en `nl.paragraph.margin-block-end`.
 
 ### Kleurgebruik {#kleurgebruik}
 
@@ -57,13 +57,13 @@ Zie de WCAG-succescriteria:
 
 Zorg dat de lengte van de tekst niet te lang wordt, bijvoorbeeld door deze design token in te stellen: `nl.article.max-inline-size`. De ideale regellengte verschilt per schrift en taal, maar ergens tussen de 50 en 75 tekens voor Nederlands is prima. Je kunt in CSS bijvoorbeeld de `ch` eenheid gebruiken: `--nl-article-max-inline-size: 60ch`.
 
-Voor het [WCAG-succescriterium 1.4.8 Visuele weergave](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) is het nodig dat de regellengte beperkt kan worden tot maximaal 80 tekens (`80ch`), bijvoorbeeld door de viewport van de browser kleiner te maken.
+Voor het [WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8) is het nodig dat de regellengte beperkt kan worden tot maximaal 80 tekens (`80ch`), bijvoorbeeld door de viewport van de browser kleiner te maken.
 
 ### Tekstuitlijning {#tekstuitlijning}
 
 Tekst dient uitsluitend links uitgelijnd zijn, voor Nederlandse teksten. Gebruik daarvoor `text-align: start`.
 
-`text-align: justify` moet vermeden kunnen worden volgens het [WCAG-succescriterium 1.4.8 Visuele weergave](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html), dus gebruik deze voor het gemak helemaal niet. Rechts uitlijnen en tekst centreren moet je ook niet gebruiken voor lopende tekst.
+`text-align: justify` moet vermeden kunnen worden volgens het [WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8), dus gebruik deze voor het gemak helemaal niet. Rechts uitlijnen en tekst centreren moet je ook niet gebruiken voor lopende tekst.
 
 ## Hoe het niet moet {#hoe-het-niet-moet}
 

--- a/docs/richtlijnen/stijl/ruimte.md
+++ b/docs/richtlijnen/stijl/ruimte.md
@@ -145,7 +145,7 @@ De ruimte tussen een voorgaande sectie en een koptekst moet groter zijn dan de r
 
 ![Screenshot van een artikel. Duidelijk is dat de witruimte boven kopteksten groter is dan onder de kopteksten.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_ruimte_relaties-typografie.png)
 
-[WCAG richtlijn 1.4.8 ‘Visual Presentation’](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) beschrijft dat de regelafstand van een alinea ten minste 1.5 zou moeten zijn. En dat de afstand tussen alinea’s ten minste 1,5 keer zo groot zou moeten zijn als de regelafstand.
+[WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8) beschrijft dat de regelafstand van een alinea ten minste 1.5 zou moeten zijn. En dat de afstand tussen alinea’s ten minste 1,5 keer zo groot zou moeten zijn als de regelafstand.
 
 ### Hiërarchie
 
@@ -179,8 +179,8 @@ Voor iemand met een bevende hand kan een website lastiger te gebruiken zijn als 
 
 ### Gerelateerde WCAG Richtlijnen
 
-- [1.4.8: Visual presentation](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html)
-- [Use White Spacing - Supplemental Guidance to WCAG 2](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p10-whitespace/)
+- [WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8).
+- [Use White Spacing - Supplemental Guidance to WCAG 2](https://www.w3.org/WAI/WCAG2/supplemental/patterns/o3p10-whitespace/).
 
 ### Links
 

--- a/docs/richtlijnen/stijl/typografie.md
+++ b/docs/richtlijnen/stijl/typografie.md
@@ -289,7 +289,7 @@ Ken jij een Open Source lettertype dat voldoet aan de richtlijnen? [Neem contact
 ### Gerelateerde WCAG-succescriteria:
 
 - [1.4.4 Herschalen van tekst](/wcag/1.4.4)
-- [1.4.8 Visuele weergave](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html)
+- [1.4.8 Visuele weergave](/wcag/1.4.8)
 
 ### Links
 

--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -54,6 +54,7 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
 - [1.4.4 Herschalen van tekst](/wcag/1.4.4)
 - [1.4.5 Afbeeldingen van tekst](/wcag/1.4.5)
+- [1.4.8 Visuele weergave](/wcag/1.4.8)
 - [1.4.10 Reflow](/wcag/1.4.10)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)
 - [1.4.12 Tekstafstand](/wcag/1.4.12)

--- a/docs/wcag/1.4.08.mdx
+++ b/docs/wcag/1.4.08.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.8 Visuele presentatie
 pagination_label: WCAG-succescriterium 1.4.8 Visuele presentatie
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Een gebruiker moet de visuele weergave van tekstblokken zelf kunnen aanpassen om deze beter te kunnen lezen.
 slug: 1.4.8
 keywords:
   - WCAG

--- a/docs/wcag/1.4.08.mdx
+++ b/docs/wcag/1.4.08.mdx
@@ -1,0 +1,40 @@
+---
+title: WCAG-succescriterium 1.4.8 Visuele presentatie
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 1.4.8 Visuele presentatie
+pagination_label: WCAG-succescriterium 1.4.8 Visuele presentatie
+description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+slug: 1.4.8
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_1.4.8-summary.md";
+
+# WCAG-succescriterium 1.4.8 Visuele presentatie
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.4.8 Visual Presentation</span>](https://www.w3.org/TR/WCAG22/#visual-presentation).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.4.8 Visuele presentatie](https://www.w3.org/Translations/WCAG22-nl/#visuele-weergave).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.4.8 Visual Presentation</span>](https://www.w3.org/WAI/WCAG22/quickref/#visual-presentation).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 1.4.8 Visual Presentation</span>](https://www.w3.org/WAI/WCAG22/Understanding/visual-presentation.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_1.4.8-summary.md
+++ b/docs/wcag/summaries/_1.4.8-summary.md
@@ -1,0 +1,13 @@
+<!-- @license CC0-1.0 -->
+
+Een gebruiker moet de visuele weergave van tekstblokken zelf kunnen aanpassen om deze beter te kunnen lezen.
+
+Zoals het aanpassen van:
+
+- de voor- en achtergrondkleur;
+- de breedte van de tekst;
+- de uitlijning van de tekst;
+- de regelafstand;
+- de mogelijkheid alleen tekst te vergroten.
+
+Dit moet voor een gebruiker mogelijk zijn door het zelf aanpassen van de computer- of browserinstellingen of de eigen hulpsoftware. Hiervoor hoeven er geen opties of knoppen op de website zelf beschikbaar te zijn. Wel mag het ontwerp en de HTML/CSS de aanpassingen door een gebruiker niet blokkeren.

--- a/docs/wcag/summaries/_1.4.8-summary.md
+++ b/docs/wcag/summaries/_1.4.8-summary.md
@@ -1,13 +1,13 @@
 <!-- @license CC0-1.0 -->
 
-Een gebruiker moet de visuele weergave van tekstblokken zelf kunnen aanpassen om deze beter te kunnen lezen.
+Sommige gebruikers maken teksten die meerdere zinnen lang zijn beter leesbaar voor zichzelf. Dit kan door het zelf aanpassen van de computer- of browserinstellingen of met eigen hulpsoftware.
 
 Zoals het aanpassen van:
 
-- de voor- en achtergrondkleur;
+- de kleur van de tekst en de achtergrondkleur;
 - de breedte van de tekst;
 - de uitlijning van de tekst;
 - de regelafstand;
 - de mogelijkheid alleen tekst te vergroten.
 
-Dit moet voor een gebruiker mogelijk zijn door het zelf aanpassen van de computer- of browserinstellingen of de eigen hulpsoftware. Hiervoor hoeven er geen opties of knoppen op de website zelf beschikbaar te zijn. Wel mag het ontwerp en de HTML/CSS de aanpassingen door een gebruiker niet blokkeren.
+Hiervoor hoeven er geen opties of knoppen op de website zelf beschikbaar te zijn. Wel mag het ontwerp en de HTML/CSS de aanpassingen door een gebruiker niet blokkeren.

--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -155,7 +155,7 @@ export default function DocSidebarItemCategory({
               'menu__link--sublist': collapsible,
               'menu__link--sublist-caret': !href && collapsible,
             })}
-            href={collapsible ? (hrefWithSSRFallback ?? '#') : hrefWithSSRFallback}
+            href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
             {...props}
           >
             {label}

--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -155,7 +155,7 @@ export default function DocSidebarItemCategory({
               'menu__link--sublist': collapsible,
               'menu__link--sublist-caret': !href && collapsible,
             })}
-            href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
+            href={collapsible ? (hrefWithSSRFallback ?? '#') : hrefWithSSRFallback}
             {...props}
           >
             {label}


### PR DESCRIPTION
Gerelateerd issue: https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-wcag-summary-148-visua-69b6d6-nl-design-system.vercel.app/wcag/1.4.8

@hidde:
Dit is een samenvatting voor niet technische personen, meer het 'wat' en 'waarom'.
Pas bij de volledige uitleg kom precies het 'hoe'.
