### PR TITLE
docs: WCAG 2.4.12 Focus niet bedekt (uitgebreid) - summary

### DIFF
--- a/.changeset/wcag-2.4.12-summary.md
+++ b/.changeset/wcag-2.4.12-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 2.4.12 Focus niet bedekt (uitgebreid)](/wcag/2.4.12).

--- a/docs/wcag/2.4.12.mdx
+++ b/docs/wcag/2.4.12.mdx
@@ -1,0 +1,42 @@
+---
+title: WCAG-succescriterium 2.4.12 Focus niet bedekt (uitgebreid)
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 2.4.12 Focus niet bedekt (uitgebreid)
+pagination_label: WCAG-succescriterium 2.4.12 Focus niet bedekt (uitgebreid)
+description: Zorg ervoor dat een element dat de toetsenbordfocus heeft volledig zichtbaar is en niet bedekt is door andere inhoud.
+slug: 2.4.12
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_2.4.12-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AA">WCAG-succescriterium 2.4.11 Focus niet bedekt (minimum)</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">2.4.12 Focus Not Obscured (Enhanced)</span>](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced).
+- Nederlandse vertaling van het WCAG-succescriterium: [2.4.12 Focus niet bedekt (uitgebreid)](https://www.w3.org/Translations/WCAG22-nl/#focus-not-obscured-enhanced).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 2.4.12 Focus Not Obscured (Enhanced)</span>](https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 2.4.12 Focus Not Obscured (Enhanced)</span>](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/2.4.12.mdx
+++ b/docs/wcag/2.4.12.mdx
@@ -18,7 +18,7 @@ import WCAGFooterInfo from "./_wcag_footer_info.md";
 import Summary from "./summaries/_2.4.12-summary.md";
 
 {/* prettier-ignore */}
-<WcagHeadingGroup level={1} conformanceLevel="Niveau AA">WCAG-succescriterium 2.4.11 Focus niet bedekt (minimum)</WcagHeadingGroup>
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 2.4.12 Focus niet bedekt (uitgebreid)</WcagHeadingGroup>
 
 ## W3C referenties
 

--- a/docs/wcag/summaries/_2.4.12-summary.md
+++ b/docs/wcag/summaries/_2.4.12-summary.md
@@ -1,0 +1,5 @@
+<!-- @license CC0-1.0 -->
+
+Zorg ervoor dat een element dat de toetsenbordfocus heeft volledig zichtbaar is en niet bedekt is door andere inhoud.
+
+Dit is belangrijk voor gebruikers van alleen een toetsenbord of van spraakbesturing.


### PR DESCRIPTION
Voegt pagina met samenvatting "2.4.12 Focus niet bedekt (uitgebreid)" toe.
Gerelateerd issue https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-docs-wcag-2412-summary-nl-design-system.vercel.app/wcag/2.4.12