### PR TITLE
Richtlijn bij Voorkom fouten: Gebruik geen invoerpatroon op een formulierveld.

### DIFF
--- a/.changeset/guidelines-no-input-mask.md
+++ b/.changeset/guidelines-no-input-mask.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Richtlijn toegevoegd bij Voorkom fouten: [Gebruik geen invoerpatroon op een formulierveld](/formulieren/voorkom-fouten/geen-invoerpatronen).

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
@@ -2,8 +2,8 @@
 title: Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken | Voorkom fouten in een formulier | Richtlijnen
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: Gebruik geen invoerpatronen
-pagination_label: Gebruik geen invoerpatronen
+sidebar_label: Vermijd invoerpatronen
+pagination_label: Vermijd invoerpatronen
 description: Maak het een gebruiker zo gemakkelijk mogelijk om flexibel een veld in te voeren. Een vast invoerpatroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
 slug: /richtlijnen/formulieren/voorkom-fouten/geen-invoerpatronen
 keywords:

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
@@ -1,0 +1,26 @@
+---
+title: Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken | Voorkom fouten in een formulier | Richtlijnen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Gebruik geen invoerpatronen
+pagination_label: Gebruik geen invoerpatronen
+description: Maak het een gebruiker zo gemakkelijk mogelijk om flexibel een veld in te voeren. Een vast invoerpatroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
+slug: /richtlijnen/formulieren/voorkom-fouten/geen-invoerpatronen
+keywords:
+  - labels
+  - formulier
+  - design
+  - code
+---
+
+{/* @license CC0-1.0 */}
+
+import Guideline from "./_guideline.md";
+import GuidelineCode from "./_guideline.mdx";
+import FormFooterInfo from "../../_form_footer_info.md";
+
+<Guideline />
+
+<GuidelineCode />
+
+<FormFooterInfo />

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_category_.json
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Gebruik geen invoerpatronen",
+  "link": {
+    "type": "doc",
+    "id": "README"
+  }
+}

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_category_.json
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Gebruik geen invoerpatronen",
+  "label": "Vermijd invoerpatronen",
   "link": {
     "type": "doc",
     "id": "README"

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.md
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.md
@@ -1,16 +1,18 @@
 <!-- @license CC0-1.0 -->
 
-# Gebruik geen invoerpatroon op een formulierveld
+# Vermijd invoerpatroon op een formulierveld
 
 Maak het een gebruiker zo gemakkelijk mogelijk om flexibel een veld in te voeren. Een vast invoerpatroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
 
 Wanneer je een gebruiker dwingt om volgens een vast patroon bijvoorbeeld van telefoonnummer in te voeren, kan dit leiden tot verwarring als ze alleen een mobiel nummer heeft.
 
-Een pattern kan ook een blokkade zijn om een formulier in te vullen. Bijvoorbeeld:
+Een vast patroon kan ook een blokkade zijn om een formulier in te vullen. Bijvoorbeeld:
 
 - Het telefoonnummer past niet in het vereiste patroon: de gebruiker wil een buitenlands nummer invoeren, maar dat kan niet.
 - De gebruiker wil belangrijke informatie toevoegen zoals: 'alleen 's middags bellen' maar dat kan niet.
 - De gebruiker begrijpt niet wat er fout gaat omdat bijvoorbeeld letters niet kunnen worden ingevoerd en er geen goede feedback is over wat er fout gaat.
+
+**Let op**: Er zijn situaties waar het precies invullen van een formulierveld vereist is, zoals bijvoorbeeld bij het invoeren van een wachtwoord. Geef in dat geval altijd duidelijk in de description aan [hoe een veld in te vullen](/richtlijnen/formulieren/voorkom-fouten/geldige-waardes).
 
 ## Wat is een patroon op een invoerveld?
 
@@ -40,7 +42,7 @@ Dan heb je pech als je geen vaste telefoon meer hebt of een buitenlands nummer w
   id="telefoon"
   name="telefoon"
   pattern="[0-9]{3}-[0-9]{7}"
-  placeholder="010-4567890"
+  placeholder="___-_______"
   autocomplete="tel"
 />
 ```
@@ -50,12 +52,12 @@ Dan heb je pech als je geen vaste telefoon meer hebt of een buitenlands nummer w
 Adam Silver vat het goed samen in zijn artikel [<span lang="en">The problem with input masks and what to do instead</span>](https://adamsilver.io/blog/the-problem-with-input-masks-and-what-to-do-instead/).
 
 - Het patroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
-- Patronen zijn verwarrend, de cursor verspringt automatisch naar een volgende positie en speciale tekens kunnen niet worden verwijderd.
+- Afgedwongen patronen zijn verwarrend, de cursor verspringt automatisch naar een volgende positie en speciale tekens zoals '-', '(' of ')' kunnen niet worden verwijderd.
 - De placeholder met het voorbeeld kan lijken op een al ingevuld veld.
 - De placeholder met het voorbeeld verdwijnt bij het invullen en je weet niet meer hoe de rest van de waarde in te vullen.
-- Omdat de er tekens worden verwijderd of overgeslagen lijkt het alsof er wat fout gaat zonder dat er een foutmelding verschijnt.
+- Omdat de er tekens worden verwijderd of overgeslagen lijkt het alsof er wat fout gaat zonder dat er een meteen foutmelding verschijnt.
 
-In het artikel van Giovani Camara [Accessible input masking](https://giovanicamara.com/blog/accessible-input-masking/) laat hij de YouTube video [Allow users to edit anywhere](https://www.youtube.com/watch?v=rTk3XNSXJXY) zien wat er fout kan gaan als een gebruiker een waarde wil wijzigen. De cursus kan vanzelf naar het einde van de waarde springen, terwijl je het eerste karakter wilt aanpassen. Dit is voor iedereen irritant en leidt tot fouten.
+In het artikel van Giovani Camara [<span lang="en">Accessible input masking</span>](https://giovanicamara.com/blog/accessible-input-masking/) laat hij de YouTube video [<span lang="en">Allow users to edit anywhere</span>](https://www.youtube.com/watch?v=rTk3XNSXJXY) zien wat er fout kan gaan als een gebruiker een waarde wil wijzigen. De cursus kan vanzelf naar het einde van de waarde springen, terwijl je het eerste karakter wilt aanpassen. Dit is voor iedereen irritant en leidt tot fouten.
 
 Het aangeven van invoerpatronen in de placeholder of in het value-attribute kan heel zijn onduidelijk voor screenreader gebruikers. Een opsomming van underscores is niet erg informatief. Kijk en luister naar de [demo op YouTube van Giovani Camara](https://www.youtube.com/watch?v=7WWQXGgRDLc) hiervan met VoiceOver.
 

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.md
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.md
@@ -1,0 +1,69 @@
+<!-- @license CC0-1.0 -->
+
+# Gebruik geen invoerpatroon op een formulierveld
+
+Maak het een gebruiker zo gemakkelijk mogelijk om flexibel een veld in te voeren. Een vast invoerpatroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
+
+Wanneer je een gebruiker dwingt om volgens een vast patroon bijvoorbeeld van telefoonnummer in te voeren, kan dit leiden tot verwarring als ze alleen een mobiel nummer heeft.
+
+Een pattern kan ook een blokkade zijn om een formulier in te vullen. Bijvoorbeeld:
+
+- Het telefoonnummer past niet in het vereiste patroon: de gebruiker wil een buitenlands nummer invoeren, maar dat kan niet.
+- De gebruiker wil belangrijke informatie toevoegen zoals: 'alleen 's middags bellen' maar dat kan niet.
+- De gebruiker begrijpt niet wat er fout gaat omdat bijvoorbeeld letters niet kunnen worden ingevoerd en er geen goede feedback is over wat er fout gaat.
+
+## Wat is een patroon op een invoerveld?
+
+Een patroon legt precies vast hoe een formulierveld moet worden ingevuld en staat geen andere invoer toe.
+
+Dus kan door het gebruik van het [HTML-attribuut `pattern`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/pattern), in combinatie met JavaScript.
+
+Het `pattern` legt vast wat precies de waarde moet zijn, JavaScript controleert die waarde, past eventueel de layout aan en blokkeert niet-geldige invoer.
+
+Hoe de gebruiker een veld moet invoeren volgens het gewenste patroon staat dan in de description of in een placeholder.
+
+Je kunt een invoerveld van een voornaam beperken tot bijvoorbeeld minimaal 3 en maximaal 12 karakters.
+Dan heb je pech als je Jo of Claus-Casimir heet.
+
+```html
+<!-- Foute code, niet gebruiken -->
+<input id="voornaam" name="voornaam" type="text" pattern="\w{3,16}" autocomplete="given-name" />
+```
+
+Je kunt een invoerveld voor een telefoonnummer een verplicht formaat geven.
+Dan heb je pech als je geen vaste telefoon meer hebt of een buitenlands nummer wilt opgeven.
+
+```html
+<!-- Foute code, niet gebruiken -->
+<input
+  type="tel"
+  id="telefoon"
+  name="telefoon"
+  pattern="[0-9]{3}-[0-9]{7}"
+  placeholder="010-4567890"
+  autocomplete="tel"
+/>
+```
+
+## De problemen met de gebruikerservaring en de toegankelijkheid van invoerpatronen
+
+Adam Silver vat het goed samen in zijn artikel [<span lang="en">The problem with input masks and what to do instead</span>](https://adamsilver.io/blog/the-problem-with-input-masks-and-what-to-do-instead/).
+
+- Het patroon kan niet geschikt zijn voor het antwoord wat de gebruiker wil geven.
+- Patronen zijn verwarrend, de cursor verspringt automatisch naar een volgende positie en speciale tekens kunnen niet worden verwijderd.
+- De placeholder met het voorbeeld kan lijken op een al ingevuld veld.
+- De placeholder met het voorbeeld verdwijnt bij het invullen en je weet niet meer hoe de rest van de waarde in te vullen.
+- Omdat de er tekens worden verwijderd of overgeslagen lijkt het alsof er wat fout gaat zonder dat er een foutmelding verschijnt.
+
+In het artikel van Giovani Camara [Accessible input masking](https://giovanicamara.com/blog/accessible-input-masking/) laat hij de YouTube video [Allow users to edit anywhere](https://www.youtube.com/watch?v=rTk3XNSXJXY) zien wat er fout kan gaan als een gebruiker een waarde wil wijzigen. De cursus kan vanzelf naar het einde van de waarde springen, terwijl je het eerste karakter wilt aanpassen. Dit is voor iedereen irritant en leidt tot fouten.
+
+Het aangeven van invoerpatronen in de placeholder of in het value-attribute kan heel zijn onduidelijk voor screenreader gebruikers. Een opsomming van underscores is niet erg informatief. Kijk en luister naar de [demo op YouTube van Giovani Camara](https://www.youtube.com/watch?v=7WWQXGgRDLc) hiervan met VoiceOver.
+
+Is een exacte invoer nodig, bijvoorbeeld bij een geboortedatum, biedt dan een optie aan die iedereen makkelijk kan invullen. De richtlijn [Zorg dat iedereen een formulierelement kan bedienen of geef een alternatief](https://nldesignsystem.nl/richtlijnen/formulieren/wanneer-welk-form-element/iedereen-kan-invullen) gaat hier uitgebreid op in.
+
+Daarnaast zijn een goede description en duidelijke foutmeldingen belangrijk. Help de gebruiker en laat deze niet puzzelen over hoe precies een veld in te vullen en wat er nu weer fout gaat.
+
+Het geven van goede feedback over het juist invoeren van gegevens in formuliervelden is nodig om te voldoen aan de WCAG-succescriteria:
+
+- [3.3.1 Foutidentificatie](https://nldesignsystem.nl/wcag/3.3.1) (niveau A).
+- [3.3.3 Foutsuggestie](https://nldesignsystem.nl/wcag/3.3.3) (niveau AA).

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
@@ -1,0 +1,37 @@
+{/* @license CC0-1.0 */}
+
+import { Canvas } from "@site/src/components/Canvas/Canvas";
+import { Guideline } from "@site/src/components/Guideline";
+
+<Guideline appearance="do" title="Geef in de description aan hoe een veld kan worden ingevoerd.">
+  <Canvas language="html">
+    {() => (
+      <>
+        <label for="postcode1">Je postcode</label>
+        <input type="text" id="postcode1" name="postcode" autocomplete="postal-code" />
+      </>
+    )}
+  </Canvas>
+</Guideline>
+
+<Guideline
+  appearance="dont"
+  title="Gebruik het pattern-attribuut met het invoerpatroon en geef aan hoe een veld in te vullen met het value-attribuut."
+  description="Dit voorbeeld valideert de waarde niet met JavaScript en is alleen ter illustratie."
+>
+  <Canvas language="html">
+    {() => (
+      <>
+        <label for="postcode2">Je postcode</label>
+        <input
+          type="text"
+          placeholder="____ __"
+          id="postcode2"
+          name="postcode"
+          pattern="[1-9][0-9]{3}\s?[a-zA-Z]{2}"
+          autocomplete="postal-code"
+        />
+      </>
+    )}
+  </Canvas>
+</Guideline>

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
@@ -16,7 +16,7 @@ import { Guideline } from "@site/src/components/Guideline";
 
 <Guideline
   appearance="dont"
-  title="Gebruik het pattern-attribuut met het invoerpatroon en geef aan hoe een veld in te vullen met het value-attribuut."
+  title="Gebruik het pattern-attribuut met het invoerpatroon en geef aan hoe een veld in te vullen met de placeholder."
   description="Dit voorbeeld valideert de waarde niet met JavaScript en is alleen ter illustratie."
 >
   <Canvas language="html">

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/_guideline.mdx
@@ -7,8 +7,15 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <label for="postcode1">Je postcode</label>
-        <input type="text" id="postcode1" name="postcode" autocomplete="postal-code" />
+        <label for="bevestigingcode">Je bevestigingcode</label>
+        <p id="description-bevestigingcode">Vul een nummer van 8 cijfers in.</p>
+        <input
+          type="text"
+          inputmode="numeric"
+          id="bevestigingcode"
+          name="bevestigingcode"
+          aria-describedby="description-bevestigingcode"
+        />
       </>
     )}
   </Canvas>


### PR DESCRIPTION
Issue: https://github.com/nl-design-system/documentatie/issues/758
Preview: https://documentatie-git-guideline-no-mask-in-input-nl-design-system.vercel.app/richtlijnen/formulieren/voorkom-fouten/geen-invoerpatronen