### PR TITLE
docs: WCAG 2.4.9 Linkdoel (alleen link) - summary

### DIFF
--- a/.changeset/wcag-2.4.9-summary.md
+++ b/.changeset/wcag-2.4.9-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.4.9 Linkdoel (alleen link)](/wcag/2.4.9).

--- a/docs/wcag/2.4.09.mdx
+++ b/docs/wcag/2.4.09.mdx
@@ -1,0 +1,42 @@
+---
+title: WCAG-succescriterium 2.4.9 Linkdoel (alleen link)
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.4.9 Linkdoel (alleen link)
+pagination_label: WCAG-succescriterium 2.4.9 Linkdoel (alleen link)
+description: Maak duidelijk waar een link naartoe gaat. Zorg dat de linktekst op zichzelf het doel duidelijk beschrijft.
+slug: 2.4.9
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.4.9-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.4.9 Linkdoel (alleen link)</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.9 Link Purpose (Link Only)</span>](https://www.w3.org/TR/WCAG22/#link-purpose-link-only).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.9 Linkdoel (alleen link)](https://www.w3.org/Translations/WCAG22-nl/#linkdoel-alleen-link).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.9 Link Purpose (Link Only)</span>](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.9 Link Purpose (Link Only)</span>](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-link-only.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_2.4.9-summary.md
+++ b/docs/wcag/summaries/_2.4.9-summary.md
@@ -1,0 +1,8 @@
+<!-- @license CC0-1.0 -->
+
+Maak duidelijk waar een link naartoe gaat. Zorg dat de linktekst op zichzelf het doel duidelijk beschrijft.
+Behalve waar het doel van de link dubbelzinnig voor gebruikers in het algemeen zou zijn.
+
+De linktekst is de tekst die zichtbaar is, maar ook de tekst die aan een gebruiker van hulpsoftware wordt voorgelezen. Screenreadergebruikers kunnen een lijst van alle links op een pagina oproepen en zo snel door de website navigeren, maar dan moeten de linkteksten wel onderscheidbaar zijn. De linktekst 'Klik hier' geeft dan onvoldoende informatie.
+
+Uitgebreide informatie over goede linkteksten staat bij [WCAG-succescriterium 2.4.4 Linkdoel (in context)](/wcag/2.4.4).


### PR DESCRIPTION
Voegt pagina met samenvatting "WCAG-pagina 2.4.9 Linkdoel (alleen link)" toe.
Gerelateerd issue https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-docs-wcag-249-summary-nl-design-system.vercel.app/wcag/2.4.9