### PR TITLE
docs: WCAG 3.1.3 Ongebruikelijke woorden - summary

### DIFF
--- a/.changeset/wcag-3.1.3-summary.md
+++ b/.changeset/wcag-3.1.3-summary.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Samenvatting toegevoegd voor het [WCAG-succescriterium 3.1.3 Ongebruikelijke woorden](/wcag/3.1.3).

--- a/docs/wcag/3.1.03.mdx
+++ b/docs/wcag/3.1.03.mdx
@@ -4,10 +4,9 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3.1.3 Ongebruikelijke woorden
 pagination_label: WCAG-succescriterium 3.1.3 Ongebruikelijke woorden
-description: Maak functionaliteit voorspelbaar en daardoor goed te begrijpen. Als een gebruiker een component focus geeft met het toetsenbord of door erop te klikken met de muis, zorg dan dat die actie niet automatisch een contextwijziging veroorzaakt.
+description: Voeg uitleg toe over ongebruikelijke woorden of zinsdelen en over woorden die op een ongebruikelijke manier worden gebruikt. Dit geldt ook voor vakjargon en uitdrukkingen die niet letterlijk kunnen worden begrepen zoals idioom en spreekwoorden.
 slug: 3.1.3
 keywords:
-  Voeg uitleg toe over ongebruikelijke woorden of zinsdelen en over woorden die op een ongebruikelijke manier worden gebruikt. Dit geldt ook voor vakjargon en uitdrukkingen die niet letterlijk kunnen worden begrepen zoals idioom en spreekwoorden.
   - WCAG
 ---
 

--- a/docs/wcag/3.1.03.mdx
+++ b/docs/wcag/3.1.03.mdx
@@ -1,0 +1,43 @@
+---
+title: WCAG-succescriterium 3.1.3 Ongebruikelijke woorden
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 3.1.3 Ongebruikelijke woorden
+pagination_label: WCAG-succescriterium 3.1.3 Ongebruikelijke woorden
+description: Maak functionaliteit voorspelbaar en daardoor goed te begrijpen. Als een gebruiker een component focus geeft met het toetsenbord of door erop te klikken met de muis, zorg dan dat die actie niet automatisch een contextwijziging veroorzaakt.
+slug: 3.1.3
+keywords:
+  Voeg uitleg toe over ongebruikelijke woorden of zinsdelen en over woorden die op een ongebruikelijke manier worden gebruikt. Dit geldt ook voor vakjargon en uitdrukkingen die niet letterlijk kunnen worden begrepen zoals idioom en spreekwoorden.
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_3.1.3-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau AAA">WCAG-succescriterium 3.1.3 Ongebruikelijke woorden</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.1.3 Unusual Words</span>](https://www.w3.org/TR/WCAG22/#unusual-words)
+- Nederlandse vertaling van het WCAG-succescriterium: [3.1.3 Ongebruikelijke woorden](https://www.w3.org/Translations/WCAG22-nl/#ongebruikelijke-woorden).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.1.3 Unusual Words</span>](https://www.w3.org/WAI/WCAG22/quickref/#unusual-words).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 3.1.3: Unusual Words</span>](https://www.w3.org/WAI/WCAG22/Understanding/unusual-words.html).
+
+## Uitleg
+
+<Summary />
+
+## Opgelet
+
+Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+
+## Gebruikersonderzoek
+
+<CTAGebruikersonderzoek />
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_3.1.3-summary.md
+++ b/docs/wcag/summaries/_3.1.3-summary.md
@@ -1,0 +1,11 @@
+<!-- @license CC0-1.0 -->
+
+Voeg uitleg toe over ongebruikelijke woorden of zinsdelen en over woorden die op een ongebruikelijke manier worden gebruikt. Dit geldt ook voor vakjargon en uitdrukkingen die niet letterlijk kunnen worden begrepen zoals idioom en spreekwoorden.
+
+Dit is fijn voor lezers:
+
+- voor wie Nederlands niet de moedertaal is;
+- met een cognitieve beperking die uitdrukkingen en spreekwoorden niet begrijpen omdat ze tekst letterlijk nemen.
+- die de woorden in vakjargon niet kennen.
+
+Bied links naar de uitleg aan of verduidelijk woorden in de tekst zelf.


### PR DESCRIPTION
Voegt pagina met samenvatting "3.1.3 Ongebruikelijke woorden" toe.
Gerelateerd issue https://github.com/nl-design-system/documentatie/issues/1304
Preview: https://documentatie-git-docs-wcag-313-summary-nl-design-system.vercel.app/wcag/3.1.3