### PR TITLE
feat: use search params for filters

### DIFF
--- a/src/components/ComponentPage.tsx
+++ b/src/components/ComponentPage.tsx
@@ -127,7 +127,7 @@ export const Implementations = ({ component, headingLevel }: ComponentPageSectio
                   {project.progress.value} van {project.progress.max} stappen gedocumenteerd op het{' '}
                   <Link href={project.url}>{project.title} projectbord</Link>
                 </Paragraph>
-                {links.length && (
+                {links.length > 0 && (
                   <>
                     <Heading level={headingLevel + 1}>Component gebruiken?</Heading>
                     <LinkList>


### PR DESCRIPTION
Door de filter keuzes naar de search parameters in de url te pushen blijven de filters aan na refresh én kan een URL inclusief filters worden gedeeld.

Stel je gaat nu naar https://www.nldesignsystem.nl/componenten/?filter=helpWanted&filter=todo dan doet het niets.

Met deze PR kun je naar https://documentatie-git-fix-component-implemen-9870e6-nl-design-system.vercel.app/componenten/?filter=helpWanted&filter=todo en dan zie je geen componenten meer met Help Wanted of Todo status. 

