### PR TITLE
fix: Fout in slug /richtlijnen/formulieren/foutmeldingen/duidelijk

### DIFF
--- a/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
+++ b/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
@@ -6,6 +6,7 @@ sidebar_label: Duidelijke foutmeldingen
 pagination_label: Duidelijke foutmeldingen
 description: Richtlijnen voor duidelijke foutmeldingen in een formulier.
 slug: /richtlijnen/formulieren/foutmeldingen/duidelijk
+keywords:
   - labels
   - formulier
   - design


### PR DESCRIPTION
De regel ‘keywords’ was weggevalen en daardoor werden de keywords aan de slug van de pagina /richtlijnen/formulieren/foutmeldingen/duidelijk toegevoegd.