### PR TITLE
docs: add year to design systems week pages

### DIFF
--- a/docs/community/events/design-systems-week-2023/1-programma.md
+++ b/docs/community/events/design-systems-week-2023/1-programma.md
@@ -1,5 +1,5 @@
 ---
-title: Programma
+title: Programma • Design Systems Week 2023
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Programma

--- a/docs/community/events/design-systems-week-2023/2-tijdschema-per-dag.md
+++ b/docs/community/events/design-systems-week-2023/2-tijdschema-per-dag.md
@@ -1,5 +1,5 @@
 ---
-title: Tijdschema
+title: Tijdschema • Design Systems Week 2023
 description: Tijdschema per dag voor de Design Systems Week 2023
 hide_table_of_contents: true
 sidebar_label: Tijdschema
@@ -11,7 +11,7 @@ import { Icon, Link, UnorderedList, UnorderedListItem } from "@utrecht/component
 import { IconUser, IconUsers } from "@tabler/icons-react";
 import { SessionTable } from "@site/src/components/SessionTable";
 
-# Design Systems Week Tijdschema
+# Tijdschema Design Systems Week 2023
 
 NL Design System organiseert dit jaar voor de 3e keer de Design Systems Week. Van **2 tot 5 oktober** zijn er dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems**.
 

--- a/docs/community/events/design-systems-week-2023/english/1-program.md
+++ b/docs/community/events/design-systems-week-2023/english/1-program.md
@@ -1,5 +1,5 @@
 ---
-title: Program
+title: Program • Design Systems Week 2023
 description: Program of all English talks for the Design Systems Week 2023
 hide_title: true
 hide_table_of_contents: true

--- a/docs/community/events/design-systems-week-2023/english/2-timetable.md
+++ b/docs/community/events/design-systems-week-2023/english/2-timetable.md
@@ -1,5 +1,5 @@
 ---
-title: Timetable
+title: Timetable • Design Systems Week 2023
 description: Timetable for all English talks of the Design Systems Week 2023
 hide_table_of_contents: true
 hide_title: true
@@ -13,7 +13,7 @@ import { SessionTable } from "@site/src/components/SessionTable";
 
 <div lang="en">
 
-# Design Systems Week Timetable
+# Timetable Design Systems Week 2023
 
 <Paragraph lead>
     From 2 to 5 October NL Design System organises the third edition of Design Systems Week. Speakers from various organisations will join us for short talks about the how and why of design systems. This year there will be talks both in Dutch and English. For convenience we also have a <Link href="/events/design-systems-week-2023/en/program">program of all talks that will be in English</Link>.

--- a/docs/community/events/design-systems-week-2024/english/index.md
+++ b/docs/community/events/design-systems-week-2024/english/index.md
@@ -1,8 +1,8 @@
 ---
-title: About Design Systems Week
+title: Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: true
-sidebar_label: About Design Systems Week
+sidebar_label: About
 pagination_label: About
 sidebar_position: 1
 slug: /events/design-systems-week-2024/en

--- a/docs/community/events/design-systems-week-2024/english/program.md
+++ b/docs/community/events/design-systems-week-2024/english/program.md
@@ -25,25 +25,25 @@ Some of the talks are in Dutch, others are in English. This page lists the talks
 
 _All sessions can be joined online for free. Each talk will take about 30 minutes, including time for questions. [Sign up](/events/design-systems-week/sign-up) to receive updates and download [our calendar file](/dsweek-2024/dsweek-2024.ics) to add the week to your calendar._
 
-<DSWSession title="RTL Styling in CSS" speakers={[speakers.AhmadShadeed]} organisation="Independent" lang="en">
+<DSWSession title="RTL Styling in CSS" speakers={[speakers.AhmadShadeed]} organisation="Independent" lang="en" headingLevel={2}>
 
 <Paragraph>Building components in CSS isn't only about making them performant and responsive. We need to think about how they will work for multilingual websites. In this talk, Ahmad will show how to adapt an existing component and make it work with both left-to-right (LTR) and right-to-left (RTL), how to test, avoid common issues, and more.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} lang="en" organisation="US Web Design System">
+<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} lang="en" organisation="US Web Design System" headingLevel={2}>
 
 Amy will share plain-language accessibility tests the USWDS team has created for checking the accessibility of individual components. Attendees will learn how any web team — technical or not — can use these tests to perform baseline manual accessibility testing (like keyboard, screen reader, mobile, and zoom magnification testing) on their own sites. She will also describe the team’s iterative design and development process for these checklists, and how other teams can develop their own.
 
 </DSWSession>
 
-<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" lang="en">
+<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" lang="en" headingLevel={2}>
 
 <Paragraph>Building a Design System is exciting. But once your system is out there being used to power production applications, rolling out updates becomes a risky endeavor. Testing is a critical aspect of design systems development and maintenance that helps manage those risks. In this talk, Gert explains tools and strategies that help you test your UI components and integrations, so your design system can continue to evolve.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en">
+<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en" headingLevel={2}>
 
 Join Geri, a seasoned design systems explorer with 8 years of adventures under her belt, as she navigates the uncharted territories of accessibility in a major product org. With no playbook in hand, Geri’s quest is one we can all relate to: figuring it out as we go along.
 
@@ -51,13 +51,13 @@ In this ‘choose your own adventure’ session, you’ll discover how the princ
 
 </DSWSession>
 
-<DSWSession title="Advantages to working in the open with government design systems" speakers={[speakers.MikeGifford]} organisation="Civic Actions" lang="en">
+<DSWSession title="Advantages to working in the open with government design systems" speakers={[speakers.MikeGifford]} organisation="Civic Actions" lang="en" headingLevel={2}>
 
 For many governments, contributing to open source project is culturally a challenge. It often requires engagement with people in other departments and often outside of government. Design systems however provide a unique opportunity for governments to become more confident in their open source adoption. Mike has contributed to several government design systems. As a Drupal Core Accessibility Maintainer, he is often looking for best practices and comparing different approaches taken by governments around the world.
 
 </DSWSession>
 
-<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" lang="en">
+<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" lang="en" headingLevel={2}>
 
 Lessons from working on the GOV.‌UK Design System and other common platforms in UK government. How leaning on the principles that make the Web great can create more value for the public we serve.
 

--- a/docs/community/events/design-systems-week-2024/english/program.md
+++ b/docs/community/events/design-systems-week-2024/english/program.md
@@ -1,5 +1,5 @@
 ---
-title: Program
+title: Program • Design Systems Week 2024
 description: Program of all talks that are in English for Design Systems Week 2024.
 hide_title: true
 hide_table_of_contents: true
@@ -15,7 +15,7 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 
 <div lang="en">
 
-# Program
+# Program Design Systems Week 2024
 
 <Paragraph lead>
   Design Systems Week features a number of short talks about the how and why of design systems. All online. This year, we'll cover subjects like managing design systems, integrating accessibility, user research and code.

--- a/docs/community/events/design-systems-week-2024/english/timetable.md
+++ b/docs/community/events/design-systems-week-2024/english/timetable.md
@@ -1,5 +1,5 @@
 ---
-title: Timetable
+title: Timetable • Design Systems Week 2024
 description: Timetable for all English talks of the Design Systems Week 2023
 hide_table_of_contents: true
 hide_title: true
@@ -13,7 +13,7 @@ import { SessionTable } from "../../../../../src/components/SessionTable";
 
 <div lang="en">
 
-# Timetable
+# Timetable Design Systems Week 2024
 
 <Paragraph lead>
     From 2 to 5 October NL Design System organises the third edition of Design Systems Week. Speakers from various organisations will join us for short talks about the how and why of design systems. This year there will be talks both in Dutch and English. For convenience we also have a <Link href="/events/design-systems-week-2023/en/program">program of all talks that will be in English</Link>.

--- a/docs/community/events/design-systems-week-2024/index.md
+++ b/docs/community/events/design-systems-week-2024/index.md
@@ -1,9 +1,9 @@
 ---
-title: Over Design Systems Week
+title: Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Over Design Systems Week
-pagination_label: Over
+pagination_label: Over Design Systems Week
 sidebar_position: 1
 slug: /events/design-systems-week-2024
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24.png

--- a/docs/community/events/design-systems-week-2024/programma.md
+++ b/docs/community/events/design-systems-week-2024/programma.md
@@ -13,7 +13,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 import speakers from "./speakers.json";
 import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-module';
 
-## Programma Design Systems Week 2024
+# Programma Design Systems Week 2024
 
 <Paragraph lead>Tijdens Design Systems Week kun je 4 dagen lang meerdere korte talks per dag volgen over het hoe en waarom van design systems. Online. Dit jaar bijvoorbeeld over het managen van design systems, toegankelijkheid, gebruikersonderzoek en code.</Paragraph>
 
@@ -24,37 +24,37 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 - Bij Nederlandstalige sessies is een schrijftolk aanwezig.
 - Sommige sessies worden in het Engels gegeven, dit wordt per sessie aangegeven.
 
-<DSWSession title="RTL Styling in CSS" speakers={[speakers.AhmadShadeed]} organisation="Independent">
+<DSWSession title="RTL Styling in CSS" speakers={[speakers.AhmadShadeed]} organisation="Independent" headingLevel={2}>
 
 <Paragraph>Bij het bouwen van componenten met CSS gaat het er niet alleen om dat ze performant en responsive gebouwd zijn. We moeten er ook rekening mee houden hoe ze werken in meertalige websites. In zijn presentatie laat Ahmad zien hoe je een bestaand component kunt aanpassen zodat het werkt in zowel talen die van links naar rechts gelezen worden (LTR), als in talen die van rechts naar links gelezen worden (RTL). Hij laat ook zien hoe je veel voorkomende issues kunt testen en voorkomen.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} organisation="US Web Design System">
+<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} organisation="US Web Design System" headingLevel={2}>
 
 <Paragraph>Amy gaat ons laten zien hoe het US Web Design System toegankelijkheidstests in duidelijke taal heeft toegevoegd bij individuele componenten. In deze talk leer je hoe elk webteam – technisch of niet — deze tests kan gebruiken om een minimale baseline aan toegankelijkheidstests te doen, zoals tests met toetsenbord, screenreader, mobiele devices en vergrotingssoftware. Ze laat ook het iteratieve ontwerp- en bouwproces zien dat haar team heeft bij het maken van deze checklists.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned>
+<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned headingLevel={2}>
 
 <Paragraph>Met de komst van Sass, bundlers en frontend frameworks verdween een van de hoekstenen van het web development van vroeger. We hebben het over die style.css van duizend regels lang. Destijds had je nog een idee wat er allemaal in je CSS belandde, maar nu? Ga mee op expeditie door je CSS en we bekijken welke waardevolle informatie jouw CSS onthult over je Design System en je CSS kennis.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned>
+<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned headingLevel={2}>
 
 <Paragraph>Darice gaat ons vertellen waarom zelfs als je design systeem de conformiteitscheck doorstaat, het mogelijk nog steeds niet toegankelijk is. Toegankelijkheid is meer dan ARIA, kleurcontrast en een toetsenbord-toegankelijk formulier. Aan de hand van voorbeelden en persoonlijke verhalen laat Darice zien welke ontoegankelijkheden ze regelmatig tegenkomt.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic">
+<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" headingLevel={2}>
 
 <Paragraph>Het bouwen van een design system is heel interessant. Maar zodra je design system gebruikt wordt ingezet voor applicaties in productie, wordt het uitrollen van updates risivovoller. Testen is een essentieel onderdeel van het maken van design systems en onderhoud helpt om de risico's te managen. In deze sessie legt Gert tools en methoden uit die je kunnen helpen om je UI componenten en integraties te testen, zodat je design system zich kan blijven doorontwikkelen.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway">
+<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" headingLevel={2}>
 
 <Paragraph>Kom kijken hoe Geri, een ervaren design systems verkenner met 8 jaar ervaring in design system avonturen, het onbekende terrein betreedt van toegankelijkheid in een grote productorganisatie. Zonder spelregels is Geri's zoektocht eentje die we allemaal vast herkennen: we vinden het uit terwijl we bezig zijn.</Paragraph>
 
@@ -62,7 +62,7 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 
 </DSWSession>
 
-<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned>
+<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned headingLevel={2}>
 
 <Paragraph>In deze sessie vertellen Vincent, Warre en Gijs over de evolutie van het Vlaams Design System: hoe het evolueerde van een bibliotheek met web componenten naar een dienstverlening om van bij de start bouwers van e-loketten, toepassingen en websites te ondersteunen bij het ontwerpen en ontwikkelen. Met als focus: een herkenbare en eengemaakte gebruikerservaring voor burgers.</Paragraph>
 
@@ -70,7 +70,7 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 
 </DSWSession>
 
-<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong]} organisation="NL Design System community" captioned>
+<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong]} organisation="NL Design System community" captioned headingLevel={2}>
 
 <Paragraph>De [Heartbeat](/events/heartbeat) is een tweewekelijkse online bijeenkomst waarin het kernteam en de community van NL Design System delen waar ze mee bezig zijn. In deze speciale editie van de Heartbeat horen we uit verschillende organisaties in de community over hun ervaringen met NL Design System.</Paragraph>
 
@@ -80,13 +80,13 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 
 </DSWSession>
 
-<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned>
+<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned headingLevel={2}>
 
 <Paragraph>Hoe is het om te leven met een visuele beperking? Wat zijn de problemen waar je geheel verwacht of onverwachts tegenaan loopt? In deze sessie zal Kim Denie haar eigen verhaal vertellen en vanuit haar ervaring toelichten hoe je bijvoorbeeld achter het loket, op de werkvloer en online zo toegankelijk en inclusief mogelijk kan zijn.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned>
+<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned headingLevel={2}>
 
 <Paragraph>Gebruikersonderzoeken doen is leuk. Je krijgt van de mensen voor wie je het echt doet, te horen wat je goed doet, en wat er niet lekker gaat. Daardoor kan je verbeteringen doorvoeren die er voor je gebruikers echt toe doen.</Paragraph>
 
@@ -96,19 +96,19 @@ import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-modul
 
 </DSWSession>
 
-<DSWSession title="Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen" speakers={[speakers.LotteBijl]} organisation="Belastingdienst" captioned>
+<DSWSession title="Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen" speakers={[speakers.LotteBijl]} organisation="Belastingdienst" captioned headingLevel={2}>
 
 <Paragraph>Als overheidsorganisatie houdt de Belastingdienst zich al jaren bezig met het digitaal toegankelijk maken van hun diensten, met als doel iedereen te kunnen bedienen, ongeacht hun beperkingen. Maar hoe bepaal je welke problemen na een WCAG-audit de hoogste prioriteit hebben, zodat ontwikkelteams snel de grootste impact voor gebruikers kunnen realiseren? En hoe voorkom je toekomstige toegankelijkheidsproblemen voor gebruikers? In deze sessie deelt Lotte Bijl hoe de Belastingdienst inclusief gebruikersonderzoek heeft ingezet om deze vragen te kunnen beantwoorden en vertelt ze over de inzichten en de uitdagingen die zij tegenkwamen bij het organiseren van deze onderzoeken.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="De voordelen van open werken met design systems bij de overheid" speakers={[speakers.MikeGifford]} organisation="Civic Actions">
+<DSWSession title="De voordelen van open werken met design systems bij de overheid" speakers={[speakers.MikeGifford]} organisation="Civic Actions" headingLevel={2}>
 
 <Paragraph>Voor veel overheden is bijdragen aan open source projecten een culturele uitdagingen. Er wordt vaak samengewerkt met mensen in andere delen van de overheid en daarbuiten. Design systems zijn een unieke kans voor overheden om met meer vertrouwen bij open source te omarmen. Mike heeft bijgedragen aan verschillende design systems van overheden en is altijd op zoek naar best practices en aanpakken van overheden over de hele wereld.</Paragraph>
 
 </DSWSession>
 
-<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance">
+<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" headingLevel={2}>
 
 <Paragraph>Steve vertelt over wat hij leerde terwijl hij werkte aan het GOV.‌UK Design System en andere platformen van de Britse overheid. Hij laat zien wat we kunnen leren van de principes die het web zo fantastisch maken, om meer waarde te creëren voor het publiek waar we het voor doen.</Paragraph>
 

--- a/docs/community/events/design-systems-week-2024/programma.md
+++ b/docs/community/events/design-systems-week-2024/programma.md
@@ -1,5 +1,5 @@
 ---
-title: Programma
+title: Programma • Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Programma
@@ -13,7 +13,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 import speakers from "./speakers.json";
 import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-module';
 
-## Programma
+## Programma Design Systems Week 2024
 
 <Paragraph lead>Tijdens Design Systems Week kun je 4 dagen lang meerdere korte talks per dag volgen over het hoe en waarom van design systems. Online. Dit jaar bijvoorbeeld over het managen van design systems, toegankelijkheid, gebruikersonderzoek en code.</Paragraph>
 

--- a/docs/community/events/design-systems-week-2024/tijdschema-per-dag.md
+++ b/docs/community/events/design-systems-week-2024/tijdschema-per-dag.md
@@ -1,5 +1,5 @@
 ---
-title: Tijdschema
+title: Tijdschema • Design Systems Week 2024
 description: Tijdschema per dag voor de Design Systems Week 2024
 hide_table_of_contents: true
 sidebar_label: Tijdschema
@@ -12,7 +12,7 @@ import { Icon, Link, UnorderedList, UnorderedListItem } from "@utrecht/component
 import { IconUser, IconUsers } from "@tabler/icons-react";
 import { SessionTable } from "../../../../src/components/SessionTable";
 
-# Tijdschema
+# Tijdschema Design Systems Week 2024
 
 NL Design System organiseert dit jaar voor de 4e keer de Design Systems Week. Van **14 tot 17 oktober** zijn er dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems**.
 

--- a/docs/community/events/design-systems-week/aanmelden-bedankt.mdx
+++ b/docs/community/events/design-systems-week/aanmelden-bedankt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding • Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
@@ -10,7 +10,7 @@ unlisted: true
 
 # Bedankt!
 
-Je bent nu aangemeld voor Design Systems Week!
+Je bent nu aangemeld voor Design Systems Week 2024!
 
 [Voeg toe aan je kalender (.ics)](/dsweek-2024/dsweek-2024.ics)
 

--- a/docs/community/events/design-systems-week/aanmelden.mdx
+++ b/docs/community/events/design-systems-week/aanmelden.mdx
@@ -1,5 +1,5 @@
 ---
-title: Aanmelden voor Design Systems Week
+title: Aanmelden • Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
@@ -9,7 +9,7 @@ slug: /events/design-systems-week/aanmelden
 
 import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
 
-# Meld je aan voor Design Systems Week
+# Meld je aan voor Design Systems Week 2024
 
 Tijdens Design Systems Week zijn er dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems**.
 

--- a/docs/community/events/design-systems-week/sign-up-thanks.mdx
+++ b/docs/community/events/design-systems-week/sign-up-thanks.mdx
@@ -1,8 +1,8 @@
 ---
-title: Thanks for signing up!
+title: Thanks for signing up! • Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: Aanmelden
+sidebar_label: Signing up
 pagination_label: Sign up for Design Systems Week
 slug: /events/design-systems-week/sign-up/thanks
 unlisted: true
@@ -10,7 +10,7 @@ unlisted: true
 
 # Thanks!
 
-You are now signed up for Design Systems Week!
+You are now signed up for Design Systems Week 2024!
 
 [Add to your calendar (.ics)](/dsweek-2024/dsweek-2024.ics)
 

--- a/docs/community/events/design-systems-week/sign-up.mdx
+++ b/docs/community/events/design-systems-week/sign-up.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sign up for Design Systems Week
+title: Sign up • Design Systems Week 2024
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Sign up
@@ -9,7 +9,7 @@ slug: /events/design-systems-week/sign-up
 
 import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
 
-# Sign up for Design Systems Week
+# Sign up for Design Systems Week 2024
 
 Design System Week 2024 will feature short talks about the how and why of design systems, from managing design systems to user research and accessibility.
 


### PR DESCRIPTION
https://codefornl.slack.com/archives/C02CWGL2M18/p1727418393325329

> Op de pagina's over de Design Systems Week staat niet overal vermeld om welk jaar het gaat. Na te hebben gezocht met een zoekmachine (duckduckgo) was ik vrolijk events van het tijdschema van 2023 in mijn agenda aan het zetten, omdat die pagina als eerste in de zoekresultaten stond.
> 
> Is het een idee om het jaartal in de h1 te zetten bij Programma en Tijdschema? Op de pagina [Programma](https://www.nldesignsystem.nl/events/design-systems-week-2024/programma) is de eerste heading op de pagina trouwens een h2.