### PR TITLE
docs: WCAG-pagina 2.2.5 Herauthentisering - summary

### DIFF
--- a/.changeset/wcag-2.2.5-summary.md
+++ b/.changeset/wcag-2.2.5-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.2.5 Herauthentisering](/wcag/2.2.5).

--- a/docs/wcag/2.2.05.mdx
+++ b/docs/wcag/2.2.05.mdx
@@ -1,0 +1,42 @@
+---
+title: WCAG-succescriterium 2.2.5 Herauthentisering
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.2.5 Herauthentisering
+pagination_label: WCAG-succescriterium 2.2.5 Herauthentisering
+description: Zorg ervoor dat er als een geauthentiseerde sessie verloopt, de gebruiker de activiteit zonder gegevensverlies voortzetten na opnieuw authentiseren.
+slug: 2.2.5
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.2.5-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.2.5 Herauthentisering</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.2.5 Re-authenticating</span>](https://www.w3.org/TR/WCAG22/#/re-authenticating).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.2.5 Herauthentisering](https://www.w3.org/Translations/WCAG22-nl/#herauthentisering).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.2.5 Re-authenticating</span>](https://www.w3.org/WAI/WCAG22/quickref/#/re-authenticating).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.2.5 Re-authenticating</span>](https://www.w3.org/WAI/WCAG22/Understanding//re-authenticating.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_2.2.5-summary.md
+++ b/docs/wcag/summaries/_2.2.5-summary.md
@@ -2,6 +2,8 @@
 
 Zorg ervoor dat er als een geauthentiseerde sessie verloopt, de gebruiker de activiteit zonder gegevensverlies kan voortzetten na opnieuw authentiseren.
 
+Sommige gebruikers hebben meer tijd nodig dan anderen om een taak af te maken.
+
 Voorbeelden:
 
 - Na opnieuw inloggen bij een webwinkel, staat je bestelling nog steeds in het winkelwagentje.

--- a/docs/wcag/summaries/_2.2.5-summary.md
+++ b/docs/wcag/summaries/_2.2.5-summary.md
@@ -1,0 +1,9 @@
+<!-- @license CC0-1.0 -->
+
+Zorg ervoor dat er als een geauthentiseerde sessie verloopt, de gebruiker de activiteit zonder gegevensverlies kan voortzetten na opnieuw authentiseren.
+
+Voorbeelden:
+
+- Na opnieuw inloggen bij een webwinkel, staat je bestelling nog steeds in het winkelwagentje.
+- Je bent bezig met het opstellen van een e-mail, de tekst gaat niet verloren als je uitgelogd wordt.
+- Tijdens het invullen van een enquete moet je opnieuw inloggen. De vragen die je al hebt beantwoord zijn bewaard.


### PR DESCRIPTION
Voegt de pagina /wcag/2.2.5/ toe met alleen een summary.
Gerelateerd issue: #1304
Preview: https://documentatie-git-docs-wcag-255-nl-design-system.vercel.app/wcag/2.2.5/ 

Note: branch heet wcag-2.5.5 ivp 2.2.5 :typo:
