### PR TITLE
docs: add captionlinks

### DIFF
--- a/docs/community/events/design-systems-week-2024/programma.mdx
+++ b/docs/community/events/design-systems-week-2024/programma.mdx
@@ -55,7 +55,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '50AFAB63-ACDE-4137-8BD5-57B5C34F8B50')}>
+<DSWSession title="Wat je allemaal niet weet over je CSS" speakers={[speakers.BartVeneman]} organisation="Project Wallace" captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" headingLevel={2} session={sessions.find((session)=> session.uuid === '50AFAB63-ACDE-4137-8BD5-57B5C34F8B50')}>
 
 <Paragraph>
   Met de komst van Sass, bundlers en frontend frameworks verdween een van de hoekstenen van het web development van
@@ -66,7 +66,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming" speakers={[speakers.CharlottevanBijnen]} organisation="Valsplat" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '268DE453-5636-468C-8721-EAB3134D02A4')}>
+<DSWSession title="Jongeren en jeugdcriminaliteit: een journey voor (en naar) betere communicatie door de Raad voor de Kinderbescherming" speakers={[speakers.CharlottevanBijnen]} captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" organisation="Valsplat" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '268DE453-5636-468C-8721-EAB3134D02A4')}>
 
 <Paragraph>
   Journeys worden vaak gezien als hét middel voor empathie, maar dat is te kort door de bocht. Het is slechts een tool.
@@ -96,7 +96,8 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '5C1C0DCD-33E3-4F57-90F8-4807A55F6200')}>
+<DSWSession title="Unmeasurable Accessibility: Beyond conformance" speakers={[speakers.DariceDeCuba]} organisation="darice.org" captioned captionLink="https://text-on-tap.live/index.html#e=k9uc6NUzDE
+" headingLevel={2} session={sessions.find((session)=> session.uuid === '5C1C0DCD-33E3-4F57-90F8-4807A55F6200')}>
 
 <Paragraph>
   Darice gaat ons vertellen waarom zelfs als je design systeem de conformiteitscheck doorstaat, het mogelijk nog steeds
@@ -133,7 +134,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '0963CB03-7FBC-4EBD-AAF1-6534402F3A58')}>
+<DSWSession title="Vlaams Design System: 10 jaar lessons learned" speakers={[speakers.GijsVeyfeyken, speakers.VincentSennesael, speakers.WarreBuysse]} organisation="Agentschap Digitaal Vlaanderen" captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" headingLevel={2} session={sessions.find((session)=> session.uuid === '0963CB03-7FBC-4EBD-AAF1-6534402F3A58')}>
 
 <Paragraph>
   In deze sessie vertellen Vincent, Warre en Gijs over de evolutie van het Vlaams Design System: hoe het evolueerde van
@@ -146,7 +147,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong, speakers.LarsvandeCappelle]} organisation="NL Design System community" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === 'F07EEF22-EA9B-4967-B326-2B721E7F2DD2')}>
+<DSWSession title="Heartbeat: de Design Systems Week lightning talks editie" speakers={[speakers.MariekeBrouwer, speakers.BryandeJong, speakers.LarsvandeCappelle]} organisation="NL Design System community" captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" headingLevel={2} session={sessions.find((session)=> session.uuid === 'F07EEF22-EA9B-4967-B326-2B721E7F2DD2')}>
 
 <Paragraph>
   De [Heartbeat](/events/heartbeat) is een tweewekelijkse online bijeenkomst waarin het kernteam en de community van NL
@@ -177,7 +178,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === 'E42373CE-E7D8-4996-B087-7DAB45D5AF96')}>
+<DSWSession title="Tips voor toegankelijke dienstverlening" speakers={[speakers.KimDenie]} organisation="adviseur" captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" headingLevel={2} session={sessions.find((session)=> session.uuid === 'E42373CE-E7D8-4996-B087-7DAB45D5AF96')}>
 
 <Paragraph>
   Hoe is het om te leven met een visuele beperking? Wat zijn de problemen waar je geheel verwacht of onverwachts
@@ -187,7 +188,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned headingLevel={2} session={sessions.find((session)=> session.uuid === '7A2AC63A-0D82-4156-A187-C688BAD1BE47')}>
+<DSWSession title="Je eerste gebruikersonderzoek doen, hoe doe je dat?" speakers={[speakers.JeroenDuChatinier]} organisation="Gemeente Utrecht" captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" headingLevel={2} session={sessions.find((session)=> session.uuid === '7A2AC63A-0D82-4156-A187-C688BAD1BE47')}>
 
 <Paragraph>
   Gebruikersonderzoeken doen is leuk. Je krijgt van de mensen voor wie je het echt doet, te horen wat je goed doet, en
@@ -240,7 +241,7 @@ import DSWSession from "../../../../src/components/DSWSession";
 
 </DSWSession>
 
-<DSWSession title="Werken op schaal" speakers={[speakers.ThijsLouisse]} organisation="ING" headingLevel={2} captioned session={sessions.find((session)=> session.uuid === '17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA')}>
+<DSWSession title="Werken op schaal" speakers={[speakers.ThijsLouisse]} organisation="ING" headingLevel={2} captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" session={sessions.find((session)=> session.uuid === '17A1CBCD-ACB8-4A85-87E4-A4CD258AFABA')}>
 
 <Paragraph>
   Het design system van ING wordt door bijna 2000 _consuming packages_ als _dependency_ gebruikt. Als een nieuwe versie

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -18,6 +18,7 @@ interface DSWSessionProps {
   organisation: string;
   videoId?: string;
   captioned?: boolean;
+  captionLink?: string;
   session?: Session;
 }
 
@@ -41,6 +42,7 @@ export const DSWSession = ({
   videoId,
   children,
   captioned,
+  captionLink,
   session,
 }: PropsWithChildren<DSWSessionProps>) => (
   <article className={clsx(style['dsw-session'])} id={title.toLowerCase().replace(/\s/gi, '-')}>
@@ -83,7 +85,18 @@ export const DSWSession = ({
     )}
     {captioned && (
       <Paragraph>
-        <b>Goed te weten:</b> Bij deze sessie is een schrijftolk aanwezig.
+        <b>Goed te weten:</b> Bij deze sessie is een schrijftolk aanwezig
+        {captionLink && (
+          <>
+            {' '}
+            (
+            <a href={captionLink}>
+              tolktekst<span className="sr-only"> bij {title}</span>
+            </a>
+            )
+          </>
+        )}
+        .
       </Paragraph>
     )}
     <aside className={clsx(style['dsw-session__speakers'])}>


### PR DESCRIPTION
tolktekstlinks zijn anders per schrijftolk, dit voegt ze toe aan de sessies waarvan we de link to nu toe hebben, en plaatst ze in het programma. 

ik had niet heel veel inspiratie, zo ziet het eruit (met visuallyhidden nog de naam van de sessie voor linkuniekheid)

<img width="547" alt="Screenshot 2024-10-14 at 14 33 06" src="https://github.com/user-attachments/assets/f37b088a-f825-492c-8429-65b4fad6594e">
