### PR TITLE
docs: WCAG intro-pagina: links naar complete lijst succescriteria

### DIFF
--- a/docs/wcag/0-introduction.mdx
+++ b/docs/wcag/0-introduction.mdx
@@ -4,10 +4,11 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie WCAG-pagina's
 pagination_label: Introductie WCAG-pagina's
-description: Introductie van de pagina met informatie over de WCAG-succescriteria.
-slug: introduction
+description: Introductie van informatie over de WCAG-succescriteria.
+slug: /wcag
 keywords:
   - WCAG
+  - succescriteria
 ---
 
 import FormFooterInfo from "./_wcag_footer_info.md";
@@ -18,7 +19,7 @@ In deze pagina's vind je [<span lang="en">Web Content Accessibility Guidelines</
 
 Het doel is om WCAG begrijpelijk uit te leggen en daardoor makkelijker toepasbaar te maken. Daarnaast staat beschreven hoe je webpagina's voor de verschillende succescriteria kunt testen.
 
-**Let op**: Deze pagina's bevatten praktische uitleg, voorbeelden en interpretatie bij de Web Content Accessibility Guidelines (WCAG). De richtlijnen in NL Design System zijn niet verplicht en geen vervanging voor [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/), de norm waarnaar in wetgeving wordt verwezen (zie [Wat is verplicht - DigiToegankelijk](https://www.digitoegankelijk.nl/wetgeving/wat-is-verplicht)).
+**Let op**: Deze pagina's bevatten praktische uitleg, voorbeelden en interpretatie bij de Web Content Accessibility Guidelines (WCAG) voor de niveau's A, AA en AAA. De richtlijnen in NL Design System zijn niet verplicht en geen vervanging voor [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/), de norm waarnaar in wetgeving wordt verwezen (zie [Wat is verplicht - DigiToegankelijk](https://www.digitoegankelijk.nl/wetgeving/wat-is-verplicht)).
 
 ## Opzet
 
@@ -32,9 +33,9 @@ Elk WCAG-succescriterium heeft een eigen pagina waarin is opgenomen:
 - Relevant gebruikersonderzoek.
 - Veelgemaakte fouten en de oplossingen hiervoor.
 
-## WCAG-pagina's
+Sommige succescriteria bevatten nu alleen nog links en een uitleg. Het doel is om eind van 2024 de inhoud van de A- en AA-criteria compleet te hebben.
 
-Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind van dit jaar de lijst compleet te hebben.
+## WCAG-pagina's
 
 ### Waarneembaar
 
@@ -45,18 +46,24 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [1.2.4 Ondertitels voor doven en slechthorenden (live)](/wcag/1.2.4)
 - [1.2.5 Audiodescriptie (vooraf opgenomen)](/wcag/1.2.5)
 - [1.2.6 Gebarentaal (vooraf opgenomen)](/wcag/1.2.6)
+- [1.2.7 Verlengde audiodescriptie (vooraf opgenomen)](/wcag/1.2.7)
 - [1.2.8 Media-alternatief (vooraf opgenomen)](/wcag/1.2.8)
+- [1.2.9 Louter-geluid (live)](/wcag/1.2.9)
 - [1.3.1 Info en relaties](/wcag/1.3.1)
 - [1.3.2 Betekenisvolle volgorde](/wcag/1.3.2)
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.3.3)
 - [1.3.4 Weergavestand](/wcag/1.3.4)
 - [1.3.5 Identificeer het doel van de input](/wcag/1.3.5)
+- [1.3.6 Identificeer het doel](/wcag/1.3.6)
 - [1.4.1 Gebruik van kleur](/wcag/1.4.1)
 - [1.4.2 Geluidsbediening](/wcag/1.4.2)
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
 - [1.4.4 Herschalen van tekst](/wcag/1.4.4)
 - [1.4.5 Afbeeldingen van tekst](/wcag/1.4.5)
+- [1.4.6 Contrast (versterkt)](/wcag/1.4.6)
+- [1.4.7 Weinig of geen achtergrondgeluid](/wcag/1.4.7)
 - [1.4.8 Visuele weergave](/wcag/1.4.8)
+- [1.4.9 Afbeeldingen van tekst (geen uitzondering)](/wcag/1.4.9)
 - [1.4.10 Reflow](/wcag/1.4.10)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)
 - [1.4.12 Tekstafstand](/wcag/1.4.12)
@@ -66,10 +73,17 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 
 - [2.1.1 Toetsenbord](/wcag/2.1.1)
 - [2.1.2 Geen toetsenbordval](/wcag/2.1.2)
+- [2.1.3 Toetsenbord (geen uitzondering)](/wcag/2.1.3)
 - [2.1.4 Enkel teken sneltoetsen](/wcag/2.1.4)
 - [2.2.1 Timing aanpasbaar](/wcag/2.2.1)
 - [2.2.2 Pauzeren, stoppen, verbergen](/wcag/2.2.2)
+- [2.2.3 Geen timing](/wcag/2.2.3)
+- [2.2.4 Onderbrekingen](/wcag/2.2.4)
+- [2.2.5 Herauthentisering](/wcag/2.2.5)
+- [2.2.6 Time-outs](/wcag/2.2.6)
 - [2.3.1 Drie flitsen of beneden drempelwaarde](/wcag/2.3.1)
+- [2.3.2 Drie flitsen](/wcag/2.3.2)
+- [2.3.3 Animatie uit interacties](/wcag/2.3.3)
 - [2.4.1 Blokken omzeilen](/wcag/2.4.1)
 - [2.4.2 Paginatitel](/wcag/2.4.2)
 - [2.4.3 Focus volgorde](/wcag/2.4.3)
@@ -77,6 +91,8 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [2.4.5 Meerdere manieren](/wcag/2.4.5)
 - [2.4.6 Koppen en labels](/wcag/2.4.6)
 - [2.4.7 Focus zichtbaar](/wcag/2.4.7)
+- [2.4.8 Locatie](/wcag/2.4.8)
+- [2.4.9 Linkdoel (alleen link)](/wcag/2.4.9)
 - [2.4.10 Paragraafkoppen](/wcag/2.4.10)
 - [2.4.11 Focus niet bedekt (minimum)](/wcag/2.4.11)
 - [2.4.13 Focusweergave](/wcag/2.4.13)
@@ -85,6 +101,7 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 - [2.5.3 Label in naam](/wcag/2.5.3)
 - [2.5.4 Bewegingsactivering](/wcag/2.5.4)
 - [2.5.5 Grootte van het aanwijsgebied](/wcag/2.5.5)
+- [2.5.6 Input gelijktijdige invoermechanismen](/wcag/2.5.6)
 - [2.5.7 Sleepbewegingen](/wcag/2.5.7)
 - [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8)
 
@@ -92,17 +109,25 @@ Op dit moment zijn de volgende succescriteria beschreven, het doel is om eind va
 
 - [3.1.1 Taal van de pagina](/wcag/3.1.1)
 - [3.1.2 Taal van onderdelen](/wcag/3.1.2)
+- [3.1.3 Ongebruikelijke woorden](/wcag/3.1.3)
+- [3.1.4 Afkortingen](/wcag/3.1.4)
+- [3.1.5 Leesniveau](/wcag/3.1.5)
+- [3.1.6 Uitspraak](/wcag/3.1.6)
 - [3.2.1 Bij focus](/wcag/3.2.1)
 - [3.2.2 Bij input](/wcag/3.2.2)
 - [3.2.3 Consistente navigatie](/wcag/3.2.3)
 - [3.2.4 Consistente identificatie](/wcag/3.2.4)
+- [3.2.5 Verandering op verzoek](/wcag/3.2.5)
 - [3.2.6 Consistente hulp](/wcag/3.2.6)
 - [3.3.1 Foutidentificatie](/wcag/3.3.1)
 - [3.3.2 Labels of instructies](/wcag/3.3.2)
 - [3.3.3 Foutsuggestie](/wcag/3.3.3)
 - [3.3.4 Foutpreventie (wettelijk, financieel, gegevens)](/wcag/3.3.4)
+- [3.3.5 Hulp](/wcag/3.3.5)
+- [3.3.6 Foutpreventie (alle)](/wcag/3.3.6)
 - [3.3.7 Overbodige invoer](/wcag/3.3.7)
 - [3.3.8 Toegankelijke authenticatie (minimum)](/wcag/3.3.8)
+- [3.3.9 Toegankelijke authenticatie (uitgebreid)](/wcag/3.3.9)
 
 ### Robuust
 


### PR DESCRIPTION
Gerelateerd: #1304.
Preview: https://documentatie-git-docs-wcag-update-intro-page-nl-design-system.vercel.app/wcag/
