### PR TITLE
Align titles

### DIFF
--- a/docs/community/community-sprints.mdx
+++ b/docs/community/community-sprints.mdx
@@ -1,5 +1,5 @@
 ---
-title: Community sprints
+title: Community sprints • Community
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Community sprints

--- a/docs/community/events/community-bijeenkomst-2-success.mdx
+++ b/docs/community/events/community-bijeenkomst-2-success.mdx
@@ -1,12 +1,10 @@
 ---
-title: Bedankt voor je aanmelding!
+title: Bedankt voor je aanmelding! • Communitybijeenkomst • Bijeenkomsten
 hide_title: false
 hide_table_of_contents: false
 description: Je bent nu aangemeld voor de communitybijeenkomst.
 slug: /community/communitybijeenkomst-18-10-2024/bedankt
 unlisted: true
-keywords:
-  - nl design system
 ---
 
 {/* @license CC0-1.0 */}

--- a/docs/community/events/community-bijeenkomst-2.mdx
+++ b/docs/community/events/community-bijeenkomst-2.mdx
@@ -1,5 +1,5 @@
 ---
-title: Communitybijeenkomst 18 oktober 2024
+title: Communitybijeenkomst 18 oktober 2024 • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 unlisted: true

--- a/docs/community/events/design-open-dag-success.mdx
+++ b/docs/community/events/design-open-dag-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding!
+title: Bedankt voor je aanmelding! • Design Open Dag • Bijeenkomsten
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Design Open Dag

--- a/docs/community/events/design-open-dag.mdx
+++ b/docs/community/events/design-open-dag.mdx
@@ -1,9 +1,10 @@
 ---
-title: Design Open Dag
+title: Design Open Dag • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design Open Dag
-pagination_label: Tijdens de Design Open Dag komen designers bij elkaar om samen te werken aan designvraagstukken.
+pagination_label: Design Open Dag
+description: Tijdens de Design Open Dag komen designers bij elkaar om samen te werken aan designvraagstukken.
 slug: /events/design-open-dag
 ---
 

--- a/docs/community/events/design-open-hour/aanmelden-success.mdx
+++ b/docs/community/events/design-open-hour/aanmelden-success.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding • Design Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
-pagination_label: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+pagination_label: Aanmelden
+description: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
 slug: /events/design-open-hour/aanmelden/bedankt
 unlisted: true
 ---

--- a/docs/community/events/design-open-hour/aanmelden.mdx
+++ b/docs/community/events/design-open-hour/aanmelden.mdx
@@ -1,9 +1,10 @@
 ---
-title: Aanmelden voor de Design Open Hour
+title: Aanmelden • Design Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
-pagination_label: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+pagination_label: Aanmelden
+description: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
 slug: /events/design-open-hour/aanmelden
 ---
 

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -1,10 +1,10 @@
 ---
-title: Design Open Hour
+title: Design Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design Open Hour
-pagination_label: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
-description: Wat is Design Open Hour?
+description: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+pagination_label: Design Open Hour
 slug: /events/design-open-hour
 ---
 

--- a/docs/community/events/developer-open-hour/aanmelden-success.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden-success.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding • Developer Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
-pagination_label: In het Developer Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+pagination_label: Aanmelden
+description: In het Developer Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
 slug: /events/developer-open-hour/aanmelden/bedankt
 unlisted: true
 ---

--- a/docs/community/events/developer-open-hour/aanmelden.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden.mdx
@@ -1,9 +1,10 @@
 ---
-title: Aanmelden voor de Developer Open Hour
+title: Aanmelden • Developer Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden
-pagination_label: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
+pagination_label: Aanmelden
+description: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
 slug: /events/developer-open-hour/aanmelden
 ---
 

--- a/docs/community/events/developer-open-hour/developer-open-hour.mdx
+++ b/docs/community/events/developer-open-hour/developer-open-hour.mdx
@@ -1,10 +1,10 @@
 ---
-title: Developer Open Hour
+title: Developer Open Hour • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Developer Open Hour
-pagination_label: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
-description: Wat is Developer Open Hour?
+pagination_label: Developer Open Hour
+description: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
 slug: /events/developer-open-hour
 ---
 

--- a/docs/community/events/estafettemodeldag-success.mdx
+++ b/docs/community/events/estafettemodeldag-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding!
+title: Bedankt voor je aanmelding! • Estafettemodeldagen • Bijeenkomsten
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Sluit je aan

--- a/docs/community/events/estafettemodeldag.mdx
+++ b/docs/community/events/estafettemodeldag.mdx
@@ -1,9 +1,10 @@
 ---
-title: Estafettemodeldag
+title: Estafettemodeldag • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Estafettemodeldag
-pagination_label: In het Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
+pagination_label: Estafettemodeldag
+description: In het Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
 slug: /community/events/estafettemodeldag
 ---
 

--- a/docs/community/events/heartbeat/aanmelden-success.mdx
+++ b/docs/community/events/heartbeat/aanmelden-success.mdx
@@ -1,9 +1,10 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding • Heartbeat • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: Aanmelden
-pagination_label: 2 wekelijkse updates van het kernteam en community
+sidebar_label: Aanmelden geukt
+pagination_label: Aanmelden geukt
+description: 2 wekelijkse updates van het kernteam en community
 slug: /events/heartbeat/aanmelden/bedankt
 unlisted: true
 ---

--- a/docs/community/events/heartbeat/aanmelden.mdx
+++ b/docs/community/events/heartbeat/aanmelden.mdx
@@ -1,9 +1,10 @@
 ---
-title: Aanmelden voor de Heartbeat
+title: Aanmelden • Heartbeat • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
+description: 2 wekelijkse updates van het kernteam en community
 sidebar_label: Aanmelden
-pagination_label: 2 wekelijkse updates van het kernteam en community
+pagination_label: Aanmelden
 slug: /events/heartbeat/aanmelden
 ---
 

--- a/docs/community/events/heartbeat/heartbeat.mdx
+++ b/docs/community/events/heartbeat/heartbeat.mdx
@@ -1,10 +1,10 @@
 ---
-title: Heartbeat
+title: Heartbeat • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Heartbeat
-pagination_label: 2 wekelijkse updates van het kernteam en community
-description: Wat is de Heartbeat?
+pagination_label: Heartbeat
+description: 2 wekelijkse updates van het kernteam en community
 slug: /events/heartbeat
 ---
 

--- a/docs/community/events/heartbeat/videos.mdx
+++ b/docs/community/events/heartbeat/videos.mdx
@@ -1,9 +1,10 @@
 ---
-title: Video's
+title: Video's • Heartbeat • Bijeenkomsten
 hide_title: true
 hide_table_of_contents: false
-sidebar_label: "Video's"
-pagination_label: "Video's van de afgelopen Heartbeats"
+sidebar_label: Video's
+pagination_label: Video's
+description: Video's van de afgelopen Heartbeats
 slug: /events/heartbeat/videos
 ---
 

--- a/docs/community/sluit-je-aan-success.mdx
+++ b/docs/community/sluit-je-aan-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding!
+title: Bedankt voor je aanmelding! • Community
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Sluit je aan

--- a/docs/community/sluit-je-aan.mdx
+++ b/docs/community/sluit-je-aan.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sluit je aan bij onze community
-hide_title: false
+title: Sluit je aan • Community
+hide_title: true
 hide_table_of_contents: false
 sidebar_label: Sluit je aan
 pagination_label: Sluit je aan
@@ -12,6 +12,8 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+
+# Sluit je aan bij onze community
 
 De NL Design System community brengt specialisten bij elkaar, zoals designers, developers, researchers en toegankelijkheidsspecialisten. Samen met het [kernteam](/project/kernteam) verzamelt de community de beste richtlijnen, componenten en voorbeelden om robuuste websites en webapplicaties voor de digitale overheid te bouwen.
 

--- a/docs/community/wie-doet-mee.mdx
+++ b/docs/community/wie-doet-mee.mdx
@@ -1,6 +1,6 @@
 ---
-title: Wie doet mee?
-hide_title: false
+title: Wie doet mee? • Community
+hide_title: true
 hide_table_of_contents: false
 sidebar_label: Wie doet mee?
 pagination_label: Wie doet mee?
@@ -10,6 +10,8 @@ keywords:
 ---
 
 {/* @license CC0-1.0 */}
+
+# Wie doet mee?
 
 NL Design System wordt gebouwd en gebruikt door diverse overheidsorganisaties en hun leveranciers. Meedoen kan op [diverse niveaus](/handboek/organisatie/meedoen), van delen van kennis, gebruiken van bestaande componenten en daar feedback over geven tot bijdragen van eigen componenten.
 

--- a/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
@@ -1,5 +1,5 @@
 ---
-title: Candidate stappenplan
+title: Candidate stappenplan • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Candidate

--- a/docs/handboek/component-bijdragen/community-stappenplan-voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan-voor-organisaties.mdx
@@ -1,5 +1,5 @@
 ---
-title: Community stappenplan voor organisaties
+title: Community stappenplan voor organisaties • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Organisaties

--- a/docs/handboek/component-bijdragen/community-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan.mdx
@@ -1,5 +1,5 @@
 ---
-title: Community stappenplan
+title: Community stappenplan • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Community

--- a/docs/handboek/component-bijdragen/definition-of-done.mdx
+++ b/docs/handboek/component-bijdragen/definition-of-done.mdx
@@ -1,5 +1,5 @@
 ---
-title: Definition of Done voor componenten
+title: Definition of Done voor componenten • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Definition of Done

--- a/docs/handboek/component-bijdragen/hall-of-fame-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/hall-of-fame-stappenplan.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hall of Fame stappenplan
+title: Hall of Fame stappenplan • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Hall of Fame

--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -1,5 +1,5 @@
 ---
-title: Help Wanted stappenplan
+title: Help Wanted stappenplan • Component bijdragen • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Help Wanted

--- a/docs/handboek/design-tokens/README.mdx
+++ b/docs/handboek/design-tokens/README.mdx
@@ -1,5 +1,5 @@
 ---
-title: Design Tokens
+title: Design Tokens • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design Tokens

--- a/docs/handboek/designer/README.md
+++ b/docs/handboek/designer/README.md
@@ -1,5 +1,5 @@
 ---
-title: Designer - Introductie
+title: Introductie • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie

--- a/docs/handboek/designer/community.md
+++ b/docs/handboek/designer/community.md
@@ -1,5 +1,5 @@
 ---
-title: Community voor designers
+title: Community voor designers • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Community

--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -1,5 +1,5 @@
 ---
-title: Figma structuur
+title: Figma structuur • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Figma structuur

--- a/docs/handboek/designer/stappenplan.mdx
+++ b/docs/handboek/designer/stappenplan.mdx
@@ -1,5 +1,5 @@
 ---
-title: Stappenplan
+title: Stappenplan • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Stappenplan

--- a/docs/handboek/designer/voorbeeld-thema.md
+++ b/docs/handboek/designer/voorbeeld-thema.md
@@ -1,5 +1,5 @@
 ---
-title: Voorbeeld thema
+title: Voorbeeld thema • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Voorbeeld thema

--- a/docs/handboek/designer/zelf-componenten-maken.mdx
+++ b/docs/handboek/designer/zelf-componenten-maken.mdx
@@ -1,5 +1,5 @@
 ---
-title: Zelf componenten maken
+title: Zelf componenten maken • Designer • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Zelf componenten maken

--- a/docs/handboek/developer/01-aan-de-slag.md
+++ b/docs/handboek/developer/01-aan-de-slag.md
@@ -1,5 +1,5 @@
 ---
-title: Developer getting started
+title: Aan de slag • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aan de slag

--- a/docs/handboek/developer/02-architectuur.md
+++ b/docs/handboek/developer/02-architectuur.md
@@ -1,5 +1,5 @@
 ---
-title: Architectuur
+title: Architectuur • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Architectuur

--- a/docs/handboek/developer/03-thema-maken.mdx
+++ b/docs/handboek/developer/03-thema-maken.mdx
@@ -1,5 +1,5 @@
 ---
-title: Thema maken
+title: Thema maken • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Thema maken

--- a/docs/handboek/developer/04-samenwerken-aan-componenten.md
+++ b/docs/handboek/developer/04-samenwerken-aan-componenten.md
@@ -1,5 +1,5 @@
 ---
-title: Bestaand of nieuw component gebruiken
+title: Bestaand of nieuw component gebruiken • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Component kiezen

--- a/docs/handboek/developer/05-component-inzetten.mdx
+++ b/docs/handboek/developer/05-component-inzetten.mdx
@@ -1,5 +1,5 @@
 ---
-title: Component inzetten
+title: Component inzetten • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Component inzetten

--- a/docs/handboek/developer/06-component-uitbreiden.md
+++ b/docs/handboek/developer/06-component-uitbreiden.md
@@ -1,5 +1,5 @@
 ---
-title: Component uitbreiden
+title: Component uitbreiden • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Component uitbreiden

--- a/docs/handboek/developer/07-componenten-maken.md
+++ b/docs/handboek/developer/07-componenten-maken.md
@@ -1,5 +1,5 @@
 ---
-title: Componenten maken
+title: Componenten maken • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Componenten maken

--- a/docs/handboek/developer/08-meewerken-als-developer.md
+++ b/docs/handboek/developer/08-meewerken-als-developer.md
@@ -1,5 +1,5 @@
 ---
-title: Meewerken aan NL Design System
+title: Meewerken aan NL Design System • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Meewerken

--- a/docs/handboek/developer/10-herbruikbare-css.md
+++ b/docs/handboek/developer/10-herbruikbare-css.md
@@ -1,5 +1,5 @@
 ---
-title: Herbruikbare CSS schrijven
+title: Herbruikbare CSS schrijven • Developer • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Herbruikbare CSS schrijven

--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Estafettemodel
+title: Estafettemodel • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Estafettemodel

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -1,5 +1,5 @@
 ---
-title: Introductie
+title: Introductie • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie

--- a/docs/handboek/leverancier/introductie.md
+++ b/docs/handboek/leverancier/introductie.md
@@ -1,5 +1,5 @@
 ---
-title: Voor leveranciers
+title: Voor leveranciers • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voor leveranciers

--- a/docs/handboek/manager/introductie.md
+++ b/docs/handboek/manager/introductie.md
@@ -1,5 +1,5 @@
 ---
-title: Voor managers
+title: Voor managers • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voor managers

--- a/docs/handboek/naamgeving.mdx
+++ b/docs/handboek/naamgeving.mdx
@@ -1,5 +1,5 @@
 ---
-title: Naamgeving
+title: Naamgeving • Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Naamgeving

--- a/docs/handboek/organisatie/meedoen.md
+++ b/docs/handboek/organisatie/meedoen.md
@@ -1,5 +1,5 @@
 ---
-title: Meedoen als organisatie
+title: Meedoen als organisatie • Organisatie • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Meedoen

--- a/docs/handboek/organisatie/vragen-over-aanbestedingen.md
+++ b/docs/handboek/organisatie/vragen-over-aanbestedingen.md
@@ -1,5 +1,5 @@
 ---
-title: Vragen over aanbestedingen
+title: Vragen over aanbestedingen • Organisatie • Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Aanbestedingen

--- a/docs/open-source/cc0.md
+++ b/docs/open-source/cc0.md
@@ -1,5 +1,5 @@
 ---
-title: Creative Commons 0 Universal licentie
+title: Creative Commons 0 Universal licentie • Open Source
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Creative Commons 0

--- a/docs/open-source/eupl.md
+++ b/docs/open-source/eupl.md
@@ -1,5 +1,5 @@
 ---
-title: EUPL 1.2 licentie
+title: EUPL 1.2 licentie • Open Source
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: EUPL 1.2

--- a/docs/project/blijf-op-de-hoogte.mdx
+++ b/docs/project/blijf-op-de-hoogte.mdx
@@ -1,5 +1,5 @@
 ---
-title: Op de hoogte blijven
+title: Op de hoogte blijven • Project
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Op de hoogte blijven

--- a/docs/project/faq.mdx
+++ b/docs/project/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: Veelgestelde vragen
+title: Veelgestelde vragen • Project
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Veelgestelde vragen

--- a/docs/project/kernteam.mdx
+++ b/docs/project/kernteam.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kernteam
+title: Kernteam • Project
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Kernteam

--- a/docs/project/links.mdx
+++ b/docs/project/links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Links naar anderen
+title: Links naar anderen • Project
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Links

--- a/docs/project/newsletter-success.mdx
+++ b/docs/project/newsletter-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding • Nieuwsbrief
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/project/over-nl-design-system.mdx
+++ b/docs/project/over-nl-design-system.mdx
@@ -1,5 +1,5 @@
 ---
-title: Over NL Design System
+title: Over NL Design System • Project
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Over NL Design System

--- a/docs/voorbeelden/README.md
+++ b/docs/voorbeelden/README.md
@@ -1,5 +1,5 @@
 ---
-title: Voorbeelden - Overzicht
+title: Overzicht • Voorbeelden
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Overzicht

--- a/docs/voorbeelden/onderzoek/README.md
+++ b/docs/voorbeelden/onderzoek/README.md
@@ -1,5 +1,5 @@
 ---
-title: Gebruikersonderzoek
+title: Gebruikersonderzoek • Voorbeelden
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Gebruikersonderzoek

--- a/docs/voorbeelden/patronen/formulieren/bevestigingspagina.mdx
+++ b/docs/voorbeelden/patronen/formulieren/bevestigingspagina.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bevestigingspagina
+title: Bevestigingspagina • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Bevestigingspagina

--- a/docs/voorbeelden/patronen/formulieren/controlepagina.mdx
+++ b/docs/voorbeelden/patronen/formulieren/controlepagina.mdx
@@ -1,5 +1,5 @@
 ---
-title: Controlepaginapagina
+title: Controlepaginapagina • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Controlepaginapagina

--- a/docs/voorbeelden/patronen/formulieren/foutmeldingen.mdx
+++ b/docs/voorbeelden/patronen/formulieren/foutmeldingen.mdx
@@ -1,5 +1,5 @@
 ---
-title: Foutmeldingen
+title: Foutmeldingen • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Foutmeldingen

--- a/docs/voorbeelden/patronen/formulieren/funnel-header.mdx
+++ b/docs/voorbeelden/patronen/formulieren/funnel-header.mdx
@@ -1,5 +1,5 @@
 ---
-title: Funnel header
+title: Funnel header • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Funnel header

--- a/docs/voorbeelden/patronen/formulieren/inloggen.mdx
+++ b/docs/voorbeelden/patronen/formulieren/inloggen.mdx
@@ -1,5 +1,5 @@
 ---
-title: Inloggen
+title: Inloggen • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Inloggen

--- a/docs/voorbeelden/patronen/formulieren/intropagina.mdx
+++ b/docs/voorbeelden/patronen/formulieren/intropagina.mdx
@@ -1,5 +1,5 @@
 ---
-title: Intropagina
+title: Intropagina • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Intropagina

--- a/docs/voorbeelden/patronen/formulieren/meerstappenformulier.mdx
+++ b/docs/voorbeelden/patronen/formulieren/meerstappenformulier.mdx
@@ -1,5 +1,5 @@
 ---
-title: Meerstappenformulier
+title: Meerstappenformulier • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Meerstappenformulier

--- a/docs/voorbeelden/patronen/formulieren/niet-verplichte-velden.mdx
+++ b/docs/voorbeelden/patronen/formulieren/niet-verplichte-velden.mdx
@@ -1,5 +1,5 @@
 ---
-title: Niet verplichte velden
+title: Niet verplichte velden • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Niet verplichte velden

--- a/docs/voorbeelden/patronen/formulieren/opslaan-of-stoppen.mdx
+++ b/docs/voorbeelden/patronen/formulieren/opslaan-of-stoppen.mdx
@@ -1,5 +1,5 @@
 ---
-title: Opslaan of stoppen
+title: Opslaan of stoppen • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Opslaan of stoppen

--- a/docs/voorbeelden/patronen/formulieren/responsive-design.mdx
+++ b/docs/voorbeelden/patronen/formulieren/responsive-design.mdx
@@ -1,5 +1,5 @@
 ---
-title: Responsive design
+title: Responsive design • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Responsive design

--- a/docs/voorbeelden/patronen/formulieren/stapelen-en-uitlijnen.mdx
+++ b/docs/voorbeelden/patronen/formulieren/stapelen-en-uitlijnen.mdx
@@ -1,5 +1,5 @@
 ---
-title: Stapelen en uitlijnen
+title: Stapelen en uitlijnen • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Stapelen en uitlijnen

--- a/docs/voorbeelden/patronen/formulieren/startpunt.mdx
+++ b/docs/voorbeelden/patronen/formulieren/startpunt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Startpunt
+title: Startpunt • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Startpunt

--- a/docs/voorbeelden/patronen/formulieren/terug-navigeren.mdx
+++ b/docs/voorbeelden/patronen/formulieren/terug-navigeren.mdx
@@ -1,5 +1,5 @@
 ---
-title: Terug navigeren
+title: Terug navigeren • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Terug navigeren

--- a/docs/voorbeelden/patronen/formulieren/uploaden.mdx
+++ b/docs/voorbeelden/patronen/formulieren/uploaden.mdx
@@ -1,5 +1,5 @@
 ---
-title: Uploaden
+title: Uploaden • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Uploaden

--- a/docs/voorbeelden/patronen/formulieren/visual-design.mdx
+++ b/docs/voorbeelden/patronen/formulieren/visual-design.mdx
@@ -1,5 +1,5 @@
 ---
-title: Visueel ontwerp
+title: Visueel ontwerp • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Visueel ontwerp

--- a/docs/voorbeelden/patronen/formulieren/volgende-stap.mdx
+++ b/docs/voorbeelden/patronen/formulieren/volgende-stap.mdx
@@ -1,5 +1,5 @@
 ---
-title: "'Volgende stap' actie"
+title: "'Volgende stap' actie • Formulieren • Patronen • Voorbeelden"
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: "'Volgende stap' actie"

--- a/docs/voorbeelden/patronen/formulieren/voortgang-indicatie.mdx
+++ b/docs/voorbeelden/patronen/formulieren/voortgang-indicatie.mdx
@@ -1,5 +1,5 @@
 ---
-title: Voortgang indicatie
+title: Voortgang indicatie • Formulieren • Patronen • Voorbeelden
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voortgang indicatie

--- a/docs/voorbeelden/templates/README.md
+++ b/docs/voorbeelden/templates/README.md
@@ -1,5 +1,5 @@
 ---
-title: Templates
+title: Templates • Voorbeelden
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Templates


### PR DESCRIPTION
Opbouw pagina titles zoals richtlijnen gemaakt.

Opbouw wordt `{pagina title} • {sub category?} • {category?}`

## Los:
- [richtlijnen pagina's](https://github.com/nl-design-system/documentatie/pull/1445)
- [design systems week pagina's](https://github.com/nl-design-system/documentatie/pull/1442)