### PR TITLE
feat: cta-links for events

### DIFF
--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -8,6 +8,10 @@ description: Wat is Design Open Hour?
 slug: /events/design-open-hour
 ---
 
+import DocusaurusLink from "@docusaurus/Link";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+
 # Design Open Hour
 
 ![Screenshot van een online meeting met verschillende aanwezigen vanuit de community.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-open-hour.jpg)
@@ -19,6 +23,18 @@ Wees welkom bij het 2-wekelijkse (online) ‘Design Open Hour’. Een moment om 
 In principe is er vooraf geen agenda. Deze stellen we aan het begin gezamenlijk op (zie de [Canvas in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F07AVE99NU9)). Iedereen kan iets inbrengen. Soms staat de Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
 
 Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Design Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
+
+<ActionGroup>
+  <DocusaurusLink
+    href="/events/design-open-hour/aanmelden"
+    className="utrecht-button-link utrecht-button-link--primary-action"
+  >
+    {"Meld je aan"}
+    <IconChevronRight />
+  </DocusaurusLink>
+</ActionGroup>
+
+## Ervaringen
 
 Benieuwd hoe andere designers de Design Open Hour ervaren?
 
@@ -40,11 +56,24 @@ Iedereen kan aansluiten!
 
 De Design Open Hour vindt plaats in het [#nl-design-system-designers](https://codefornl.slack.com/archives/C01D78C2E4E)-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
 
-Nog geen account in de Slack van Code for NL? [Meld je aan](https://praatmee.codefor.nl/).
+Door je aan te melden kunnen wij je op de hoogte houden van Design Open Hours. Je ontvangt dan ook direct een kalenderbestandje, zodat je de Design Open Hour makkelijk aan je agenda kan toevoegen.
 
-## Op de hoogte blijven
-
-[Laat je gegevens achter](/events/design-open-hour/aanmelden) om op de hoogte te blijven van Design Open Hours. Je ontvangt dan ook direct een kalenderbestandje, zodat je de Design Open Hour makkelijk aan je agenda kan toevoegen.
+<ActionGroup>
+  <DocusaurusLink
+    href="/events/design-open-hour/aanmelden"
+    className="utrecht-button-link utrecht-button-link--primary-action"
+  >
+    {"Meld je aan"}
+    <IconChevronRight />
+  </DocusaurusLink>
+  <DocusaurusLink
+    href="https://praatmee.codefor.nl/"
+    className="utrecht-button-link utrecht-button-link--secondary-action"
+  >
+    {"Doe mee op Slack"}
+    <IconChevronRight />
+  </DocusaurusLink>
+</ActionGroup>
 
 ## Vragen of ideeën
 

--- a/docs/community/events/developer-open-hour/developer-open-hour.mdx
+++ b/docs/community/events/developer-open-hour/developer-open-hour.mdx
@@ -8,6 +8,10 @@ description: Wat is Developer Open Hour?
 slug: /events/developer-open-hour
 ---
 
+import DocusaurusLink from "@docusaurus/Link";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+
 # Developer Open Hour
 
 ## Over het Developer Open Hour
@@ -29,11 +33,24 @@ Iedereen kan aansluiten! Wekelijks, of incidenteel, wanneer je vragen hebt of ie
 
 Het Developer Open Hour vindt plaats in het [#nl-design-system-developers](https://codefornl.slack.com/archives/C01DAT4TRPF)-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken.
 
-Nog geen account in de Code for NL Slack? [Meld je aan](https://praatmee.codefor.nl/).
+Door je aan te melden kunnen wij je op de hoogte houden van Developer Open Hours. Je ontvangt dan ook direct een kalenderbestandje, zodat je de Developer Open Hour makkelijk aan je agenda kan toevoegen.
 
-## Op de hoogte blijven
-
-[Meld je aan voor de Developer Open Hour](/events/developer-open-hour/aanmelden) om op de hoogte te blijven en een kalenderbestand te downloaden.
+<ActionGroup>
+  <DocusaurusLink
+    href="/events/developer-open-hour/aanmelden"
+    className="utrecht-button-link utrecht-button-link--primary-action"
+  >
+    {"Meld je aan"}
+    <IconChevronRight />
+  </DocusaurusLink>
+  <DocusaurusLink
+    href="https://praatmee.codefor.nl/"
+    className="utrecht-button-link utrecht-button-link--secondary-action"
+  >
+    {"Doe mee op Slack"}
+    <IconChevronRight />
+  </DocusaurusLink>
+</ActionGroup>
 
 ## Vragen of ideeën
 

--- a/docs/community/events/heartbeat/heartbeat.mdx
+++ b/docs/community/events/heartbeat/heartbeat.mdx
@@ -8,11 +8,29 @@ description: Wat is de Heartbeat?
 slug: /events/heartbeat
 ---
 
+import DocusaurusLink from "@docusaurus/Link";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+
 # Heartbeat
 
 In de Heartbeat vertelt het kernteam van NL Design System elke twee weken wat de laatste stand van zaken is. Daarnaast laten we organisaties aan het woord die met/aan het NL Design System werken.
 
-Deze sessies zijn publiek toegankelijk. [Meld je aan](/events/heartbeat/aanmelden) of [kijk de video's terug](/events/heartbeat/videos).
+Deze sessies zijn publiek toegankelijk.
+
+<ActionGroup>
+  <DocusaurusLink
+    href="/events/heartbeat/aanmelden"
+    className="utrecht-button-link utrecht-button-link--primary-action"
+  >
+    {"Meld je aan"}
+    <IconChevronRight />
+  </DocusaurusLink>
+  <DocusaurusLink href="/events/heartbeat/videos" className="utrecht-button-link utrecht-button-link--secondary-action">
+    {"Kijk de Heartbeat terug"}
+    <IconChevronRight />
+  </DocusaurusLink>
+</ActionGroup>
 
 ## Planning
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,6 +41,7 @@
   --utrecht-accordion-panel-padding-block-start: 0;
   --utrecht-accordion-panel-padding-inline-end: 16px;
   --utrecht-accordion-panel-padding-inline-start: 16px;
+  --utrecht-button-secondary-action-border-width: 2px;
   --utrecht-accordion-button-gap: 16px;
   --utrecht-form-toggle-width: 2.5em;
   --utrecht-form-toggle-height: 1.5em;
@@ -54,6 +55,8 @@
   -moz-osx-font-smoothing: auto !important;
   --doc-sidebar-width: clamp(20rem, 30rem, 30vw);
   --navbar-inner-min-height: 64px;
+  --utrecht-button-group-inline-gap: 1ch;
+  --utrecht-button-icon-gap: 1ch;
 }
 
 .utrecht-form-field--checkbox {
@@ -89,66 +92,14 @@
   position: relative;
 }
 
-.button.button--primary {
-  --ifm-button-background-color: #148839;
-  --ifm-button-color: #fff;
-
-  border-color: #148839;
-}
-
-.button--primary::after {
-  background-color: #0b732c;
-  background-image: url("../icons/arrow-right-white.svg");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 10px 16px;
-  bottom: 0;
-  content: " ";
-  display: block;
-  position: absolute;
-  right: 0;
-  top: 0;
-  transition: background-color 0.2s;
-  width: var(--gc-button-icon-size);
-}
-
-.button.button--primary:hover {
-  background-color: #0b732c;
-}
-
-.button--primary:hover::after {
-  background-color: #055c21;
-}
-
-.button.button--secondary {
-  color: #004152;
-}
-
-.button--secondary::after {
-  background-color: #d1dfe3;
-  background-image: url("../icons/arrow-right-blue.svg");
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: 10px 16px;
-  bottom: 0;
-  content: " ";
-  display: block;
-  position: absolute;
-  right: 0;
-  top: 0;
-  transition: background-color 0.2s;
-  width: 32px;
-}
-
-.button.button--secondary:hover {
-  background-color: #004152;
-  border-color: #004152;
-  color: white;
-}
-
-.button--secondary:hover::after {
-  background-color: #00303d;
-  background-image: url("../icons/arrow-right-white.svg");
+.utrecht-button-link:hover,
+.utrecht-button:hover {
+  --utrecht-button-primary-action-background-color: #0b732c;
+  --utrecht-button-primary-action-color: #fff;
+  --utrecht-button-secondary-action-border-color: #0b6728;
+  --utrecht-button-secondary-action-color: #0b6728;
+  --ifm-link-hover-color: var(--_utrecht-button-color);
+  --ifm-link-hover-decoration: none;
 }
 
 .utrecht-form-field--checkbox > p {


### PR DESCRIPTION
https://codefornl.slack.com/archives/C02CWGL2M18/p1727417749645349

> [@Yolijn](https://codefornl.slack.com/team/U01B7T1F24S)
 ik stel voor dat we voor alle community events een "Link that looks like a button" gebruiken, een CTA link zeg maar. Het is echt te subtiel. Als ik iemand een linkje wil sturen om zich aan te melden, dan wil ik liefst een linkje sturen naar de pagina over de heartbeat, zodat ze nog even extra het gevoel krijgen "ja dat wil ik, tof!" in plaats van direct naar het formulier voor "geen ons je data!", dat is zo transactioneel :sweat_smile: Maar elke keer ben ik bang dat ze afhanken omdat ze het linkje niet vinden

<img width="1652" alt="Screenshot 2024-09-30 at 18 25 28" src="https://github.com/user-attachments/assets/7754e9ed-2925-4a83-a82d-882344333665">
<img width="1652" alt="Screenshot 2024-09-30 at 18 25 21" src="https://github.com/user-attachments/assets/92f81035-da49-4872-a16c-71462ae87f0e">
<img width="1652" alt="Screenshot 2024-09-30 at 18 25 09" src="https://github.com/user-attachments/assets/0a60db37-fdcd-4f93-babb-f43db735ef2f">
