### PR TITLE
docs: WCAG-pagina 3.3.6 Foutpreventie (alle)

### DIFF
--- a/.changeset/wcag-3.3.md
+++ b/.changeset/wcag-3.3.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Pagina toegevoegd voor het [WCAG-succescriterium 3.3.6 Foutpreventie (alle)](/wcag/3.3.6).

--- a/docs/richtlijnen/formulieren/multistep/2-location/_guideline.md
+++ b/docs/richtlijnen/formulieren/multistep/2-location/_guideline.md
@@ -6,4 +6,4 @@ Plaats tekst en uitleg die hoort bij het formulier buiten het `<form>` element. 
 
 Het voordeel van een formulier in meer stappen is, dat je makkelijker uitgebreide informatie per stap kunt toevoegen **boven** het formulier. Dat scheelt de complexiteit van eventueel gebruik van ARIA om tekst te laten voorlezen bij een formulierveld.
 
-Het aangeven van de hoeveelheid stappen boven het formulier is nodig om te voldoen aan het [WCAG-succescriterium 1.3.2 Betekenisvolle volgorde](wcag/1.3.2) (niveau A).
+Het aangeven van de hoeveelheid stappen boven het formulier is nodig om te voldoen aan het [WCAG-succescriterium 1.3.2 Betekenisvolle volgorde](/wcag/1.3.2) (niveau A).

--- a/docs/richtlijnen/formulieren/placeholder/4-colour-contrast/_guideline.md
+++ b/docs/richtlijnen/formulieren/placeholder/4-colour-contrast/_guideline.md
@@ -17,4 +17,4 @@ Zie [::placeholder - CSS: Cascading Style Sheets](https://developer.mozilla.org/
 
 **Tip:** De lichtste kleur grijs die je kunt gebruiken ten opzichte van een witte achtergrond is #757575 of rgb( 117, 117, 117).
 
-Voldoende kleurcontrast tussen placeholder en achtergrond is nodig om te voldoen aan het [WCAG-succescriterium 1.4.3 Contrast (minimum)](wcag/1.4.3) (niveau AA).
+Voldoende kleurcontrast tussen placeholder en achtergrond is nodig om te voldoen aan het [WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3) (niveau AA).

--- a/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
+++ b/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
@@ -9,4 +9,4 @@ Als het essentieel is dat de informatie correct is, zijn er deze alternatieven:
 - toon dan voor het verzenden nog eens de invoer, bijvoorbeeld op een controlepagina;
 - (als het om een e-mailadres gaat) stuur een e-mail ter bevestiging om de juistheid van het e-mailadres te controleren.
 
-Gegevens niet meerdere keren binnen een formulier uit vragen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.7 Overbodige Invoer](/wcag/3.3.7) (niveau A).
+Gegevens niet meerdere keren binnen een formulier uitvragen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.7 Overbodige Invoer](/wcag/3.3.7) (niveau A).

--- a/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
+++ b/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/_guideline.md
@@ -9,4 +9,4 @@ Als het essentieel is dat de informatie correct is, zijn er deze alternatieven:
 - toon dan voor het verzenden nog eens de invoer, bijvoorbeeld op een controlepagina;
 - (als het om een e-mailadres gaat) stuur een e-mail ter bevestiging om de juistheid van het e-mailadres te controleren.
 
-Gegevens niet meerdere keren binnen een formulier uit vragen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.7 Overbodige Invoer](wcag/3.3.7) (niveau A).
+Gegevens niet meerdere keren binnen een formulier uit vragen is nodig om te voldoen aan het [WCAG-succescriterium 3.3.7 Overbodige Invoer](/wcag/3.3.7) (niveau A).

--- a/docs/wcag/3.3.06.mdx
+++ b/docs/wcag/3.3.06.mdx
@@ -1,0 +1,35 @@
+---
+title: WCAG-succescriterium 3.3.6 Foutpreventie (alle)
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: 3.3.6 Foutpreventie (alle)
+pagination_label: WCAG-succescriterium 3.3.6 Foutpreventie (alle)
+description: Wanneer een gebruiker een formulier invult zorg er dan voor dat gebruiker de ingevulde gegevens kan controleren en corrigeren.
+slug: 3.3.6
+keywords:
+  - WCAG
+---
+
+{/* @license CC0-1.0 */}
+
+import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
+import WCAGFooterInfo from "./_wcag_footer_info.md";
+import Summary from "./summaries/_3.3.6-summary.md";
+
+{/* prettier-ignore */}
+<WcagHeadingGroup level={1} conformanceLevel="Niveau A">WCAG-succescriterium 3.3.6 Foutpreventie (alle)</WcagHeadingGroup>
+
+## W3C referenties
+
+- Engelse tekst van het WCAG-succescriterium: [<span lang="en">3.3.6 Error Prevention (All)</span>](https://www.w3.org/TR/WCAG22/#error-prevention-all.).
+- Nederlandse vertaling van het WCAG-succescriterium: [3.3.6 Foutpreventie (alle)](https://www.w3.org/Translations/WCAG22-nl/#foutpreventie-alle).
+- Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 3.3.6 Error Prevention (All)</span>](https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-all).
+- Engelstalige toelichting: [<span lang="en">Understanding SC 3.3.6: Error Prevention (All)</span>](https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-all.html).
+
+## Uitleg
+
+<Summary />
+
+Informatie over bronnen, gebruikersonderzoek en hoe te testen kun je vinden op de pagina [WCAG Succescriterium 3.3.4](/wcag/3.3.4).
+
+<WCAGFooterInfo />

--- a/docs/wcag/summaries/_3.3.6-summary.md
+++ b/docs/wcag/summaries/_3.3.6-summary.md
@@ -1,0 +1,11 @@
+<!-- @license CC0-1.0 -->
+
+Wanneer een gebruiker een formulier invult zorg er dan voor dat gebruiker de ingevulde gegevens kan controleren en corrigeren.
+
+Bied ten minste één van de volgende opties aan:
+
+- **Omkeerbaar**: Geef de gebruiker de mogelijkheid om de inzending of transactie terug te draaien.
+- **Gecontroleerd**: Controleer tijdens het invullen de gegevens op invoerfouten en geef de gebruiker de mogelijkheid de gegevens te verbeteren.
+- **Bevestigd**: Geef de gebruiker, voor inzending, de mogelijkheid om de ingevulde gegevens te beoordelen, te bevestigen en te verbeteren.
+
+Dit komt overeen met [WCAG Succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](/wcag/3.3.4), maar nu geldt het voor alle formulieren.


### PR DESCRIPTION
Voegt pagina "3.3.6 Foutpreventie (alle)" toe.
Gerelateerd issue https://github.com/nl-design-system/documentatie/issues/1304 en
https://github.com/nl-design-system/documentatie/issues/1286
Preview: https://documentatie-git-docs-wcag-336-summary-nl-design-system.vercel.app/wcag/3.3.6

Omdat de inhoud hetzelfde is als [WCAG Succescriterium 3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](https://nldesignsystem.nl/wcag/3.3.4), alleen de toepassing anders, is voor de bronnen en het testen verwezen naar die pagina.
Deze pagina kan dus als compleet beschouwd worden.
