### PR TITLE
WCAG-pagina's: 1.2.6 Gebarentaal (vooraf opgenomen) summary

### DIFF
--- a/.changeset/wcag-1.2.6-changelog.md
+++ b/.changeset/wcag-1.2.6-changelog.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)](/wcag/1.2.6).

--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -44,6 +44,7 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [1.2.3 Audiodescriptie of media-alternatief (vooraf opgenomen)](/wcag/1.2.3)
 - [1.2.4 Ondertitels voor doven en slechthorenden (live)](/wcag/1.2.4)
 - [1.2.5 Audiodescriptie (vooraf opgenomen)](/wcag/1.2.5)
+- [1.2.6 Gebarentaal (vooraf opgenomen)](/wcag/1.2.6)
 - [1.3.1 Info en relaties](/wcag/1.3.1)
 - [1.3.2 Betekenisvolle volgorde](/wcag/1.3.2)
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.3.3)

--- a/docs/wcag/1.2.06.mdx
+++ b/docs/wcag/1.2.06.mdx
@@ -1,0 +1,40 @@
+---
+title: WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 1.2.6 Gebarentaal (vooraf opgenomen)
+pagination_label: WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)
+description: Voeg gebarentaal toe aan een vooraf opgenomen video met gesproken woord.
+slug: 1.2.6
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_1.2.6-summary.md";
+
+# WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.2.6 Sign Language (Prerecorded)</span>](https://www.w3.org/TR/WCAG22/#sign-language-prerecorded).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.2.6 Gebarentaal (vooraf opgenomen)](https://www.w3.org/Translations/WCAG22-nl/#gebarentaal-vooraf-opgenomen).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.2.6 Sign Language (Prerecorded)</span>](https://www.w3.org/WAI/WCAG22/quickref/#sign-language-prerecorded).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 1.2.6 Sign Language (Prerecorded)</span>](https://www.w3.org/WAI/WCAG22/Understanding/sign-language-prerecorded.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/1.2.06.mdx
+++ b/docs/wcag/1.2.06.mdx
@@ -12,11 +12,13 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 import Summary from "./summaries/_1.2.6-summary.md";
 
-# WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 1.2.6 Gebarentaal (vooraf opgenomen)</WcagHeadingGroup>
 
 ## W3C referenties
 

--- a/docs/wcag/summaries/_1.2.6-summary.md
+++ b/docs/wcag/summaries/_1.2.6-summary.md
@@ -1,0 +1,5 @@
+<!-- @license CC0-1.0 -->
+
+Voeg gebarentaal toe aan een vooraf opgenomen video met gesproken woord.
+
+Gebarentaal is voor dove gebruikers vaak hun eerste taal en daardoor makkelijker te volgen dan uitgeschreven ondertiteling. Daarnaast kan de gebarentolk ook de emotie en intonatie van de teksten overbrengen, die ontbreekt bij ondertiteling.


### PR DESCRIPTION
Issue: https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-wcag-126-gebarentaal-summary-nl-design-system.vercel.app/wcag/1.2.6

Dit is een samenvatting voor niet technische personen, meer het 'wat' en 'waarom'.
Pas bij de volledige uitleg kom precies het 'hoe'.