### PR TITLE
docs: fix broken links and typos

### DIFF
--- a/.changeset/docs-fix-broken-links-changelog.md
+++ b/.changeset/docs-fix-broken-links-changelog.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Fixt gebroken links in patronen en richtlijnen.

--- a/docs/richtlijnen/formulieren/_form_footer_info.md
+++ b/docs/richtlijnen/formulieren/_form_footer_info.md
@@ -2,4 +2,4 @@
 
 Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/) met je suggesties.

--- a/docs/voorbeelden/patronen/formulieren/_pattern_footer_info.mdx
+++ b/docs/voorbeelden/patronen/formulieren/_pattern_footer_info.mdx
@@ -4,4 +4,4 @@ Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun
 
 ## Vragen
 
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../../project/kernteam.mdx).
+Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](/project/kernteam).

--- a/docs/voorbeelden/patronen/formulieren/controlepagina.mdx
+++ b/docs/voorbeelden/patronen/formulieren/controlepagina.mdx
@@ -46,9 +46,9 @@ Een controlepagina kan worden ingezet om ingevulde data te controleren voordat m
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-- [Bied als laatste stap een opsomming aan van alle ingevoerde gegevens](/richtlijnen/formulieren/meerdere-stappen#bied-als-laatste-stap-een-opsomming-aan-van-alle-ingevoerde-gegevens).
-- [Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken](/richtlijnen/formulieren/voorkom-fouten#maak-het-mogelijk-een-inzending-te-controleren-te-wijzigen-of-ongedaan-te-maken).
-- [Geef duidelijk aan wanneer het formulier verzonden gaat worden](/richtlijnen/formulieren/meerdere-stappen#geef-duidelijk-aan-wanneer-het-formulier-verzonden-gaat-worden).
+- [Bied als laatste stap een opsomming aan van alle ingevoerde gegevens](/richtlijnen/formulieren/meerdere-stappen/samenvatting).
+- [Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken](/richtlijnen/formulieren/voorkom-fouten/controleren-en-aanpassen).
+- [Geef duidelijk aan wanneer het formulier verzonden gaat worden](/richtlijnen/formulieren/meerdere-stappen/verzenden-aangeven).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/funnel-header.mdx
+++ b/docs/voorbeelden/patronen/formulieren/funnel-header.mdx
@@ -33,7 +33,7 @@ Boven een meerstappenformulier kun je een 'Funnel header' toepassen. Hieronder v
 
 ### Verder onderzoeken
 
-- De wachting van wat er getoond wordt nadat je op de naam klikt loopt uiteen. Een ingang naar de mijn omgeving, een menu en uitloggen worden allemaal genoemd.
+- De verwachting van wat er getoond wordt nadat je op de naam klikt loopt uiteen. Een ingang naar de mijn omgeving, een menu en uitloggen worden allemaal genoemd.
 - Welke informatie en opties zijn nodig wanneer men op de button klikt? En sluiten deze aan bij de verwachting. Dit zouden we graag verder uitzoeken.
 
 <VideoPlayer videoId="_yU8tIHw9WQ" />

--- a/docs/voorbeelden/patronen/formulieren/inloggen.mdx
+++ b/docs/voorbeelden/patronen/formulieren/inloggen.mdx
@@ -49,8 +49,8 @@ Bij een meerstappenformulier kan het voorkomen dat de gebruiker moet inloggen. H
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-- [Leg uit waarom informatie nodig is](/richtlijnen/formulieren/vragen#leg-uit-waarom-informatie-nodig-is).
-- [Sta knippen en plakken van een wachtwoord toe](/richtlijnen/formulieren/voorkom-fouten#sta-knippen-en-plakken-van-een-wachtwoord-toe).
+- [Leg uit waarom informatie nodig is](/richtlijnen/formulieren/vragen/leg-uit-waarom).
+- [Sta knippen en plakken van een wachtwoord toe](/richtlijnen/formulieren/voorkom-fouten/wachtwoord-plakken/).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/intropagina.mdx
+++ b/docs/voorbeelden/patronen/formulieren/intropagina.mdx
@@ -47,8 +47,8 @@ Een intropagina kan worden ingezet vooraf aan meerstappenformulier. Het helpt om
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-- [Leg uit waarom informatie nodig is](/richtlijnen/formulieren/vragen#leg-uit-waarom-informatie-nodig-is).
-- [Vermeld duidelijk of een veld verplicht is](/richtlijnen/formulieren/voorkom-fouten#vermeld-duidelijk-of-een-veld-verplicht-is).
+- [Leg uit waarom informatie nodig is](/richtlijnen/formulieren/vragen/leg-uit-waarom).
+- [Vermeld duidelijk of een veld wel of niet verplicht is](/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/niet-verplichte-velden.mdx
+++ b/docs/voorbeelden/patronen/formulieren/niet-verplichte-velden.mdx
@@ -42,7 +42,7 @@ import ResearchInfo from "./_research-info.mdx";
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-[Vermeld duidelijk of een veld verplicht is](/richtlijnen/formulieren/voorkom-fouten#vermeld-duidelijk-of-een-veld-verplicht-is).
+[Vermeld duidelijk of een veld verplicht is](/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/terug-navigeren.mdx
+++ b/docs/voorbeelden/patronen/formulieren/terug-navigeren.mdx
@@ -37,7 +37,7 @@ Een meerstappenformulier bevat navigatie opties om terug te navigeren. Hieronder
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-[Zorg voor een consistente navigatie en benaming van links en buttons](/richtlijnen/formulieren/meerdere-stappen#zorg-voor-een-consistente-navigatie-en-benaming-van-links-en-buttons).
+[Zorg voor een consistente navigatie en benaming van links en buttons](/richtlijnen/formulieren/meerdere-stappen/consistente-benaming).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/uploaden.mdx
+++ b/docs/voorbeelden/patronen/formulieren/uploaden.mdx
@@ -40,7 +40,7 @@ Het uploaden zelf is nog niet uitgewerkt. We leren graag welke wat de beste mani
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-[Plaats descriptions tussen label en formulierveld](/richtlijnen/formulieren/descriptions#plaats-descriptions-tussen-label-en-formulierveld).
+[Plaats descriptions tussen label en formulierveld](/richtlijnen/formulieren/descriptions/plaatsing).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/volgende-stap.mdx
+++ b/docs/voorbeelden/patronen/formulieren/volgende-stap.mdx
@@ -40,7 +40,7 @@ Een meerstappenformulier bevat een 'Volgende stap' actie. Hieronder verzamelen w
 ## Gerelateerde richtlijnen van het NL Design System
 
 - [Buttons in een formulier](/richtlijnen/formulieren/buttons).
-- [Zorg voor een consistente navigatie en benaming van links en buttons](/richtlijnen/formulieren/meerdere-stappen#zorg-voor-een-consistente-navigatie-en-benaming-van-links-en-buttons).
+- [Zorg voor een consistente navigatie en benaming van links en buttons](/richtlijnen/formulieren/meerdere-stappen/consistente-benaming).
 
 <ResearchInfo />
 

--- a/docs/voorbeelden/patronen/formulieren/voortgang-indicatie.mdx
+++ b/docs/voorbeelden/patronen/formulieren/voortgang-indicatie.mdx
@@ -45,8 +45,8 @@ Bij een meerstappenformulier kan je voortgang indicatie toepassen. Hieronder ver
 
 ## Gerelateerde richtlijnen van het NL Design System
 
-- [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](/richtlijnen/formulieren/meerdere-stappen#geef-aan-hoeveel-stappen-er-zijn-en-in-welke-stap-de-gebruiker-zich-bevindt).
-- [Plaats de informatie over waar de gebruiker is in de stappen boven het formulier](/richtlijnen/formulieren/meerdere-stappen#plaats-de-informatie-over-waar-de-gebruiker-is-in-de-stappen-boven-het-formulier).
+- [Geef aan hoeveel stappen er zijn en in welke stap de gebruiker zich bevindt](/richtlijnen/formulieren/meerdere-stappen/voortgang-tonen).
+- [Plaats de informatie over waar de gebruiker is in de stappen boven het formulier](/richtlijnen/formulieren/meerdere-stappen/plaatsing-voortgang).
 
 ---
 


### PR DESCRIPTION
Deze PR fixt wat gebroken links na de refactoring van de richtlijnen