### PR TITLE
docs: WCAG 2.4.8 Locatie - summary

### DIFF
--- a/.changeset/wcag-2.4.8-summary.md
+++ b/.changeset/wcag-2.4.8-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.4.8 Locatie](/wcag/2.4.8).

--- a/docs/wcag/2.4.07.mdx
+++ b/docs/wcag/2.4.07.mdx
@@ -25,7 +25,7 @@ import Summary from "./summaries/_2.4.7-summary.md";
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.7 Focus Visible</span>](https://www.w3.org/TR/WCAG22/#focus-visible).
 - Nederlandse vertaling van het WCAG-succescriterium: [2.4.7 Focus zichtbaar](https://www.w3.org/Translations/WCAG22-nl/#focus-zichtbaar).
-- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 12.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.7 Focus Visible</span>](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html).
 
 ## Uitleg

--- a/docs/wcag/2.4.08.mdx
+++ b/docs/wcag/2.4.08.mdx
@@ -1,0 +1,43 @@
+---
+title: WCAG-succescriterium 2.4.8 Locatie
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.4.8 Locatie
+pagination_label: 2.4.8 Locatie
+description: Laat gebruikers weten waar ze zich precies bevinden binnen een website.
+slug: 2.4.8
+keywords:
+  - WCAG
+  - Toetsenbord
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.4.8-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.4.8 Locatie</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.8 Location</span>](https://www.w3.org/TR/WCAG22/#location).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.8 Locatie](https://www.w3.org/Translations/WCAG22-nl/#locatie).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.8 Location</span>](https://www.w3.org/WAI/WCAG22/quickref/#location).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.8 Location</span>](https://www.w3.org/WAI/WCAG22/Understanding/location.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_2.4.8-summary.md
+++ b/docs/wcag/summaries/_2.4.8-summary.md
@@ -1,0 +1,11 @@
+<!-- @license CC0-1.0 -->
+
+Laat gebruikers weten waar ze zich precies bevinden binnen een website.
+
+Dit is voor iedereen fijn, maar speciaal ook voor mensen met een cognitieve beperking. Ook bezoekers, die via een zoekmachine en niet via de homepagina binnenkomen, begrijpen dan waar ze zich bevinden.
+
+Dit kan via bijvoorbeeld:
+
+- Een broodkruimelpad.
+- Het aangeven van de huidige pagina in een menu.
+- Een sitemap.

--- a/docs/wcag/summaries/_2.4.8-summary.md
+++ b/docs/wcag/summaries/_2.4.8-summary.md
@@ -2,7 +2,7 @@
 
 Laat gebruikers weten waar ze zich precies bevinden binnen een website.
 
-Dit is voor iedereen fijn, maar speciaal ook voor mensen met een cognitieve beperking. Ook bezoekers, die via een zoekmachine en niet via de homepagina binnenkomen, begrijpen dan waar ze zich bevinden.
+Dit is voor iedereen fijn, maar speciaal ook voor mensen met een cognitieve beperking. Ook bezoekers die via een zoekmachine en niet via de homepagina binnenkomen begrijpen dan waar ze zich bevinden.
 
 Dit kan via bijvoorbeeld:
 


### PR DESCRIPTION
Voegt pagina met samenvatting "WCAG-pagina 2.4.8 Locatie" toe.
Gerelateerd issue https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-docs-wcag-248-summary-nl-design-system.vercel.app/wcag/2.4.8