### PR TITLE
feat: add link to iCal from DSW program pages

### DIFF
--- a/docs/community/events/design-systems-week-2024/english/program.mdx
+++ b/docs/community/events/design-systems-week-2024/english/program.mdx
@@ -13,6 +13,7 @@ import DocusaurusLink from "@docusaurus/Link";
 import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
 import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 import DSWSession from "../../../../../src/components/DSWSession";
+import sessions from "../sessions.json";
 import speakers from "../speakers.json";
 
 <div lang="en">
@@ -42,7 +43,7 @@ import speakers from "../speakers.json";
   </ButtonLink>
 </ActionGroup>
 
-<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} lang="en" organisation="US Web Design System" headingLevel={2}>
+<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} lang="en" organisation="US Web Design System" headingLevel={2} session={sessions.find((session)=> session.uuid === 'FE871D75-D5C2-4842-A100-71A8A7069FAD')}>
 
 Amy will share plain-language accessibility tests the USWDS team has created for checking the accessibility of individual components. Attendees will learn how any web team — technical or not — can use these tests to perform baseline manual accessibility testing (like keyboard, screen reader, mobile, and zoom magnification testing) on their own sites. She will also describe the team’s iterative design and development process for these checklists, and how other teams can develop their own.
 
@@ -59,7 +60,7 @@ Amy will share plain-language accessibility tests the USWDS team has created for
 
 </DSWSession>
 
-<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en" headingLevel={2}>
+<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en" headingLevel={2} session={sessions.find((session)=> session.uuid === 'C0639355-E372-422F-8EC9-B069C08CDEEA')}>
 
 Join Geri, a seasoned design systems explorer with 8 years of adventures under her belt, as she navigates the uncharted territories of accessibility in a major product org. With no playbook in hand, Geri’s quest is one we can all relate to: figuring it out as we go along.
 
@@ -67,13 +68,13 @@ In this ‘choose your own adventure’ session, you’ll discover how the princ
 
 </DSWSession>
 
-<DSWSession title="Advantages to working in the open with government design systems" speakers={[speakers.MikeGifford]} organisation="Civic Actions" lang="en" headingLevel={2}>
+<DSWSession title="Advantages to working in the open with government design systems" speakers={[speakers.MikeGifford]} organisation="Civic Actions" lang="en" headingLevel={2} session={sessions.find((session)=> session.uuid === 'CE68A449-D6B7-44C2-B114-017668D83998')}>
 
 For many governments, contributing to open source project is culturally a challenge. It often requires engagement with people in other departments and often outside of government. Design systems however provide a unique opportunity for governments to become more confident in their open source adoption. Mike has contributed to several government design systems. As a Drupal Core Accessibility Maintainer, he is often looking for best practices and comparing different approaches taken by governments around the world.
 
 </DSWSession>
 
-<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" lang="en" headingLevel={2}>
+<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" lang="en" headingLevel={2} session={sessions.find((session)=> session.uuid === '17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA')}>
 
 Lessons from working on the GOV.‌UK Design System and other common platforms in UK government. How leaning on the principles that make the Web great can create more value for the public we serve.
 

--- a/docs/community/events/design-systems-week-2024/programma.mdx
+++ b/docs/community/events/design-systems-week-2024/programma.mdx
@@ -12,6 +12,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 import DocusaurusLink from "@docusaurus/Link";
 import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
 import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import sessions from "./sessions.json";
 import speakers from "./speakers.json";
 import DSWSession from "../../../../src/components/DSWSession";
 
@@ -42,7 +43,7 @@ import DSWSession from "../../../../src/components/DSWSession";
   </ButtonLink>
 </ActionGroup>
 
-<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} organisation="US Web Design System" headingLevel={2}>
+<DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} organisation="US Web Design System" headingLevel={2} session={sessions.find((session)=> session.uuid === 'FE871D75-D5C2-4842-A100-71A8A7069FAD')}>
 
 <Paragraph>
   Amy gaat ons laten zien hoe het US Web Design System toegankelijkheidstests in duidelijke taal heeft toegevoegd bij
@@ -54,7 +55,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned headingLevel={2}>
+<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '50AFAB63-ACDE-4137-8BD5-57B5C34F8B50')}>
 
 <Paragraph>
   Met de komst van Sass, bundlers en frontend frameworks verdween een van de hoekstenen van het web development van
@@ -65,7 +66,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming" speakers={[speakers.CharlottevanBijnen]} organisation="Valsplat" captioned headingLevel={2}>
+<DSWSession title="Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming" speakers={[speakers.CharlottevanBijnen]} organisation="Valsplat" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '268DE453-5636-468C-8721-EAB3134D02A4')}>
 
 <Paragraph>
   Journeys worden vaak gezien als hét middel voor empathie, maar dat is te kort door de bocht. Het is slechts een tool.
@@ -95,7 +96,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned headingLevel={2}>
+<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '5C1C0DCD-33E3-4F57-90F8-4807A55F6200')}>
 
 <Paragraph>
   Darice gaat ons vertellen waarom zelfs als je design systeem de conformiteitscheck doorstaat, het mogelijk nog steeds
@@ -105,7 +106,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" headingLevel={2}>
+<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" headingLevel={2} session={sessions.find((session)=> session.uuid === 'C0639355-E372-422F-8EC9-B069C08CDEEA')}>
 
 <Paragraph>
   Het bouwen van een design system is heel interessant. Maar zodra je design system wordt ingezet voor applicaties in
@@ -116,7 +117,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" headingLevel={2}>
+<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" headingLevel={2} session={sessions.find((session)=> session.uuid === '3A80C3A1-4657-42F8-908D-F9B7565CAF69')}>
 
 <Paragraph>
   Kom kijken hoe Geri, een ervaren design systems verkenner met 8 jaar ervaring in design system avonturen, het
@@ -132,7 +133,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned headingLevel={2}>
+<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '0963CB03-7FBC-4EBD-AAF1-6534402F3A58')}>
 
 <Paragraph>
   In deze sessie vertellen Vincent, Warre en Gijs over de evolutie van het Vlaams Design System: hoe het evolueerde van
@@ -145,7 +146,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong, speakers.LarsvandeCappelle]} organisation="NL Design System community" captioned headingLevel={2}>
+<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong, speakers.LarsvandeCappelle]} organisation="NL Design System community" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === 'F07EEF22-EA9B-4967-B326-2B721E7F2DD2')}>
 
 <Paragraph>
   De [Heartbeat](/events/heartbeat) is een tweewekelijkse online bijeenkomst waarin het kernteam en de community van NL
@@ -176,7 +177,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned headingLevel={2}>
+<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === 'E42373CE-E7D8-4996-B087-7DAB45D5AF96')}>
 
 <Paragraph>
   Hoe is het om te leven met een visuele beperking? Wat zijn de problemen waar je geheel verwacht of onverwachts
@@ -186,7 +187,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned headingLevel={2}>
+<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '7A2AC63A-0D82-4156-A187-C688BAD1BE47')}>
 
 <Paragraph>
   Gebruikersonderzoeken doen is leuk. Je krijgt van de mensen voor wie je het echt doet, te horen wat je goed doet, en
@@ -205,7 +206,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen" speakers={[speakers.LotteBijl]} organisation="Belastingdienst" captioned headingLevel={2}>
+<DSWSession title="Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen" speakers={[speakers.LotteBijl]} organisation="Belastingdienst" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === 'A778C5D1-743F-4C8E-93AF-56F8375C29AC')}>
 
 <Paragraph>
   Als overheidsorganisatie houdt de Belastingdienst zich al jaren bezig met het digitaal toegankelijk maken van hun
@@ -218,7 +219,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="De voordelen van open werken met design systems bij de overheid" speakers={[speakers.MikeGifford]} organisation="Civic Actions" headingLevel={2}>
+<DSWSession title="De voordelen van open werken met design systems bij de overheid" speakers={[speakers.MikeGifford]} organisation="Civic Actions" headingLevel={2} session={sessions.find((session)=> session.uuid === 'CE68A449-D6B7-44C2-B114-017668D83998')}>
 
 <Paragraph>
   Voor veel overheden is bijdragen aan open source projecten een culturele uitdagingen. Er wordt vaak samengewerkt met
@@ -229,7 +230,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" headingLevel={2}>
+<DSWSession title="Common direction, boring magic" speakers={[speakers.SteveMesser]} organisation="freelance" headingLevel={2} session={sessions.find((session)=> session.uuid === '17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA')}>
 
 <Paragraph>
   Steve vertelt over wat hij leerde terwijl hij werkte aan het GOV.‌UK Design System en andere platformen van de Britse
@@ -239,7 +240,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Werken op schaal" speakers={[speakers.ThijsLouisse]} organisation="ING" headingLevel={2} captioned>
+<DSWSession title="Werken op schaal" speakers={[speakers.ThijsLouisse]} organisation="ING" headingLevel={2} captioned session={sessions.find((session)=> session.uuid === '17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA')}>
 
 <Paragraph>
   Het design system van ING wordt door bijna 2000 _consuming packages_ als _dependency_ gebruikt. Als een nieuwe versie

--- a/docs/community/events/design-systems-week-2024/sessions.json
+++ b/docs/community/events/design-systems-week-2024/sessions.json
@@ -1,0 +1,227 @@
+[
+  {
+    "uuid": "C0639355-E372-422F-8EC9-B069C08CDEEA",
+    "isoDateTime": "2024-10-14T09:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Gert Hengeveld",
+        "organisation": "Chromatic"
+      }
+    ],
+    "subject": "Testing UI",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#testing-ui",
+    "icalLink": "/dsweek-2024/gert-hengeveld.ics",
+    "language": { "abbr": "EN", "description": "English" }
+  },
+  {
+    "uuid": "3A80C3A1-4657-42F8-908D-F9B7565CAF69",
+    "isoDateTime": "2024-10-14T11:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Geri Reid",
+        "organisation": "Just Eat Takeaway"
+      }
+    ],
+    "subject": "Design Systems: Choose your own adventure",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#design-systems:-choose-your-own-adventure",
+    "icalLink": "/dsweek-2024/geri-reid.ics",
+    "language": { "abbr": "EN", "description": "English" }
+  },
+  {
+    "uuid": "6CB6A172-9F41-46FB-A24F-CA1DE023550C",
+    "isoDateTime": "2024-10-14T13:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Thijs Louisse",
+        "organisation": "ING"
+      }
+    ],
+    "subject": "Werken op schaal",
+    "icalLink": "/dsweek-2024/thijs-louisse.ics",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#werken-op-schaal",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "CE68A449-D6B7-44C2-B114-017668D83998",
+    "isoDateTime": "2024-10-14T14:30:00.000Z",
+    "speakers": [
+      {
+        "name": "Mike Gifford",
+        "organisation": "CivicActions"
+      }
+    ],
+    "subject": "De voordelen van open werken met design systems bij de overheid",
+    "icalLink": "/dsweek-2024/mike-gifford.ics",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#de-voordelen-van-open-werken-met-design-systems-bij-de-overheid",
+    "language": { "abbr": "EN", "description": "English" }
+  },
+  {
+    "uuid": "E42373CE-E7D8-4996-B087-7DAB45D5AF96",
+    "isoDateTime": "2024-10-15T09:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Kim Denie",
+        "organisation": ""
+      }
+    ],
+    "subject": "Tips voor toegankelijke diensten",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#tips-voor-toegankelijke-dienstverlening",
+    "icalLink": "/dsweek-2024/kim-denie.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "F07EEF22-EA9B-4967-B326-2B721E7F2DD2",
+    "isoDateTime": "2024-10-15T11:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Bryan de Jong",
+        "organisation": "VNG / Frameless"
+      },
+      {
+        "name": "Marieke Brouwer",
+        "organisation": "Gemeente Groningen"
+      },
+      {
+        "name": "Lars van de Cappelle",
+        "organisation": "Belastingdienst"
+      }
+    ],
+    "subject": "Heartbeat: Design Systems Week editie",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#heartbeat:-de-design-systems-week-lightning-talks-editie",
+    "icalLink": "/dsweek-2024/heartbeat.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "7A2AC63A-0D82-4156-A187-C688BAD1BE47",
+    "isoDateTime": "2024-10-15T13:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Jeroen du Chatinier",
+        "organisation": "Gemeente Utrecht"
+      }
+    ],
+    "subject": "Je eerste gebruikersonderzoek doen, hoe doe je dat?",
+    "icalLink": "/dsweek-2024/jeroen-du-chatinier.ics",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#je-eerste-gebruikersonderzoek-doen,-hoe-doe-je-dat?",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "268DE453-5636-468C-8721-EAB3134D02A4",
+    "isoDateTime": "2024-10-15T14:30:00.000Z",
+    "speakers": [
+      {
+        "name": "Charlotte van Bijnen",
+        "organisation": "Valsplat"
+      }
+    ],
+    "subject": "Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming",
+    "icalLink": "/dsweek-2024/charlotte-van-bijnen.ics",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#jongeren-en-jeugdcriminaliteit:-een-journey-voor-(en-naar)-betere-communicatie-door-de-raad-van-de-kinderbescherming",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "0963CB03-7FBC-4EBD-AAF1-6534402F3A58",
+    "isoDateTime": "2024-10-15T09:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Gijs Veyfeyken",
+        "organisation": "Agentschap Digitaal Vlaanderen"
+      },
+      {
+        "name": "Vincent Sennesael",
+        "organisation": "Agentschap Digitaal Vlaanderen"
+      },
+      {
+        "name": "Warre Buysse",
+        "organisation": "Agentschap Digitaal Vlaanderen"
+      }
+    ],
+    "subject": "Vlaams Design System: 10 jaar lessons learned",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#vlaams-design-system:-10-jaar-lessons-learned",
+    "icalLink": "/dsweek-2024/vlaanderen.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "5C1C0DCD-33E3-4F57-90F8-4807A55F6200",
+    "isoDateTime": "2024-10-16T11:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Darice de Cuba",
+        "organisation": ""
+      }
+    ],
+    "subject": "Unmeasurable Accessibility: Beyond conformance",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#unmeasurable-accessibility:-beyond-conformance",
+    "icalLink": "/dsweek-2024/darice-de-cuba.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "50AFAB63-ACDE-4137-8BD5-57B5C34F8B50",
+    "isoDateTime": "2024-10-16T13:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Bart Veneman",
+        "organisation": "Project Wallace"
+      }
+    ],
+    "subject": "Wat je allemaal niet weet over je CSS",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#wat-je-allemaal-niet-weet-over-je-css",
+    "icalLink": "/dsweek-2024/bart-veneman.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "FE871D75-D5C2-4842-A100-71A8A7069FAD",
+    "isoDateTime": "2024-10-16T14:30:00.000Z",
+    "speakers": [
+      {
+        "name": "Amy Cole",
+        "organisation": "US Web Design System"
+      }
+    ],
+    "subject": "Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams",
+    "icalLink": "/dsweek-2024/amy-cole.ics",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#using-uswds-accessibility-tests-to-develop-accessibility-skills-across-government-teams",
+    "language": { "abbr": "EN", "description": "English" }
+  },
+  {
+    "uuid": "A980E371-ED8E-4EA4-A22C-CA1A212150F7",
+    "isoDateTime": "2024-10-17T09:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Robbert Broersma",
+        "organisation": "NL Design System"
+      }
+    ],
+    "subject": "Live coden",
+    "icalLink": "/dsweek-2024/robbert-broersma.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "A778C5D1-743F-4C8E-93AF-56F8375C29AC",
+    "isoDateTime": "2024-10-17T13:00:00.000Z",
+    "speakers": [
+      {
+        "name": "Lotte Bijl",
+        "organisation": "Belastingdienst"
+      }
+    ],
+    "subject": "Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#inclusief-gebruikersonderzoek-bij-de-belastingdienst,-een-blik-achter-de-schermen",
+    "icalLink": "/dsweek-2024/lotte-bijl.ics",
+    "language": { "abbr": "NL", "description": "Nederlands" }
+  },
+  {
+    "uuid": "17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA",
+    "isoDateTime": "2024-10-17T14:30:00.000Z",
+    "speakers": [
+      {
+        "name": "Steve Messer",
+        "organisation": "freelance"
+      }
+    ],
+    "subject": "Common direction, boring magic",
+    "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#common-direction,-boring-magic",
+    "icalLink": "/dsweek-2024/steve-messer.ics",
+    "language": { "abbr": "EN", "description": "Engels" }
+  }
+]

--- a/docs/community/events/design-systems-week-2024/tijdschema-per-dag.mdx
+++ b/docs/community/events/design-systems-week-2024/tijdschema-per-dag.mdx
@@ -11,6 +11,7 @@ slug: /events/design-systems-week-2024/tijdschema
 import DocusaurusLink from "@docusaurus/Link";
 import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
 import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react";
+import sessions from "./sessions.json";
 import { SessionTable } from "../../../../src/components/SessionTable";
 
 # Tijdschema Design Systems Week 2024
@@ -35,257 +36,19 @@ Dit jaar hebben we nationale én internationale sprekers. We richten ons op vers
 
 ## Maandag 14 oktober
 
-<SessionTable
-  lang="nl-NL"
-  sessions={[
-    {
-      isoDateTime: "2024-10-14T09:00:00.000Z",
-      speakers: [
-        {
-          name: "Gert Hengeveld",
-          organisation: "Chromatic",
-        },
-      ],
-      subject: "Testing UI",
-      sessionLink: "https://nldesignsystem.nl/events/design-systems-week-2024/programma#testing-ui",
-      icalLink: "/dsweek-2024/gert-hengeveld.ics",
-      language: { abbr: "EN", description: "English" },
-    },
-    {
-      isoDateTime: "2024-10-14T11:00:00.000Z",
-      speakers: [
-        {
-          name: "Geri Reid",
-          organisation: "Just Eat Takeaway",
-        },
-      ],
-      subject: "Design Systems: Choose your own adventure",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#design-systems:-choose-your-own-adventure",
-      icalLink: "/dsweek-2024/geri-reid.ics",
-      language: { abbr: "EN", description: "English" },
-    },
-    {
-      isoDateTime: "2024-10-14T13:00:00.000Z",
-      speakers: [
-        {
-          name: "Thijs Louisse",
-          organisation: "ING",
-        },
-      ],
-      subject: "Werken op schaal",
-      icalLink: "/dsweek-2024/thijs-louisse.ics",
-      sessionLink: "https://nldesignsystem.nl/events/design-systems-week-2024/programma#werken-op-schaal",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-14T14:30:00.000Z",
-      speakers: [
-        {
-          name: "Mike Gifford",
-          organisation: "CivicActions",
-        },
-      ],
-      subject: "De voordelen van open werken met design systems bij de overheid",
-      icalLink: "/dsweek-2024/mike-gifford.ics",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#de-voordelen-van-open-werken-met-design-systems-bij-de-overheid",
-      language: { abbr: "EN", description: "English" },
-    },
-  ]}
-/>
+<SessionTable lang="nl-NL" sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith("2024-10-14"))} />
 
 ## Dinsdag 15 oktober
 
-<SessionTable
-  lang="nl-NL"
-  sessions={[
-    {
-      isoDateTime: "2024-10-15T09:00:00.000Z",
-      speakers: [
-        {
-          name: "Kim Denie",
-          organisation: "",
-        },
-      ],
-      subject: "Tips voor toegankelijke diensten",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#tips-voor-toegankelijke-dienstverlening",
-      icalLink: "/dsweek-2024/kim-denie.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-15T11:00:00.000Z",
-      speakers: [
-        {
-          name: "Bryan de Jong",
-          organisation: "VNG / Frameless",
-        },
-        {
-          name: "Marieke Brouwer",
-          organisation: "Gemeente Groningen",
-        },
-        {
-          name: "Lars van de Cappelle",
-          organisation: "Belastingdienst",
-        },
-      ],
-      subject: "Heartbeat: Design Systems Week editie",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#heartbeat:-de-design-systems-week-lightning-talks-editie",
-      icalLink: "/dsweek-2024/heartbeat.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-15T13:00:00.000Z",
-      speakers: [
-        {
-          name: "Jeroen du Chatinier",
-          organisation: "Gemeente Utrecht",
-        },
-      ],
-      subject: "Je eerste gebruikersonderzoek doen, hoe doe je dat?",
-      icalLink: "/dsweek-2024/jeroen-du-chatinier.ics",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#je-eerste-gebruikersonderzoek-doen,-hoe-doe-je-dat?",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-15T14:30:00.000Z",
-      speakers: [
-        {
-          name: "Charlotte van Bijnen",
-          organisation: "Valsplat",
-        },
-      ],
-      subject:
-        "Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming",
-      icalLink: "/dsweek-2024/charlotte-van-bijnen.ics",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#jongeren-en-jeugdcriminaliteit:-een-journey-voor-(en-naar)-betere-communicatie-door-de-raad-van-de-kinderbescherming",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-  ]}
-/>
+<SessionTable lang="nl-NL" sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith("2024-10-15"))} />
 
 ## Woensdag 16 oktober
 
-<SessionTable
-  lang="nl-NL"
-  sessions={[
-    {
-      isoDateTime: "2024-10-15T09:00:00.000Z",
-      speakers: [
-        {
-          name: "Gijs Veyfeyken",
-          organisation: "Agentschap Digitaal Vlaanderen",
-        },
-        {
-          name: "Vincent Sennesael",
-          organisation: "Agentschap Digitaal Vlaanderen",
-        },
-        {
-          name: "Warre Buysse",
-          organisation: "Agentschap Digitaal Vlaanderen",
-        },
-      ],
-      subject: "Vlaams Design System: 10 jaar lessons learned",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#vlaams-design-system:-10-jaar-lessons-learned",
-      icalLink: "/dsweek-2024/vlaanderen.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-16T11:00:00.000Z",
-      speakers: [
-        {
-          name: "Darice de Cuba",
-          organisation: "",
-        },
-      ],
-      subject: "Unmeasurable Accessibility: Beyond conformance",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#unmeasurable-accessibility:-beyond-conformance",
-      icalLink: "/dsweek-2024/darice-de-cuba.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-16T13:00:00.000Z",
-      speakers: [
-        {
-          name: "Bart Veneman",
-          organisation: "Project Wallace",
-        },
-      ],
-      subject: "Wat je allemaal niet weet over je CSS",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#wat-je-allemaal-niet-weet-over-je-css",
-      icalLink: "/dsweek-2024/bart-veneman.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-16T14:30:00.000Z",
-      speakers: [
-        {
-          name: "Amy Cole",
-          organisation: "US Web Design System",
-        },
-      ],
-      subject: "Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams",
-      icalLink: "/dsweek-2024/amy-cole.ics",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#using-uswds-accessibility-tests-to-develop-accessibility-skills-across-government-teams",
-      language: { abbr: "EN", description: "English" },
-    },
-  ]}
-/>
+<SessionTable lang="nl-NL" sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith("2024-10-16"))} />
 
 ## Donderdag 17 oktober
 
-<SessionTable
-  lang="nl-NL"
-  sessions={[
-    {
-      isoDateTime: "2024-10-17T09:00:00.000Z",
-      speakers: [
-        {
-          name: "Robbert Broersma",
-          organisation: "NL Design System",
-        },
-      ],
-      subject: "Live coden",
-      icalLink: "/dsweek-2024/robbert-broersma.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-17T13:00:00.000Z",
-      speakers: [
-        {
-          name: "Lotte Bijl",
-          organisation: "Belastingdienst",
-        },
-      ],
-      subject: "Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen",
-      sessionLink:
-        "https://nldesignsystem.nl/events/design-systems-week-2024/programma#inclusief-gebruikersonderzoek-bij-de-belastingdienst,-een-blik-achter-de-schermen",
-      icalLink: "/dsweek-2024/lotte-bijl.ics",
-      language: { abbr: "NL", description: "Nederlands" },
-    },
-    {
-      isoDateTime: "2024-10-17T14:30:00.000Z",
-      speakers: [
-        {
-          name: "Steve Messer",
-          organisation: "freelance",
-        },
-      ],
-      subject: "Common direction, boring magic",
-      sessionLink: "https://nldesignsystem.nl/events/design-systems-week-2024/programma#common-direction,-boring-magic",
-      icalLink: "/dsweek-2024/steve-messer.ics",
-      language: { abbr: "EN", description: "Engels" },
-    },
-  ]}
-/>
+<SessionTable lang="nl-NL" sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith("2024-10-17"))} />
 
 <hr></hr>
 

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -1,9 +1,10 @@
 import Link from '@docusaurus/Link';
-import { IconChevronRight } from '@tabler/icons-react';
-import { Heading, Paragraph } from '@utrecht/component-library-react/dist/css-module';
+import { IconCalendarEvent, IconChevronRight } from '@tabler/icons-react';
+import { ButtonLink, Heading, Icon, Paragraph } from '@utrecht/component-library-react/dist/css-module';
 import clsx from 'clsx';
 import React, { PropsWithChildren } from 'react';
 import style from './DSWSession.module.css';
+import { Session } from './SessionTable';
 import { VideoPlayer } from './VideoPlayer';
 
 interface DSWSessionProps {
@@ -17,6 +18,7 @@ interface DSWSessionProps {
   organisation: string;
   videoId?: string;
   captioned?: boolean;
+  session?: Session;
 }
 
 interface DSWSpeaker {
@@ -39,6 +41,7 @@ export const DSWSession = ({
   videoId,
   children,
   captioned,
+  session,
 }: PropsWithChildren<DSWSessionProps>) => (
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
@@ -52,6 +55,26 @@ export const DSWSession = ({
         {', '} {organisation}
       </Paragraph>
     )}
+    {session && session.isoDateTime && session.icalLink && !videoId ? (
+      <Paragraph>
+        <ButtonLink
+          href={session.icalLink}
+          download={session.icalLink}
+          style={{ paddingInlineStart: 0, paddingInlineEnd: 0 }}
+        >
+          <Icon>
+            <IconCalendarEvent />
+          </Icon>
+          <time dateTime={session.isoDateTime}>
+            {new Intl.DateTimeFormat(lang, {
+              dateStyle: 'full',
+              timeStyle: lang === 'nl' ? 'short' : 'full',
+              timeZone: 'Europe/Amsterdam',
+            }).format(new Date(session.isoDateTime))}
+          </time>
+        </ButtonLink>
+      </Paragraph>
+    ) : null}
     {children}
     {lang === 'nl' && speakers.find(({ language }) => language !== 'nl') && (
       <Paragraph>

--- a/src/components/SessionTable.tsx
+++ b/src/components/SessionTable.tsx
@@ -20,7 +20,8 @@ interface Speaker {
   organisation: string;
 }
 
-interface Session {
+export interface Session {
+  uuid: string;
   isoDateTime: string;
   speakers: Speaker[];
   subject: string;


### PR DESCRIPTION
Op veler verzoek: tijden in het programma.

Nederlands:

<img width="840" alt="Screenshot 2024-10-14 at 09 20 39" src="https://github.com/user-attachments/assets/0c36e2c7-330a-43bc-9ce8-88052e53d54b">

Engels:

<img width="850" alt="Screenshot 2024-10-14 at 09 21 32" src="https://github.com/user-attachments/assets/120046e9-5025-4704-a4b1-a68a8b341fde">

De linkjes worden automatisch verborgen wanneer later de video beschikbaar is.