### PR TITLE
docs: WCAG 2.3.2 Drie flitsen summery en tekstaanpassing 2.3.1 Drie flitsen of beneden drempelwaarde

### DIFF
--- a/.changeset/wcag-2.3.2-summary.md
+++ b/.changeset/wcag-2.3.2-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.3.2 Drie flitsen](/wcag/2.3.2) en de tekst van de samenvatting [WCAG-succescriterium 2.3.1 Drie flitsen of beneden drempelwaarde](/wcag/2.3.1) uitgebreid met de uitzondering.

--- a/docs/wcag/2.3.01.mdx
+++ b/docs/wcag/2.3.01.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2.3.1 Drie flitsen of beneden drempelwaarde
 pagination_label: WCAG-succescriterium 2.3.1 Drie flitsen of beneden drempelwaarde
-description: Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen per seconde.
+description: Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen binnen één seconde of maak het gebied dat flitsen bevat klein genoeg.
 slug: 2.3.1
 keywords:
   - WCAG

--- a/docs/wcag/2.3.02.mdx
+++ b/docs/wcag/2.3.02.mdx
@@ -2,10 +2,10 @@
 title: WCAG-succescriterium 2.3.2 Drie flitsen
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: 2.3.1 Drie flitsen
-pagination_label: WCAG-succescriterium 2.3.1 Drie flitsen
+sidebar_label: 2.3.2 Drie flitsen
+pagination_label: WCAG-succescriterium 2.3.2 Drie flitsen
 description: Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen binnen één seconde.
-slug: 2.3.1
+slug: 2.3.2
 keywords:
   - WCAG
 ---
@@ -15,17 +15,17 @@ keywords:
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
-import Summary from "./summaries/_2.3.1-summary.md";
+import Summary from "./summaries/_2.3.2-summary.md";
 
 {/* prettier-ignore */}
-<WcagHeadingGroup level={1} conformanceLevel="Niveau A">WCAG-succescriterium 2.3.1 Drie flitsen of beneden drempelwaarde</WcagHeadingGroup>
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.3.2 Drie flitsen</WcagHeadingGroup>
 
 ## W3C referenties
 
-- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/TR/WCAG22/#three-flashes-or-below-threshold).
-- Nederlandse vertaling van het WCAG-succescriterium: [2.3.1 Drie flitsen of beneden drempelwaarde](https://www.w3.org/Translations/WCAG22-nl/#drie-flitsen-of-beneden-drempelwaarde).
-- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/WAI/WCAG22/quickref/#three-flashes-or-below-threshold).
-- Engelstalige toelichting: [<span lang="en">Understanding SC 2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold.html).
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.3.2 Three Flashes</span>](https://www.w3.org/TR/WCAG22/#three-flashes).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.3.2 Drie flitsen](https://www.w3.org/Translations/WCAG22-nl/#drie-flitsen).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.3.2 Three Flashes</span>](https://www.w3.org/WAI/WCAG22/quickref/#three-flashes).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.3.2</span>](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes).
 
 ## Uitleg
 

--- a/docs/wcag/2.3.02.mdx
+++ b/docs/wcag/2.3.02.mdx
@@ -1,0 +1,42 @@
+---
+title: WCAG-succescriterium 2.3.2 Drie flitsen
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.3.1 Drie flitsen
+pagination_label: WCAG-succescriterium 2.3.1 Drie flitsen
+description: Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen binnen één seconde.
+slug: 2.3.1
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.3.1-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau A">WCAG-succescriterium 2.3.1 Drie flitsen of beneden drempelwaarde</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/TR/WCAG22/#three-flashes-or-below-threshold).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.3.1 Drie flitsen of beneden drempelwaarde](https://www.w3.org/Translations/WCAG22-nl/#drie-flitsen-of-beneden-drempelwaarde).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/WAI/WCAG22/quickref/#three-flashes-or-below-threshold).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.3.1 Three Flashes or Below Threshold</span>](https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_2.3.1-summary.md
+++ b/docs/wcag/summaries/_2.3.1-summary.md
@@ -1,7 +1,7 @@
 <!-- @license CC0-1.0 -->
 
-Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen per seconde.
+Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen binnen één seconde of maak het gebied dat flitsen bevat klein genoeg.
 
-Het tonen van meer dan drie flitsen per seconde kan een epileptische aanval veroorzaken bij gebruikers die hiervoor gevoelig zijn.
+Het tonen van meer dan drie flitsen binnen één seconde kan een epileptische aanval veroorzaken bij gebruikers die hiervoor gevoelig zijn.
 
 Dit geldt voor alle onderdelen van de website, zoals animaties, video's en de overgang tussen pagina's.

--- a/docs/wcag/summaries/_2.3.2-summary.md
+++ b/docs/wcag/summaries/_2.3.2-summary.md
@@ -1,0 +1,7 @@
+<!-- @license CC0-1.0 -->
+
+Zorg ervoor dat de website geen onderdelen bevat met meer dan drie flitsen binnen één seconde.
+
+Het tonen van meer dan drie flitsen binnen één seconde kan een epileptische aanval veroorzaken bij gebruikers die hiervoor gevoelig zijn.
+
+Dit geldt voor alle onderdelen van de website, zoals animaties, video's en de overgang tussen pagina's.


### PR DESCRIPTION
Gerelateerd issue: #1304
Previews:
https://documentatie-git-docs-wcag-232-summary-nl-design-system.vercel.app/wcag/2.3.2
https://documentatie-git-docs-wcag-232-summary-nl-design-system.vercel.app/wcag/2.3.1

De tekst van 2.3.1 is iets uitgebeid om het verschil met 2.3.2 beter te beschrijven.