### PR TITLE
docs: WCAG-pagina’s dummy descriptions uitgeschreven.

### DIFF
--- a/.changeset/wcag-add-description.md
+++ b/.changeset/wcag-add-description.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Betere descriptions toegevoegd voor de [WCAG-overzichtspagina](/wcag/).

--- a/docs/wcag/1.2.01.mdx
+++ b/docs/wcag/1.2.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.2.1 Louter-geluid en louter-videobeeld (vooraf opgenomen)
 pagination_label: WCAG-succescriterium 1.2.1 Louter-geluid en louter-videobeeld (vooraf opgenomen)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Bied je een vooraf opgenomen video aan zonder geluid of een vooraf opgenomen audio aan zonder beeld, zorg er dan voor dat deze informatie ook op een andere manier beschikbaar is.
 slug: 1.2.1
 keywords:
   - WCAG

--- a/docs/wcag/1.2.02.mdx
+++ b/docs/wcag/1.2.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.2.2 Ondertitels voor doven en slechthorenden (vooraf opgenomen)
 pagination_label: WCAG-succescriterium 1.2.2 Ondertitels voor doven en slechthorenden (vooraf opgenomen)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Voor vooraf opgenomen audio en video zijn ondertitels beschikbaar, behalve als deze informatie al op een andere manier beschikbaar is.
 slug: 1.2.2
 keywords:
   - WCAG

--- a/docs/wcag/1.2.03.mdx
+++ b/docs/wcag/1.2.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.2.3 Audiodescriptie of media-alternatief (vooraf opgenomen)
 pagination_label: WCAG-succescriterium 1.2.3 Audiodescriptie of media-alternatief (vooraf opgenomen)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Wordt er in een video informatie getoond die niet wordt voorgelezen? Zorg er dan voor dat een blinde of slechtziende gebruiker deze informatie ook meekrijgt.
 slug: 1.2.3
 keywords:
   - WCAG

--- a/docs/wcag/1.2.04.mdx
+++ b/docs/wcag/1.2.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.2.4 Ondertitels voor doven en slechthorenden (live)
 pagination_label: WCAG-succescriterium 1.2.4 Ondertitels voor doven en slechthorenden (live)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Voor alle live audio-streams zijn ondertitels beschikbaar.
 slug: 1.2.4
 keywords:
   - WCAG

--- a/docs/wcag/1.2.05.mdx
+++ b/docs/wcag/1.2.05.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.2.5 Audiodescriptie (vooraf opgenomen)
 pagination_label: WCAG-succescriterium 1.2.5 Audiodescriptie (vooraf opgenomen)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Vooraf opgenomen video's hebben een extra audiotrack, de audiodescriptie, die belangrijke informatie beschrijft, als deze informatie niet in de originele video wordt uitgesproken.
 slug: 1.2.5
 keywords:
   - WCAG

--- a/docs/wcag/1.3.03.mdx
+++ b/docs/wcag/1.3.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.3.3 Zintuiglijke eigenschappen
 pagination_label: WCAG-succescriterium 1.3.3 Zintuiglijke eigenschappen
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Geef instructies op een inclusieve manier. De instructies kunnen begrijpen moet niet afhankelijk zijn van eigenschappen die sommige gebruikers niet ervaren, zoals vorm, kleur, afmeting, locatie op het scherm, richting, of geluid.
 slug: 1.3.3
 keywords:
   - WCAG

--- a/docs/wcag/1.3.04.mdx
+++ b/docs/wcag/1.3.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.3.4 Weergavestand
 pagination_label: WCAG-succescriterium 1.3.4 Weergavestand
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat een gebruiker het scherm niet fysiek hoeft te draaien om de inhoud van de webpagina te goed kunnen zien. Je moet een de website kunnen bekijken in zowel landschap-modus als in portret-modus.
 slug: 1.3.4
 keywords:
   - WCAG

--- a/docs/wcag/1.4.01.mdx
+++ b/docs/wcag/1.4.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.1 Gebruik van kleur
 pagination_label: WCAG-succescriterium 1.4.1 Gebruik van kleur
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat kleur niet het enige visuele middel is om informatie over te brengen, een actie aan te geven, tot een reactie op te roepen of een visueel element te onderscheiden. Niet iedereen kan kleuren zien of verandering in kleur of kleurcontrast opmerken.
 slug: 1.4.1
 keywords:
   - WCAG

--- a/docs/wcag/1.4.02.mdx
+++ b/docs/wcag/1.4.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.2 Geluidsbediening
 pagination_label: WCAG-succescriterium 1.4.2 Geluidsbediening
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Speelt er automatisch geluid af op de webpagina en duurt dit langer dan 3 seconden? Zorg er dan voor dat de gebruiker het geluid kan stoppen, pauzeren of het volume kan regelen.
 slug: 1.4.2
 keywords:
   - WCAG

--- a/docs/wcag/1.4.03.mdx
+++ b/docs/wcag/1.4.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.3 Contrast (minimum)
 pagination_label: WCAG-succescriterium 1.4.3 Contrast (minimum)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Het contrast van de tekstkleur ten opzichte van de achtergrondkleur moet hoog genoeg zijn, zodat de tekst in het algemeen goed leesbaar wordt gevonden.
 slug: 1.4.3
 keywords:
   - WCAG

--- a/docs/wcag/1.4.04.mdx
+++ b/docs/wcag/1.4.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.4 Herschalen van tekst
 pagination_label: WCAG-succescriterium 1.4.4 Herschalen van tekst
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: De gebruiker moet tekst twee keer (200%) kunnen vergroten en nog steeds goed kunnen lezen.
 slug: 1.4.4
 keywords:
   - WCAG

--- a/docs/wcag/1.4.05.mdx
+++ b/docs/wcag/1.4.05.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.5 Afbeeldingen van tekst
 pagination_label: WCAG-succescriterium 1.4.5 Afbeeldingen van tekst
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Gebruik geen afbeeldingen van tekst, wanneer je ook gewone tekst kan gebruiken met vergelijkbare visuele opmaak.
 slug: 1.4.5
 keywords:
   - WCAG

--- a/docs/wcag/1.4.06.mdx
+++ b/docs/wcag/1.4.06.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.6 Contrast (versterkt)
 pagination_label: WCAG-succescriterium 1.4.6 Contrast (versterkt)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Maak het contrast van de tekstkleur ten opzichte van de achtergrondkleur hoog, zodat de tekst goed gelezen kan worden door gebruikers die een hoog contrast nodig hebben.
 slug: 1.4.6
 keywords:
   - WCAG

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.10 Reflow
 pagination_label: WCAG-succescriterium 1.4.10 Reflow
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: De gebruiker moet de webpagina 400% kunnen vergroten in de browser en inhoud nog steeds kunnen lezen en de website goed kunnen gebruiken.
 slug: 1.4.10
 keywords:
   - WCAG

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.11 Contrast van niet-tekstuele content
 pagination_label: WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg voor voldoende kleurcontrast tussen de achtergrondkleur en de kleur van componenten die visueel betekenis hebben.
 slug: 1.4.11
 keywords:
   - WCAG

--- a/docs/wcag/1.4.12.mdx
+++ b/docs/wcag/1.4.12.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.12 Tekstafstand
 pagination_label: WCAG-succescriterium 1.4.12 Tekstafstand
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Tekst kan op een aantal manieren aangepast worden, door mensen voor wie dat prettig is.
 slug: 1.4.12
 keywords:
   - WCAG

--- a/docs/wcag/1.4.13.mdx
+++ b/docs/wcag/1.4.13.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.13 Content bij hover of focus
 pagination_label: WCAG-succescriterium 1.4.13 Content bij hover of focus
-description: Wijzigt de inhoud door hover of focus, zorg er dan voor dat de interactie voorspelbaar.
+description: Als de inhoud wijzigt wanneer een gebruiker over een element hovert met de muis of het de toetsenbordfocus geeft, zorg er dan voor dat de interactie voorspelbaar is.
 slug: 1.4.13
 keywords:
   - WCAG

--- a/docs/wcag/1.4.13.mdx
+++ b/docs/wcag/1.4.13.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.13 Content bij hover of focus
 pagination_label: WCAG-succescriterium 1.4.13 Content bij hover of focus
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Wijzigt de inhoud door hover of focus, zorg er dan voor dat de interactie voorspelbaar.
 slug: 1.4.13
 keywords:
   - WCAG

--- a/docs/wcag/2.1.02.mdx
+++ b/docs/wcag/2.1.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.1.2 Geen toetsenbordval
 pagination_label: WCAG-succescriterium 2.1.2 Geen toetsenbordval
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Wanneer een gebruiker met het toetsenbord de focus verplaatst naar een deel van de pagina, dan moet deze ook weer weg kunnen gaan met het toetsenbord. De gebruiker kan daarvoor bijvoorbeeld de Tab-toets, Escape-toets of de pijltjestoetsen gebruiken. Zo niet, beschrijf dan met welke toets het wel kan.
 slug: 2.1.2
 keywords:
   - WCAG

--- a/docs/wcag/2.1.04.mdx
+++ b/docs/wcag/2.1.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.1.4 Enkel teken sneltoetsen
 pagination_label: WCAG-succescriterium 2.1.4 Enkel teken sneltoetsen
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Maak geen extra sneltoetsen aan die bestaan uit één letter. Dit geldt voor hoofdletters en kleine letters, leestekens, cijfers of symbolen. Sneltoetsen van één letter worden bijvoorbeeld al gebruikt door screenreaders.
 slug: 2.1.4
 keywords:
   - WCAG

--- a/docs/wcag/2.2.01.mdx
+++ b/docs/wcag/2.2.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.2.1 Timing aanpasbaar
 pagination_label: WCAG-succescriterium 2.2.1 Timing aanpasbaar
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Geldt er een tijdslimiet voor een onderdeel van de pagina? Zorg er dan voor dat de gebruiker de tijdslimiet kan uitzetten of verlengen. Waarschuw de gebruiker tenminste 20 seconden voor het verstrijken van de tijdslimiet en maak verlengen simpel.
 slug: 2.2.1
 keywords:
   - WCAG

--- a/docs/wcag/2.2.02.mdx
+++ b/docs/wcag/2.2.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.2.2 Pauzeren, stoppen, verbergen
 pagination_label: WCAG-succescriterium 2.2.2 Pauzeren, stoppen, verbergen
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat gebruikers zich op de inhoud van de website kunnen concentreren en niet worden afgeleid voor animaties, automatisch scrollen, knipperende onderdelen of voortdurende automatische updates.
 slug: 2.2.2
 keywords:
   - WCAG

--- a/docs/wcag/2.3.01.mdx
+++ b/docs/wcag/2.3.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.3.1 Drie flitsen of beneden drempelwaarde
 pagination_label: WCAG-succescriterium 2.3.1 Drie flitsen of beneden drempelwaarde
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen per seconde.
 slug: 2.3.1
 keywords:
   - WCAG

--- a/docs/wcag/2.4.03.mdx
+++ b/docs/wcag/2.4.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.3 Focus volgorde
 pagination_label: WCAG-succescriterium 2.4.3 Focus volgorde
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Wanneer een toetsenbordgebruiker binnen de webpagina navigeert, bijvoorbeeld met de Tab-toets, moet de tabvolgorde logisch en voorspelbaar zijn.
 slug: 2.4.3
 keywords:
   - WCAG

--- a/docs/wcag/2.4.05.mdx
+++ b/docs/wcag/2.4.05.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.5 Meerdere manieren
 pagination_label: WCAG-succescriterium 2.4.5 Meerdere manieren
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat er meer dan één manier is om een webpagina binnen website te vinden. Bijvoorbeeld via de hoofdnavigatie, het zoekveld en de sitemap.
 slug: 2.4.5
 keywords:
   - WCAG

--- a/docs/wcag/2.4.07.mdx
+++ b/docs/wcag/2.4.07.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.7 Focus zichtbaar
 pagination_label: 2.4.7 Focus zichtbaar
-description: Beschrijving, documentatie, gerelateerde richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
+description: Zorg dat het goed zichtbaar is welk element de toetsenbordfocus heeft, wanneer je door de website navigeert met een toetsenbord of vergelijkbare bediening. Dit kan bijvoorbeeld door het gebruik van een focusring (outline).
 slug: 2.4.7
 keywords:
   - WCAG

--- a/docs/wcag/2.4.11.mdx
+++ b/docs/wcag/2.4.11.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.11 Focus niet bedekt (minimum)
 pagination_label: WCAG-succescriterium 2.4.11 Focus niet bedekt (minimum)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat een element dat de toetsenbordfocus heeft zichtbaar is en niet volledig bedekt is door andere inhoud.
 slug: 2.4.11
 keywords:
   - WCAG

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.4.13 Focusweergave
 pagination_label: 2.4.13 Focusweergave
-description: Beschrijving, documentatie, gerelateerde richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
+description: Zorg dat het goed zichtbaar is welk element de toetsenbordfocus heeft, wanneer je door de website navigeert met een toetsenbord of vergelijkbare bediening. Het moet duidelijk te zien zijn waar de toetsenbordfocus zich bevindt.
 slug: 2.4.13
 keywords:
   - WCAG

--- a/docs/wcag/2.5.01.mdx
+++ b/docs/wcag/2.5.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.1 Aanwijzergebaren
 pagination_label: WCAG-succescriterium 2.5.1 Aanwijzergebaren
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Aanwijsgebaren zijn bijvoorbeeld het slepen van inhoud binnen bepaalde kaders, het swipen van foto's of het vergroten van een kaart met twee vingers. Zorg ervoor dat de gebruiker deze acties ook kan doen met één aanwijzer zoals een muis of een vinger zonder deze extra gebaren te hoeven maken.
 slug: 2.5.1
 keywords:
   - WCAG

--- a/docs/wcag/2.5.02.mdx
+++ b/docs/wcag/2.5.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.2 Aanwijzerannulering
 pagination_label: WCAG-succescriterium 2.5.2 Aanwijzerannulering
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat, als de gebruiker bijvoorbeeld een link of button indrukt met een aanwijzer zoals een muis of vinger, er de mogelijkheid is om actie te voorkomen of ongedaan te maken.
 slug: 2.5.2
 keywords:
   - WCAG

--- a/docs/wcag/2.5.03.mdx
+++ b/docs/wcag/2.5.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.3 Label in Naam
 pagination_label: WCAG-succescriterium 2.5.3 Label in Naam
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Voor bedieningselementen met een zichtbaar label, moet de zichtbare labeltekst aanwezig zijn in of overeenkomen met de toegankelijke naam.
 slug: 2.5.3
 keywords:
   - WCAG

--- a/docs/wcag/2.5.04.mdx
+++ b/docs/wcag/2.5.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.4 Bewegingsactivering
 pagination_label: WCAG-succescriterium 2.5.4 Bewegingsactivering
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Als de gebruiker een actie kan uitvoeren door een beweging te doen met het apparaat, dan moet er ook een manier zijn om die actie te doen zonder beweging. Niet iedereen kan bijvoorbeeld schudden met een mobiel.
 slug: 2.5.4
 keywords:
   - WCAG

--- a/docs/wcag/2.5.07.mdx
+++ b/docs/wcag/2.5.07.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.7 Sleepbewegingen
 pagination_label: WCAG-succescriterium 2.5.7 Sleepbewegingen
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Acties die werken met sleepbewegingen, waarbij de aanwijzer ingedrukt moet blijven terwijl je van de ene plek naar de andere plek sleept, hebben ook een manier om de handeling zonder sleepbeweging uit te voeren.
 slug: 2.5.7
 keywords:
   - WCAG

--- a/docs/wcag/2.5.08.mdx
+++ b/docs/wcag/2.5.08.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.5.8 Grootte van het aanwijsgebied (minimum)
 pagination_label: WCAG-succescriterium 2.5.8 Grootte van het aanwijsgebied (minimum)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat de aanklikbare elementen op een pagina groot genoeg zijn om makkelijk aan te klikken met een muis of vinger. Hierbij geldt dat het aan te klikken gebied ten minste 24 bij 24 pixels groot is.
 slug: 2.5.8
 keywords:
   - WCAG

--- a/docs/wcag/3.2.01.mdx
+++ b/docs/wcag/3.2.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.1 Bij focus
 pagination_label: WCAG-succescriterium 3.2.1 Bij focus
-description: Beschrijving, documentatie, gerelateerde richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
+description: Maak functionaliteit voorspelbaar en daardoor goed te begrijpen. Als een gebruiker een component focus geeft met het toetsenbord of door erop te klikken met de muis, zorg dan dat die actie niet automatisch een contextwijziging veroorzaakt.
 slug: 3.2.1
 keywords:
   - WCAG

--- a/docs/wcag/3.2.02.mdx
+++ b/docs/wcag/3.2.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.2 Bij input
 pagination_label: WCAG-succescriterium 3.2.2 Bij input
-description: Beschrijving, documentatie, gerelateerde richtlijnen, bronnen, gebruikersonderzoek en hoe te testen.
+description: Verras een gebruiker niet, maar maak functionaliteit voorspelbaar en daardoor goed te begrijpen. Als een gebruiker een formuliercomponent of -optie selecteert of een invoerveld invult met het toetsenbord of met de muis, veroorzaakt dit niet automatisch een contextwijziging.
 slug: 3.2.2
 keywords:
   - WCAG

--- a/docs/wcag/3.2.03.mdx
+++ b/docs/wcag/3.2.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.3 Consistente navigatie
 pagination_label: WCAG-succescriterium 3.2.3 Consistente navigatie
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat navigatie-componenten die voorkomen op meerdere pagina's overal op dezelfde manier werken. De navigatie staat op dezelfde plek op elke pagina, en de onderdelen staan in dezelfde volgorde.
 slug: 3.2.3
 keywords:
   - WCAG

--- a/docs/wcag/3.2.04.mdx
+++ b/docs/wcag/3.2.04.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.4 Consistente identificatie
 pagination_label: WCAG-succescriterium 3.2.4 Consistente identificatie
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat componenten die dezelfde functie hebben binnen een website, er hetzelfde uitzien en ook hetzelfde werken.
 slug: 3.2.4
 keywords:
   - WCAG

--- a/docs/wcag/3.2.06.mdx
+++ b/docs/wcag/3.2.06.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.2.6 Consistente hulp
 pagination_label: WCAG-succescriterium 3.2.6 Consistente hulp
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Bied je hulp aan, of manieren om contact op te nemen op de website? Zorg er dan voor dat die informatie, of een link naar deze informatie, consistent op elke pagina binnen de website op dezelfde plek terugkomt.
 slug: 3.2.6
 keywords:
   - WCAG

--- a/docs/wcag/3.3.02.mdx
+++ b/docs/wcag/3.3.02.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.2 Labels of instructies
 pagination_label: WCAG-succescriterium 3.3.2 Labels of instructies
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Toon een label voor alle invoervelden, en geef aanvullende instructies wanneer het label niet voldoende helpt om een veld goed in te vullen.
 slug: 3.3.2
 keywords:
   - WCAG

--- a/docs/wcag/3.3.07.mdx
+++ b/docs/wcag/3.3.07.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.7 Overbodige invoer
 pagination_label: WCAG-succescriterium 3.3.7 Overbodige invoer
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Zorg ervoor dat een gebruiker geen informatie dubbel hoeft in te vullen in een formulier.
 slug: 3.3.7
 keywords:
   - WCAG

--- a/docs/wcag/3.3.08.mdx
+++ b/docs/wcag/3.3.08.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.8 Toegankelijke authenticatie (minimum)
 pagination_label: WCAG-succescriterium 3.3.8 Toegankelijke authenticatie (minimum)
-description: Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting.
+description: Maak inloggen makkelijk. Gebruikers moeten een wachtwoordmanager kunnen gebruiken of een wachtwoord kunnen knippen en plakken. Veilige wachtwoorden zijn juist niet bedoeld om te kunnen onthouden en niet iedereen heeft een goed geheugen.
 slug: 3.3.8
 keywords:
   - WCAG

--- a/docs/wcag/3.3.08.mdx
+++ b/docs/wcag/3.3.08.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.3.8 Toegankelijke authenticatie (minimum)
 pagination_label: WCAG-succescriterium 3.3.8 Toegankelijke authenticatie (minimum)
-description: Maak inloggen makkelijk. Gebruikers moeten een wachtwoordmanager kunnen gebruiken of een wachtwoord kunnen knippen en plakken. Veilige wachtwoorden zijn juist niet bedoeld om te kunnen onthouden en niet iedereen heeft een goed geheugen.
+description: Maak inloggen makkelijk. Zorg dat inloggen niet afhankelijk is van een cognitieve functietest, zoals het onthouden van een wachtwoord.
 slug: 3.3.8
 keywords:
   - WCAG

--- a/docs/wcag/summaries/_1.4.13-summary.md
+++ b/docs/wcag/summaries/_1.4.13-summary.md
@@ -1,5 +1,7 @@
 <!-- @license CC0-1.0 -->
 
+Als de inhoud wijzigt wanneer een gebruiker over een element hovert met de muis of het de toetsenbordfocus geeft, zorg er dan voor dat de interactie voorspelbaar is.
+
 Bij sommige componenten wordt aanvullende content zichtbaar en daarna weer verborgen door het gebruik van hover met de aanwijzer (muis) of via focus met het toetsenbord. Bijvoorbeeld bij een uitklapmenu of bij het tonen van extra informatie in een tooltip.
 
 Hiervoor gelden enkele regels:

--- a/docs/wcag/summaries/_2.4.5-summary.md
+++ b/docs/wcag/summaries/_2.4.5-summary.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-Zorg ervoor dat er meer dan één manier is om een webpagina binnen website.
+Zorg ervoor dat er meer dan één manier is om een webpagina binnen website te vinden.
 
 Behalve wanneer de webpagina het resultaat is van een proces, bijvoorbeeld een stap in een formulier.
 

--- a/docs/wcag/summaries/_2.5.2-summary.md
+++ b/docs/wcag/summaries/_2.5.2-summary.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-Zorg ervoor dat als de gebruiker bijvoorbeeld een link of button indrukt met een aanwijzer zoals een muis of vinger, er de mogelijkheid is om actie te voorkomen of ongedaan te maken.
+Zorg ervoor dat, als de gebruiker bijvoorbeeld een link of button indrukt met een aanwijzer zoals een muis of vinger, er de mogelijkheid is om actie te voorkomen of ongedaan te maken.
 
 Dit voorkomt het per ongeluk aanraken en activeren van functies, waarvan het niet de bedoeling was.
 

--- a/docs/wcag/summaries/_3.2.3-summary.md
+++ b/docs/wcag/summaries/_3.2.3-summary.md
@@ -1,5 +1,5 @@
 <!-- @license CC0-1.0 -->
 
-Navigatie-componenten die voorkomen op meerdere pagina's werken overal op dezelfde manier. De navigatie staat op dezelfde plek op elke pagina, en de onderdelen staan in dezelfde volgorde.
+Zorg ervoor dat navigatie-componenten die voorkomen op meerdere pagina's overal op dezelfde manier werken. De navigatie staat op dezelfde plek op elke pagina, en de onderdelen staan in dezelfde volgorde.
 
 Denk hierbij aan de skiplink, het hoofdmenu, de zoekoptie en de links in de footer. Dit maakt de structuur van de website makkelijker te begrijpen en hierdoor kan de gebruiker sneller navigeren.

--- a/docs/wcag/summaries/_3.3.7-summary.md
+++ b/docs/wcag/summaries/_3.3.7-summary.md
@@ -1,5 +1,7 @@
 <!-- @license CC0-1.0 -->
 
+Zorg ervoor dat een gebruiker geen informatie dubbel hoeft in te vullen in een formulier.
+
 Informatie die al eerder is ingevoerd door of aangeboden aan de gebruiker en opnieuw moet worden ingevoerd in bijvoorbeeld hetzelfde formulier is:
 
 - automatisch ingevuld, of

--- a/docs/wcag/summaries/_3.3.8-summary.md
+++ b/docs/wcag/summaries/_3.3.8-summary.md
@@ -1,6 +1,8 @@
 <!-- @license CC0-1.0 -->
 
-Maak inloggen makkelijk. Gebruikers moeten een wachtwoordmanager kunnen gebruiken of een wachtwoord kunnen knippen en plakken. Veilige wachtwoorden zijn juist niet bedoeld om te kunnen onthouden en niet iedereen heeft een goed geheugen.
+Maak inloggen makkelijk. Zorg dat inloggen niet afhankelijk is van een cognitieve functietest, zoals het onthouden van een wachtwoord.
+
+Gebruikers moeten een wachtwoordmanager kunnen gebruiken of een wachtwoord kunnen knippen en plakken. Veilige wachtwoorden zijn juist niet bedoeld om te kunnen onthouden en niet iedereen heeft een goed geheugen.
 
 Het onthouden van een wachtwoord of het oplossen van een puzzel is bij geen enkele stap van een authenticatie proces verplicht, behalve in de volgende gevallen:
 


### PR DESCRIPTION
Gerelateerd issue: #1304 
Preview: https://documentatie-git-wcag-add-descriptions-nl-design-system.vercel.app/wcag

Deze PR vervangt alle "Aan deze inhoud wordt gewerkt en bevat nu referenties en een korte samenvatting." teksten door een korte samenvatting, gebaseerd op de summary (maar dan in 1 of 2 zinnen).
Deze description is te zien op de overzichtspagina https://nldesignsystem.nl/wcag


