### PR TITLE
fix: link naar dso bijgewerkt

### DIFF
--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -205,8 +205,8 @@ Het kernteam houdt deze set van organisaties aan. Hiermee hebben we een mooie mi
 
 #### DSO
 
-- [Documentatie website](https://dso-toolkit.nl/62.8.4/intro/)
-- [Storybook](https://storybook.dso-toolkit.nl/62.8.4/?path=/docs/html-css-accordion--docs)
+- [Documentatie website](https://www.dso-toolkit.nl/)
+- Storybook bekijken via documentatie website.
 - [Github](https://github.com/dso-toolkit/dso-toolkit) ([CSS componenten](https://github.com/dso-toolkit/dso-toolkit/tree/master/packages/dso-toolkit/src/components))
 
 #### DUO


### PR DESCRIPTION
Links naar DSO leidde naar verouderde versie van hun Design System. Hierdoor linken we altijd naar de laatste versie. En zal men via de documentatie website naar de Storybook moeten navigeren.