### PR TITLE
Voeg richtlijnen over status toe

### DIFF
--- a/docs/richtlijnen/formulieren/status/1-screenreaders/README.mdx
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/README.mdx
@@ -1,0 +1,24 @@
+---
+title: Informeer gebruikers van screenreaders over het statusbericht | Status in een formulier | Richtlijnen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Informeer screenreaders
+pagination_label: Informeer screenreaders
+description: Richtlijnen om gebruikers van screenreaders te informeren over statusberichten.
+slug: /richtlijnen/formulieren/status/screenreaders
+keywords:
+  - labels
+  - formulier
+  - design
+  - code
+---
+
+{/* @license CC0-1.0 */}
+
+import Code from "./_code.mdx";
+import Guideline from "./_guideline.md";
+import FormFooterInfo from "../../_form_footer_info.md";
+
+<Guideline />
+<Code />
+<FormFooterInfo />

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_category_.json
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Informeer screenreaders",
+  "link": {
+    "type": "doc",
+    "id": "README"
+  }
+}

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_code.mdx
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_code.mdx
@@ -1,0 +1,33 @@
+{/* @license CC0-1.0 */}
+
+import { Canvas } from "@site/src/components/Canvas/Canvas";
+import { Guideline } from "@site/src/components/Guideline";
+
+<Guideline
+  appearance="do"
+  title="Geef updates over het winkelwagentje met role=status."
+  description={
+    <>
+      Wanneer een nieuw product in een winkelwagen is geplaatst of de winkelwagen geleegd is, verandert het
+      winkelwagen-icoon visueel. Een live region kan deze update ook overbrengen.
+    </>
+  }
+>
+  <Canvas language="html">
+    {() => (
+      <>
+        <p>todo: voorbeeld met winkelwagen-icoon + live region</p>
+      </>
+    )}
+  </Canvas>
+</Guideline>
+
+<Guideline appearance="dont" title="Gevonden zoekresultaten aangeven met role='alert'.">
+  <Canvas language="html">
+    {() => (
+      <>
+        <p role="alert">10 resultaten</p>
+      </>
+    )}
+  </Canvas>
+</Guideline>

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
@@ -65,5 +65,5 @@ Het informeren van alle gebruikers over een statusbericht is verplicht om te vol
 
 Bronnen:
 
-- [https://adrianroselli.com/2020/01/defining-toast-messages.html](https://adrianroselli.com/2020/01/defining-toast-messages.html)
-- [https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/](https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/)
+- [<span lang="en">Defining toast messages</span>](https://adrianroselli.com/2020/01/defining-toast-messages.html) van Adrian Roselli.
+- [<span lang="en">Patrick H. Lauke</span>](https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/) van Patrick H. Lauke.

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
@@ -25,7 +25,7 @@ Bijvoorbeeld:
 </div>
 ```
 
-Een element met role="alert" is een “assertive” live region, en functioneel gelijk aan het gebruiken van de combinatie [aria-live="assertive"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).  
+Een element met `role="alert"` is een ‘assertive’ live region, en functioneel gelijk aan het gebruiken van de combinatie [aria-live="assertive"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).  
 Het onderbreekt de gebruiker bij wat die doet en geeft de melding onmiddellijk door.
 
 **Let op**: gebruik alert spaarzaam, alleen in situaties waarin de onmiddellijke aandacht van de gebruiker vereist is.

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
@@ -25,8 +25,8 @@ Bijvoorbeeld:
 </div>
 ```
 
-Het instellen van role="alert" is gelijk aan het instellen van [aria-live="assertive"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).  
-Het onderbreekt de gebruiker bij wat ze aan het doen is en geeft de melding onmiddellijk door.
+Een element met role="alert" is een “assertive” live region, en functioneel gelijk aan het gebruiken van de combinatie [aria-live="assertive"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).  
+Het onderbreekt de gebruiker bij wat die doet en geeft de melding onmiddellijk door.
 
 **Let op**: gebruik alert spaarzaam, alleen in situaties waarin de onmiddellijke aandacht van de gebruiker vereist is.
 
@@ -53,7 +53,7 @@ Deze `role="status"` onderbreekt de gebruiker niet, maar de melding wordt pas do
 
 Met andere woorden, 'status' wacht op zijn beurt, 'alert' dringt voor.
 
-Veel CMS'en en frameworks hebben iets ingebouwd om screenreaderfeedback makkelijker te maken: ze plaatsen onderaan de pagina een vaste live-regions, waaraan je als ontwikkelaar meldingen kan toevoegen die dan worden voorgelezen.
+Veel CMS'en en frameworks hebben iets ingebouwd om screenreaderfeedback makkelijker te maken: ze plaatsen onderaan de pagina een vaste live-region, waaraan je als ontwikkelaar meldingen kan toevoegen die dan worden voorgelezen.
 
 Voorbeelden van dit soort functionaliteit:
 
@@ -61,7 +61,7 @@ Voorbeelden van dit soort functionaliteit:
 - [drupal.accounce](https://www.drupal.org/node/1973218) voor Drupal.
 - [live-announcer](https://www.npmjs.com/package/@react-aria/live-announcer) voor react-aria.
 
-Het informeren van alle gebruikers over een statusbericht is nodig om te voldoen aan het WCAG-succescriterium [4.1.3 Statusberichten](https://nldesignsystem.nl/wcag/4.1.3) (niveau AA).
+Het informeren van alle gebruikers over een statusbericht is verplicht om te voldoen aan het WCAG-succescriterium [4.1.3 Statusberichten](https://nldesignsystem.nl/wcag/4.1.3) (niveau AA).
 
 Bronnen:
 

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
@@ -2,11 +2,11 @@
 
 # Informeer gebruikers van screenreaders over het statusbericht
 
-Als de statusmelding dynamisch wordt gegenereerd en zichtbaar is, maar geen toetsenbordfocus krijgt, moet de melding worden voorgelezen aan een screenreadergebruiker.
+Als het statusbericht dynamisch wordt gegenereerd en zichtbaar is, maar geen toetsenbordfocus krijgt, moet de melding worden voorgelezen aan een screenreadergebruiker.
 
-Dit kan door van de statusmelding een live-region te maken.
+Dit kan door van het statusbericht een live-region te maken.
 
-Let op: de live-region moet al in de DOM (de gegenereerde HTML-code) aanwezig zijn, de browser geeft vaak alleen wijzigingen binnen deze (al bestaande) live-region door.
+Let op: de live-region moet al in de DOM (de door de browser verwerkte HTML-code) aanwezig zijn voor je er iets in zet. Vaak verwerkt de browser alleen wijzigingen in al bestaande live-regions.
 
 ## Live-region met `role="alert"`
 

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/_guideline.md
@@ -1,0 +1,69 @@
+<!-- @license CC0-1.0 -->
+
+# Informeer gebruikers van screenreaders over het statusbericht
+
+Als de statusmelding dynamisch wordt gegenereerd en zichtbaar is, maar geen toetsenbordfocus krijgt, moet de melding worden voorgelezen aan een screenreadergebruiker.
+
+Dit kan door van de statusmelding een live-region te maken.
+
+Let op: de live-region moet al in de DOM (de gegenereerde HTML-code) aanwezig zijn, de browser geeft vaak alleen wijzigingen binnen deze (al bestaande) live-region door.
+
+## Live-region met `role="alert"`
+
+Gebruik [role="alert"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) om belangrijke en/of tijdgevoelige berichten aan gebruikers van hulptechnologie direct over te brengen.
+
+Bijvoorbeeld:
+
+- Je inlogsessie loopt bijna af.
+- De verbinding met de server is verbroken, lokale wijzigingen worden nu niet opgeslagen.
+- Je hebt nog 20 seconden om het formulier te verzenden.
+
+```markup
+<div role="alert">
+  Waarschuwing: Je hebt nog 20 seconden
+  om het formulier te verzenden.
+</div>
+```
+
+Het instellen van role="alert" is gelijk aan het instellen van [aria-live="assertive"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).  
+Het onderbreekt de gebruiker bij wat ze aan het doen is en geeft de melding onmiddellijk door.
+
+**Let op**: gebruik alert spaarzaam, alleen in situaties waarin de onmiddellijke aandacht van de gebruiker vereist is.
+
+## Live-region met `role="status"`
+
+Een live-region met de [role="status"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) geeft de gebruiker informatie die niet belangrijk genoeg is om een 'alert' te zijn.
+
+Bijvoorbeeld:
+
+- Het aanmeldformulier is succesvol verzonden.
+- Je hebt nu 3 producten in je winkelmandje.
+- Er zijn 5 zoekresultaten gevonden voor 'eikenprocessierups'.
+
+```markup
+<div role="status">
+  Er zijn 5 zoekresultaten gevonden
+  voor 'eikenprocessierups'.
+</div>
+```
+
+Het instellen van role="status" is gelijk aan het instellen van [aria-live="polite"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) en [aria-atomic="true"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).
+
+Deze `role="status"` onderbreekt de gebruiker niet, maar de melding wordt pas doorgegeven als de gebruiker geen interactie met de hulptechnologie meer heeft.
+
+Met andere woorden, 'status' wacht op zijn beurt, 'alert' dringt voor.
+
+Veel CMS'en en frameworks hebben iets ingebouwd om screenreaderfeedback makkelijker te maken: ze plaatsen onderaan de pagina een vaste live-regions, waaraan je als ontwikkelaar meldingen kan toevoegen die dan worden voorgelezen.
+
+Voorbeelden van dit soort functionaliteit:
+
+- [wp-a11y-speak()](https://make.wordpress.org/accessibility/handbook/markup/wp-a11y-speak/) voor WordPress.
+- [drupal.accounce](https://www.drupal.org/node/1973218) voor Drupal.
+- [live-announcer](https://www.npmjs.com/package/@react-aria/live-announcer) voor react-aria.
+
+Het informeren van alle gebruikers over een statusbericht is nodig om te voldoen aan het WCAG-succescriterium [4.1.3 Statusberichten](https://nldesignsystem.nl/wcag/4.1.3) (niveau AA).
+
+Bronnen:
+
+- [https://adrianroselli.com/2020/01/defining-toast-messages.html](https://adrianroselli.com/2020/01/defining-toast-messages.html)
+- [https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/](https://tetralogical.com/blog/2024/05/01/why-are-my-live-regions-not-working/)

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/README.mdx
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/README.mdx
@@ -1,0 +1,22 @@
+---
+title: Informeer ingezoomde gebruikers | Status in een formulier | Richtlijnen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Informeer ingezoomde gebruikers
+pagination_label: Informeer ingezoomde gebruikers
+description: Richtlijnen over het informeren van ingezoomde gebruikers.
+slug: /richtlijnen/formulieren/status/zoom
+keywords:
+  - labels
+  - formulier
+  - design
+  - code
+---
+
+{/* @license CC0-1.0 */}
+
+import Guideline from "./_guideline.md";
+import FormFooterInfo from "../../_form_footer_info.md";
+
+<Guideline />
+<FormFooterInfo />

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/_category_.json
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Informeer ingezoomde gebruikers",
+  "link": {
+    "type": "doc",
+    "id": "README"
+  }
+}

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
@@ -6,4 +6,4 @@ Als een statusbericht visueel niet in de buurt staat van het element waar de mel
 
 Zet bij elkaar wat bij elkaar hoort. Is er een statusbericht, zet deze dan vlak bij waar de gebruiker op dat moment aan het werk is. Zodat het bericht in beeld is voor ingezoomde gebruikers.
 
-Zet bijvoorbeeld dynamisch gegenereerde meldingen voor een formulier altijd vlak bij het formulierveld bovenaan de pagina. Zoals de melding over het totaal aantal ingevoerde karakters voor een tekstveld of de totaalprijs in een berekening.
+Zet dynamisch gegenereerde meldingen voor een formulier altijd vlak bij het formulierveld of bijvoorbeeld bovenaan de pagina, afhankelijk van waar en wanneer de foutmelding getoond wordt. Zoals de melding over het totaal aantal ingevoerde karakters voor een tekstveld of de totaalprijs in een berekening.

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
@@ -1,0 +1,13 @@
+<!-- @license CC0-1.0 -->
+
+# Informeer ingezoomde gebruikers over het statusbericht
+
+Als een statusmelding visueel niet in de buurt staat van het element waar de melding bijhoort, zou deze kunnen worden gemist door gebruikers die zijn ingezoomd.
+
+Zet bij elkaar wat bij elkaar hoort. Is er een statusmelding, zet deze dan vlak bij waar de gebruiker op dat moment aan het werk is. Zodat de melding in beeld is voor ingezoomde gebruikers.
+
+Zet bijvoorbeeld dynamisch gegenereerde meldingen voor een formulier altijd vlak bij het formulierveld bovenaan de pagina. Zoals de melding over het totaal aantal ingevoerde karakters voor een tekstveld of de totaalprijs in een berekening.
+
+Plaats meldingen binnen een website altijd op dezelfde wijze en met dezelfde opzet. Gebruikers leren dan hoe en op welke plek de meldingen komen en zullen ze beter opmerken.
+
+Zet de statusmelding op een plek waar ingezoomde gebruikers het kunnen zien.

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
@@ -2,12 +2,12 @@
 
 # Informeer ingezoomde gebruikers over het statusbericht
 
-Als een statusmelding visueel niet in de buurt staat van het element waar de melding bijhoort, zou deze kunnen worden gemist door gebruikers die zijn ingezoomd.
+Als een statusbericht visueel niet in de buurt staat van het element waar de melding bijhoort, zou deze kunnen worden gemist door gebruikers die zijn ingezoomd.
 
-Zet bij elkaar wat bij elkaar hoort. Is er een statusmelding, zet deze dan vlak bij waar de gebruiker op dat moment aan het werk is. Zodat de melding in beeld is voor ingezoomde gebruikers.
+Zet bij elkaar wat bij elkaar hoort. Is er een statusbericht, zet deze dan vlak bij waar de gebruiker op dat moment aan het werk is. Zodat het bericht in beeld is voor ingezoomde gebruikers.
 
 Zet bijvoorbeeld dynamisch gegenereerde meldingen voor een formulier altijd vlak bij het formulierveld bovenaan de pagina. Zoals de melding over het totaal aantal ingevoerde karakters voor een tekstveld of de totaalprijs in een berekening.
 
 Plaats meldingen binnen een website altijd op dezelfde wijze en met dezelfde opzet. Gebruikers leren dan hoe en op welke plek de meldingen komen en zullen ze beter opmerken.
 
-Zet de statusmelding op een plek waar ingezoomde gebruikers het kunnen zien.
+Zet het statusbericht op een plek waar ingezoomde gebruikers het kunnen zien.

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/_guideline.md
@@ -2,12 +2,8 @@
 
 # Informeer ingezoomde gebruikers over het statusbericht
 
-Als een statusbericht visueel niet in de buurt staat van het element waar de melding bijhoort, zou deze kunnen worden gemist door gebruikers die zijn ingezoomd.
+Als een statusbericht visueel niet in de buurt staat van het element waar de melding bij hoort, kan deze worden gemist door gebruikers die zijn ingezoomd.
 
 Zet bij elkaar wat bij elkaar hoort. Is er een statusbericht, zet deze dan vlak bij waar de gebruiker op dat moment aan het werk is. Zodat het bericht in beeld is voor ingezoomde gebruikers.
 
 Zet bijvoorbeeld dynamisch gegenereerde meldingen voor een formulier altijd vlak bij het formulierveld bovenaan de pagina. Zoals de melding over het totaal aantal ingevoerde karakters voor een tekstveld of de totaalprijs in een berekening.
-
-Plaats meldingen binnen een website altijd op dezelfde wijze en met dezelfde opzet. Gebruikers leren dan hoe en op welke plek de meldingen komen en zullen ze beter opmerken.
-
-Zet het statusbericht op een plek waar ingezoomde gebruikers het kunnen zien.

--- a/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Geef gebruikers voldoende tijd
 pagination_label: Geef gebruikers voldoende tijd
-description: Richtlijnen over de tijdsduur van statusmeldingen.
+description: Richtlijnen over de tijdsduur van statusberichten.
 slug: /richtlijnen/formulieren/status/enough-time
 keywords:
   - labels

--- a/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
@@ -1,0 +1,22 @@
+---
+title: Geef gebruikers voldoende tijd | Status in een formulier | Richtlijnen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Geef gebruikers voldoende tijd
+pagination_label: Geef gebruikers voldoende tijd
+description: Richtlijnen over de tijdsduur van statusmeldingen.
+slug: /richtlijnen/formulieren/status/enough-time
+keywords:
+  - labels
+  - formulier
+  - design
+  - code
+---
+
+{/* @license CC0-1.0 */}
+
+import Guideline from "./_guideline.md";
+import FormFooterInfo from "../../_form_footer_info.md";
+
+<Guideline />
+<FormFooterInfo />

--- a/docs/richtlijnen/formulieren/status/3-enough-time/_category_.json
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Voldoende tijd",
+  "link": {
+    "type": "doc",
+    "id": "README"
+  }
+}

--- a/docs/richtlijnen/formulieren/status/3-enough-time/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/_guideline.md
@@ -1,0 +1,7 @@
+<!-- @license CC0-1.0 -->
+
+# Geef gebruikers voldoende tijd om het statusbericht te lezen
+
+Geef de gebruiker genoeg tijd om de melding te lezen en eventueel zelf te verwijderen.
+
+Maar voor een status die afhankelijk is van tijd, zoals: "bezig", "updating" heeft het vanzelf verdwijnen van die status betekenis. Als de melding verdwijnt geeft dit aan de ziende gebruiker expliciet de melding: "Het updaten is klaar". Geef het verdwijnen van de melding dan ook door aan een screenreadergebruiker.

--- a/docs/richtlijnen/formulieren/status/3-enough-time/_guideline.md
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/_guideline.md
@@ -2,6 +2,6 @@
 
 # Geef gebruikers voldoende tijd om het statusbericht te lezen
 
-Geef de gebruiker genoeg tijd om de melding te lezen en eventueel zelf te verwijderen.
+Geef de gebruiker genoeg tijd om de melding te lezen en eventueel zelf te verwijderen. Vermijd daarom het automatisch verbergen van statusberichten.
 
-Maar voor een status die afhankelijk is van tijd, zoals: "bezig", "updating" heeft het vanzelf verdwijnen van die status betekenis. Als de melding verdwijnt geeft dit aan de ziende gebruiker expliciet de melding: "Het updaten is klaar". Geef het verdwijnen van de melding dan ook door aan een screenreadergebruiker.
+Soms is een statusmelding afhankelijk van tijd, bijvoorbeeld “bezig met uploaden…”, “aan het verzenden…”. Dan kan het betekenisvol zijn om de melding vanzelf te laten verdwijnen om te communiceren dat de melding niet meer van toepassing is. Voor ziende gebruikers communiceert het verdwijnen van de melding dat de status niet meer van toepassing is. Zorg het statusbericht ook aan screenreadergebruikers wordt gecommuniceerd door [een live region te gebruiken](/richtlijnen/formulieren/status/screenreaders), met bijvoorbeeld expliciet de melding “het uploaden is voltooid”.

--- a/docs/richtlijnen/formulieren/status/README.mdx
+++ b/docs/richtlijnen/formulieren/status/README.mdx
@@ -1,0 +1,60 @@
+---
+title: Status in een formulier | Richtlijnen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Introductie status
+sidebar_position: 12
+pagination_label: Status in formulieren
+description: Richtlijnen voor het omgaan met status in formulieren.
+slug: /richtlijnen/formulieren/status/
+keywords:
+  - informatie
+  - status
+  - formulier
+  - design
+  - code
+---
+
+{/* @license CC0-1.0 */}
+
+import { OverviewPage } from "@site/src/components/OverviewPage";
+import FormFooterInfo from "../_form_footer_info.md";
+
+# Status in een formulier
+
+Het is belangrijk een gebruiker te informeren over veranderingen en updates. Is een formulier succesvol verzonden, zijn er fouten, hoeveel zoekresultaten zijn er, is de tijdslimiet bijna verstreken? Alle gebruikers moeten deze informatie krijgen. Ook gebruikers die het scherm of de verandering niet of niet goed zien.
+
+Je kunt updates over belangrijke informatie in een formulier met de gebruiker delen via een statusmelding. Als deze melding bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die de melding niet zien, deze informatie toch meekrijgen.
+
+## Wat is een statusbericht?
+
+Een [statusbericht](https://www.w3.org/Translations/WCAG22-nl/#dfn-status-messages) geeft een verandering in de content aan die geen verandering van context is, en die de gebruiker informatie geeft over het succes of de resultaten van een actie, over de wachtstatus van een applicatie, over de voortgang van een proces of over het bestaan van fouten.
+
+## Wat maakt een goed statusbericht?
+
+Iedereen moet een statusmelding meekrijgen. Ook mensen die het scherm niet zien of sterk zijn ingezoomd.
+
+Cruciaal is hierbij de term **verandering van content**. Wat is dat? En wat is het verschil tussen context en content?
+
+### Verandering van context
+
+Veranderingen van context zijn grote veranderingen in de content, zoals:
+
+- Het openen van een nieuwe pagina, inclusief wat er voor een gebruiker uitziet alsof hij naar een nieuwe pagina is gegaan.
+- Het verplaatsen van de focus naar een ander onderdeel op de pagina.
+- Content die de betekenis van de webpagina volledig verandert.
+
+### Verandering van content
+
+Een verandering van content betekent niet altijd een verandering van context. Veranderingen in de content kunnen zijn:
+
+- Dynamisch weergeven van filter- of zoekresultaten.
+- Het verhogen van het aantal producten aan het winkelmandje-icoontje.
+- Informatie over het al dan niet succesvol versturen van een formulier (zonder het herladen van de pagina).
+- Het weergeven van een teller over het nog maximaal in te voeren karakters in een invoerveld.
+
+Er zijn verschillende technieken om aan een screenreadergebruiker de statusmelding te laten voorlezen, of voor een ingezoomde gebruiker om toch de melding te kunnen lezen. Deze technieken staan bij de afzonderlijke richtlijnen over statusmeldingen beschreven.
+
+<OverviewPage excludeDocIDs={["richtlijnen/formulieren/status/README"]} />
+
+<FormFooterInfo />

--- a/docs/richtlijnen/formulieren/status/README.mdx
+++ b/docs/richtlijnen/formulieren/status/README.mdx
@@ -24,7 +24,7 @@ import FormFooterInfo from "../_form_footer_info.md";
 
 Het is belangrijk een gebruiker te informeren over veranderingen en updates. Is een formulier succesvol verzonden, zijn er fouten, hoeveel zoekresultaten zijn er, is de tijdslimiet bijna verstreken? Alle gebruikers moeten deze informatie krijgen. Ook gebruikers die het scherm of de verandering niet of niet goed zien.
 
-Je kunt updates over belangrijke informatie in een formulier met de gebruiker delen via een statusmelding. Als deze melding bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die de melding niet zien, deze informatie toch meekrijgen.
+Je kunt updates over belangrijke informatie in een formulier met de gebruiker delen via een statusbericht. Als dit bericht bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die het bericht niet zien, deze informatie toch meekrijgen.
 
 ## Wat is een statusbericht?
 
@@ -32,7 +32,7 @@ Een [statusbericht](https://www.w3.org/Translations/WCAG22-nl/#dfn-status-messag
 
 ## Wat maakt een goed statusbericht?
 
-Iedereen moet een statusmelding meekrijgen. Ook mensen die het scherm niet zien of sterk zijn ingezoomd.
+Iedereen moet een statusbericht meekrijgen. Ook mensen die het scherm niet zien of sterk zijn ingezoomd.
 
 Cruciaal is hierbij de term **verandering van content**. Wat is dat? En wat is het verschil tussen context en content?
 
@@ -53,7 +53,7 @@ Een verandering van content betekent niet altijd een verandering van context. Ve
 - Informatie over het al dan niet succesvol versturen van een formulier (zonder het herladen van de pagina).
 - Het weergeven van een teller over het nog maximaal in te voeren karakters in een invoerveld.
 
-Er zijn verschillende technieken om aan een screenreadergebruiker de statusmelding te laten voorlezen, of voor een ingezoomde gebruiker om toch de melding te kunnen lezen. Deze technieken staan bij de afzonderlijke richtlijnen over statusmeldingen beschreven.
+Er zijn verschillende technieken om aan een screenreadergebruiker het statusbericht te laten voorlezen, of voor een ingezoomde gebruiker om toch het bericht te kunnen lezen. Deze technieken staan bij de afzonderlijke richtlijnen over statusberichten beschreven.
 
 <OverviewPage excludeDocIDs={["richtlijnen/formulieren/status/README"]} />
 

--- a/docs/richtlijnen/formulieren/status/README.mdx
+++ b/docs/richtlijnen/formulieren/status/README.mdx
@@ -22,38 +22,16 @@ import FormFooterInfo from "../_form_footer_info.md";
 
 # Status in een formulier
 
-Het is belangrijk een gebruiker te informeren over veranderingen en updates. Is een formulier succesvol verzonden, zijn er fouten, hoeveel zoekresultaten zijn er, is de tijdslimiet bijna verstreken? Alle gebruikers moeten deze informatie krijgen. Ook gebruikers die het scherm of de verandering niet of niet goed zien.
+Het is belangrijk een gebruiker te informeren over veranderingen en updates.
 
-Je kunt updates over belangrijke informatie in een formulier met de gebruiker delen via een statusbericht. Als dit bericht bij verschijnen geen toetsenbordfocus krijgt, zorg er dan voor dat gebruikers die het bericht niet zien, deze informatie toch meekrijgen.
+- Is een formulier succesvol verzonden?
+- Zijn er fouten?
+- Hoeveel zoekresultaten zijn er?
+- Is de tijdslimiet bijna verstreken?
 
-## Wat is een statusbericht?
+Dit soort veranderingen binnen een pagina kun je met een [statusbericht](https://www.w3.org/Translations/WCAG22-nl/#dfn-status-messages) aangeven.
 
-Een [statusbericht](https://www.w3.org/Translations/WCAG22-nl/#dfn-status-messages) geeft een verandering in de content aan die geen verandering van context is, en die de gebruiker informatie geeft over het succes of de resultaten van een actie, over de wachtstatus van een applicatie, over de voortgang van een proces of over het bestaan van fouten.
-
-## Wat maakt een goed statusbericht?
-
-Iedereen moet een statusbericht meekrijgen. Ook mensen die het scherm niet zien of sterk zijn ingezoomd.
-
-Cruciaal is hierbij de term **verandering van content**. Wat is dat? En wat is het verschil tussen context en content?
-
-### Verandering van context
-
-Veranderingen van context zijn grote veranderingen in de content, zoals:
-
-- Het openen van een nieuwe pagina, inclusief wat er voor een gebruiker uitziet alsof hij naar een nieuwe pagina is gegaan.
-- Het verplaatsen van de focus naar een ander onderdeel op de pagina.
-- Content die de betekenis van de webpagina volledig verandert.
-
-### Verandering van content
-
-Een verandering van content betekent niet altijd een verandering van context. Veranderingen in de content kunnen zijn:
-
-- Dynamisch weergeven van filter- of zoekresultaten.
-- Het verhogen van het aantal producten aan het winkelmandje-icoontje.
-- Informatie over het al dan niet succesvol versturen van een formulier (zonder het herladen van de pagina).
-- Het weergeven van een teller over het nog maximaal in te voeren karakters in een invoerveld.
-
-Er zijn verschillende technieken om aan een screenreadergebruiker het statusbericht te laten voorlezen, of voor een ingezoomde gebruiker om toch het bericht te kunnen lezen. Deze technieken staan bij de afzonderlijke richtlijnen over statusberichten beschreven.
+Een statusbericht moet voor iedereen beschikbaar zijn, en dus ook goed werken met screenreaders en zoom-instellingen. Ook moet er voldoende tijd zijn om de content in je op te nemen.
 
 <OverviewPage excludeDocIDs={["richtlijnen/formulieren/status/README"]} />
 

--- a/docs/richtlijnen/formulieren/status/_category_.json
+++ b/docs/richtlijnen/formulieren/status/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "Status",
+  "link": {
+    "type": "doc",
+    "id": "richtlijnen/formulieren/status/README"
+  },
+  "customProps": {
+    "showLinkedDoc": true
+  }
+}

--- a/docs/wcag/4.1.03.mdx
+++ b/docs/wcag/4.1.03.mdx
@@ -41,7 +41,7 @@ Op [<span lang="en">Understanding SC 4.1.3: Status Messages</span>](https://www.
 
 ## Hoe te testen
 
-Test een statusmelding die dynamisch aan de content wordt toegevoegd en geen toetsenbordfocus krijgt.
+Test elk statusbericht dat dynamisch aan de content wordt toegevoegd en geen toetsenbordfocus krijgt.
 Wordt de tekst van de melding goed voorgelezen door een screenreader?
 
 **Let op**: dit geldt alleen voor statusberichten die worden getoond zonder dat de pagina opnieuw geladen wordt.


### PR DESCRIPTION
Review: https://documentatie-git-docs-add-status-update-48e113-nl-design-system.vercel.app/richtlijnen/formulieren/status/

fixes #1290 
fixes #1291 
fixes #1292
fixes #1293

Notities:

- let op, dit is nog niet de volledige 'status' sectie'; we gaan komende weken in https://github.com/nl-design-system/documentatie/issues/1289 meer content toevoegen over statussen; wmb kan deze al gemerged worden voor de rest er is
- ik gebruik steeds 'statusberichten' ipv 'statusmeldingen' wat we eerder gebruikten om in lijn te blijven met den officiële 2.2 vertaling
- ik heb m'n best gedaan het onderscheid tussen 'verandering van content' en 'verandering van context' impliciet te maken, door het te hebben over 'veranderingen binnen een pagina'