### PR TITLE
fix: WCAG 2.2.4 change label in the WCAG sidebar

### DIFF
--- a/docs/wcag/2.2.04.mdx
+++ b/docs/wcag/2.2.04.mdx
@@ -2,7 +2,7 @@
 title: WCAG-succescriterium 2.2.4 Onderbrekingen
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: 2.2.3 Geen timing
+sidebar_label: 2.2.4 Onderbrekingen
 pagination_label: WCAG-succescriterium 2.2.4 Onderbrekingen
 description: Stel onderbrekingen uit of zorg ervoor dat de gebruiker onderbrekingen kan uitzetten, behalve in noodsituaties.
 slug: 2.2.4


### PR DESCRIPTION
was: 2.2.3 Geen timing
moet zijn: 2.2.4 Onderbrekingen
