### PR TITLE
chore: update dependabot.yml + package.json#packageManager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      patch-and-minor-dependencies:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "private": true,
   "license": "EUPL-1.2",
-  "packageManager": "pnpm@9.7.0",
+  "packageManager": "pnpm@9.12.1",
   "engines": {
     "node": "^20",
     "pnpm": "^9"


### PR DESCRIPTION
Group all patch and minor version updates into one pull requests.

Dependabot pull requests are normally not merged because we use our own pnpm update-patch/minor/major scripts to create pull requests. Dependabot pull requests mainly serve as a reminder. This change should bring down the number of pull requests down significantly while still serving as a reminder.

For major version bumps Dependabot will still open individual pull requests.

Bump package.json#packageManager
