### PR TITLE
WCAG-pagina's: 2.5.5 Grootte van het aanwijsgebied (uitgebreid) summary

### DIFF
--- a/.changeset/wcag-2.5.5-summary.md
+++ b/.changeset/wcag-2.5.5-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.5.5 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5).

--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -82,6 +82,7 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [2.5.2 Aanwijzerannulering](/wcag/2.5.2)
 - [2.5.3 Label in naam](/wcag/2.5.3)
 - [2.5.4 Bewegingsactivering](/wcag/2.5.4)
+- [2.5.5 Grootte van het aanwijsgebied](/wcag/2.5.5)
 - [2.5.7 Sleepbewegingen](/wcag/2.5.7)
 - [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8)
 

--- a/docs/wcag/2.5.05.mdx
+++ b/docs/wcag/2.5.05.mdx
@@ -14,11 +14,13 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 import Summary from "./summaries/_2.5.5-summary.md";
 
-# WCAG-succescriterium Grootte van het aanwijsgebied (uitgebreid
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.5.5 Grootte van het aanwijsgebied (uitgebreid)</WcagHeadingGroup>
 
 ## W3C referenties
 

--- a/docs/wcag/2.5.05.mdx
+++ b/docs/wcag/2.5.05.mdx
@@ -1,0 +1,42 @@
+---
+title: WCAG-succescriterium 2.5.5 Grootte van het aanwijsgebied (uitgebreid)
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.5.5 Grootte van het aanwijsgebied (uitgebreid)
+pagination_label: WCAG-succescriterium 2.5.5 Grootte van het aanwijsgebied (uitgebreid)
+description: Maak het aanwijsgebied van knoppen, links en formuliervelden groot genoeg, zodat het makkelijker is om deze te selecteren.
+slug: 2.5.5
+keywords:
+  - WCAG
+  - Niveau AAA
+  - Target Size (Enhanced)
+---
+
+{/* @license CC0-1.0 */}
+
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.5.4-summary.md";
+
+# WCAG-succescriterium Grootte van het aanwijsgebied (uitgebreid
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">Target Size (Enhanced)</span>](https://www.w3.org/TR/WCAG22/#target-size-enhanced).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.5.5 Grootte van het aanwijsgebied (uitgebreid)](https://www.w3.org/Translations/WCAG22-nl/#grootte-van-het-aanwijsgebied).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference Target Size (Enhanced)</span>](https://www.w3.org/WAI/WCAG22/quickref/#target-size-enhanced).
+- Engelstalige toelichting: [<span lang="en">Understanding SC Target Size (Enhanced)</span>](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/2.5.05.mdx
+++ b/docs/wcag/2.5.05.mdx
@@ -16,7 +16,7 @@ keywords:
 
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
-import Summary from "./summaries/_2.5.4-summary.md";
+import Summary from "./summaries/_2.5.5-summary.md";
 
 # WCAG-succescriterium Grootte van het aanwijsgebied (uitgebreid
 

--- a/docs/wcag/summaries/_2.5.5-summary.md
+++ b/docs/wcag/summaries/_2.5.5-summary.md
@@ -1,0 +1,6 @@
+<!-- @license CC0-1.0 -->
+
+Maak het aanwijsgebied van buttons, links en formuliervelden groot genoeg, zodat het makkelijker is om deze te selecteren.
+Houd hiervoor een grootte aan van tenminste 44 bij 44 pixels.
+
+Dit zorgt ervoor dat de website makkelijker te navigeren is en dat formulieren makkelijker in te vullen zijn. Dit geldt speciaal voor mensen met dikke vingers op aanraakschermen en muisgebruikers met trillende handen door bijvoorbeeld Parkinson.


### PR DESCRIPTION
Issue:  #1304
Preview: https://documentatie-git-wcag-255-target-size-summary-nl-design-system.vercel.app/wcag/2.5.5

Dit is een samenvatting voor niet technische personen, meer het 'wat' en 'waarom'.
Pas bij de volledige uitleg kom precies het 'hoe'.