### PR TITLE
docs: linkfixes button component pagina

### DIFF
--- a/docs/componenten/button/_wcag-1.1.1.md
+++ b/docs/componenten/button/_wcag-1.1.1.md
@@ -6,8 +6,6 @@ Het beste is om altijd visueel een tekst te tonen naast of onder het icoon. Icon
 
 Is het toch gewenst om alleen een icoon te tonen, hou dan rekening met het volgende.
 
-##### In de code
-
 Een `img` met een alt-attribuut is een robuuste manier om een alternatieve tekst toe te voegen. De waarde van het alt-attribuut vormt de naam van de button:
 
 ```html
@@ -27,7 +25,7 @@ Een andere manier is een svg in de button op te nemen, samen met een visueel ver
 </button>
 ```
 
-##### NL Design System richtlijnen:
+NL Design System richtlijnen:
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam)

--- a/docs/componenten/button/_wcag-1.1.1.md
+++ b/docs/componenten/button/_wcag-1.1.1.md
@@ -31,4 +31,4 @@ Een andere manier is een svg in de button op te nemen, samen met een visueel ver
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam)
-- [Iconen toepassen in de code](https://www.nldesignsystem.nl/richtlijnen/stijl/iconen/#toepassen-in-code)
+- [Toepassen van een SVG in code](richtlijnen/stijl/iconen/gebruik-svg#toepassen-van-een-svg-in-code)

--- a/docs/componenten/button/_wcag-1.1.1.md
+++ b/docs/componenten/button/_wcag-1.1.1.md
@@ -31,4 +31,4 @@ Een andere manier is een svg in de button op te nemen, samen met een visueel ver
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam)
-- [Toepassen van een SVG in code](richtlijnen/stijl/iconen/gebruik-svg#toepassen-van-een-svg-in-code)
+- [Toepassen van een SVG in code](/richtlijnen/stijl/iconen/gebruik-svg#toepassen-van-een-svg-in-code)

--- a/docs/componenten/button/_wcag-1.1.1.md
+++ b/docs/componenten/button/_wcag-1.1.1.md
@@ -31,4 +31,5 @@ Een andere manier is een svg in de button op te nemen, samen met een visueel ver
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam)
+- [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/gebruik-svg)
 - [Toepassen van een SVG in code](/richtlijnen/stijl/iconen/gebruik-svg#toepassen-van-een-svg-in-code)

--- a/docs/componenten/button/_wcag-1.4.11.md
+++ b/docs/componenten/button/_wcag-1.4.11.md
@@ -4,4 +4,4 @@ Als het label van de button niet uit tekst bestaat maar uit bijvoorbeeld een ico
 
 NL Design System richtlijnen:
 
-* [Zorg voor voldoende kleurcontrast voor niet-tekstuele content](/richtlijnen/stijl/kleuren/contrast-niet-tekstuele-content)
+- [Zorg voor voldoende kleurcontrast voor niet-tekstuele content](/richtlijnen/stijl/kleuren/contrast-niet-tekstuele-content)

--- a/docs/componenten/button/_wcag-1.4.11.md
+++ b/docs/componenten/button/_wcag-1.4.11.md
@@ -1,3 +1,7 @@
 <!-- @license CC0-1.0 -->
 
 Als het label van de button niet uit tekst bestaat maar uit bijvoorbeeld een icoon (zoals bij een zoekknop met een vergrootglas), dan is het contrast tussen het icoon en de achtergrond minimaal 3:1. Dit is te controleren met de [Contrast checker](https://nldesignsystem.nl/contrast/).
+
+NL Design System richtlijnen:
+
+* [Zorg voor voldoende kleurcontrast voor niet-tekstuele content](/richtlijnen/stijl/kleuren/contrast-niet-tekstuele-content)

--- a/docs/componenten/button/_wcag-1.4.12.md
+++ b/docs/componenten/button/_wcag-1.4.12.md
@@ -25,3 +25,7 @@ body p {
 }
 </style>
 ```
+
+NL Design System richtlijnen:
+
+* [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-1.4.12.md
+++ b/docs/componenten/button/_wcag-1.4.12.md
@@ -28,4 +28,4 @@ body p {
 
 NL Design System richtlijnen:
 
-* [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)
+- [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-1.4.12.md
+++ b/docs/componenten/button/_wcag-1.4.12.md
@@ -29,3 +29,5 @@ body p {
 NL Design System richtlijnen:
 
 - [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)
+- [Zorg ervoor dat letters groot genoeg zijn](/richtlijnen/stijl/typografie/lettergrootte)
+- [Zorg voor een comfortabele regelafstand](/richtlijnen/stijl/typografie/regelafstand/)

--- a/docs/componenten/button/_wcag-1.4.3.md
+++ b/docs/componenten/button/_wcag-1.4.3.md
@@ -10,4 +10,4 @@ Hogere verhoudingen mogen natuurlijk altijd. Met de [Contrast checker](/contrast
 
 ##### NL Design System richtlijnen:
 
-- [Geef tekst voldoende kleurcontrast](/richtlijnen/formulieren/visueel-ontwerp/tekst-goed-zichtbaar/)
+- [Zorg voor voldoende kleurcontrast voor tekst tegen de achtergrond](/richtlijnen/stijl/kleuren/contrast-tekst/)

--- a/docs/componenten/button/_wcag-1.4.3.md
+++ b/docs/componenten/button/_wcag-1.4.3.md
@@ -8,7 +8,7 @@ De contrastverhouding van de tekstkleur in de button met de achtergrondkleur is 
 
 Hogere verhoudingen mogen natuurlijk altijd. Met de [Contrast checker](/contrast/) kun je controleren of je gekozen kleuren voldoen. Denk erom dat dit moet gelden voor alle achtergrondkleuren waarop de tekst geplaatst kan worden. Het kan dus zijn dat je meerdere checks moet doen.
 
-##### NL Design System richtlijnen:
+NL Design System richtlijnen:
 
 - [Zorg voor voldoende kleurcontrast voor tekst tegen de achtergrond](/richtlijnen/stijl/kleuren/contrast-tekst/)
 - [Geef tekst voldoende kleurcontrast](/richtlijnen/formulieren/visueel-ontwerp/tekst-goed-zichtbaar/)

--- a/docs/componenten/button/_wcag-1.4.3.md
+++ b/docs/componenten/button/_wcag-1.4.3.md
@@ -11,3 +11,4 @@ Hogere verhoudingen mogen natuurlijk altijd. Met de [Contrast checker](/contrast
 ##### NL Design System richtlijnen:
 
 - [Zorg voor voldoende kleurcontrast voor tekst tegen de achtergrond](/richtlijnen/stijl/kleuren/contrast-tekst/)
+- [Geef tekst voldoende kleurcontrast](/richtlijnen/formulieren/visueel-ontwerp/tekst-goed-zichtbaar/)

--- a/docs/componenten/button/_wcag-1.4.4.md
+++ b/docs/componenten/button/_wcag-1.4.4.md
@@ -6,4 +6,4 @@ Zorg ervoor dat de button mee kan groeien met de tekst. Geef de breedte en de ho
 
 NL Design System richtlijnen:
 
-* [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)
+- [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-1.4.4.md
+++ b/docs/componenten/button/_wcag-1.4.4.md
@@ -7,3 +7,4 @@ Zorg ervoor dat de button mee kan groeien met de tekst. Geef de breedte en de ho
 NL Design System richtlijnen:
 
 - [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)
+- [Zorg ervoor dat letters groot genoeg zijn](/richtlijnen/stijl/typografie/lettergrootte)

--- a/docs/componenten/button/_wcag-1.4.4.md
+++ b/docs/componenten/button/_wcag-1.4.4.md
@@ -3,3 +3,7 @@
 Als je de tekst vergroot tot 200% (via browserzoom en via de browserinstellingen voor tekstgrootte) blijft de tekst in zijn geheel zichtbaar.
 
 Zorg ervoor dat de button mee kan groeien met de tekst. Geef de breedte en de hoogte dus niet hard op in pixels.
+
+NL Design System richtlijnen:
+
+* [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-1.4.5.md
+++ b/docs/componenten/button/_wcag-1.4.5.md
@@ -5,3 +5,4 @@ Het label van de button bestaat uit gewone tekst, niet uit een afbeelding van te
 NL Design System richtlijnen:
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
+- [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/gebruik-svg)

--- a/docs/componenten/button/_wcag-1.4.5.md
+++ b/docs/componenten/button/_wcag-1.4.5.md
@@ -5,4 +5,3 @@ Het label van de button bestaat uit gewone tekst, niet uit een afbeelding van te
 NL Design System richtlijnen:
 
 - [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)
-- [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/gebruik-svg)

--- a/docs/componenten/button/_wcag-1.4.5.md
+++ b/docs/componenten/button/_wcag-1.4.5.md
@@ -4,4 +4,4 @@ Het label van de button bestaat uit gewone tekst, niet uit een afbeelding van te
 
 NL Design System richtlijnen:
 
-- [Afbeeldingen als buttons](https://www.nldesignsystem.nl/richtlijnen/formulieren/buttons/afbeelding-als-button)
+- [Afbeeldingen als buttons](/richtlijnen/formulieren/buttons/afbeelding-als-button)

--- a/docs/componenten/button/_wcag-2.4.13.md
+++ b/docs/componenten/button/_wcag-2.4.13.md
@@ -6,3 +6,4 @@ NL Design System richtlijnen:
 
 - [Maak toetsenbord focus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar/)
 - [Let op voorkeursinstellingen voor kleur](/richtlijnen/stijl/kleuren/voorkeuren)
+- [Zorg voor voldoende kleurcontrast voor niet-tekstuele content](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-2.4.13.md
+++ b/docs/componenten/button/_wcag-2.4.13.md
@@ -5,3 +5,4 @@ Er is een goed zichtbare focusindicator. Dit doe je met een minimale dikte van 2
 NL Design System richtlijnen:
 
 - [Maak toetsenbord focus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar/)
+- [Let op voorkeursinstellingen voor kleur](/richtlijnen/stijl/kleuren/voorkeuren)

--- a/docs/componenten/button/_wcag-2.4.6.md
+++ b/docs/componenten/button/_wcag-2.4.6.md
@@ -1,7 +1,11 @@
 <!-- @license CC0-1.0 -->
 
-Het label van de button maakt kort en bondig duidelijk waar de button voor dient.
+Het label van de button maakt kort en bondig duidelijk waar de button voor dient. Een label kan bestaan uit tekst of uit een icoon. Als je een icoon gebruikt, heeft het de voorkeur om ook een beschrijvende tekst in de button op te nemen.
 
 NL Design System richtlijnen:
 
 - [Duidelijke buttontekst die beschrijft wat de button doet](/richtlijnen/formulieren/buttons/duidelijk-buttontekst/)
+- [Respecteer conventies](/richtlijnen/stijl/iconen/respecteer-conventies)
+- [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/respecteer-conventies)
+- [Zorg voor een consistente navigatie en benaming van links en buttons](/formulieren/meerdere-stappen/consistente-benaming/)
+- [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam/)

--- a/docs/componenten/button/_wcag-2.4.7.md
+++ b/docs/componenten/button/_wcag-2.4.7.md
@@ -2,7 +2,7 @@
 
 Wanneer een button de toetsenbordfocus krijgt is de focus zichtbaar.
 
-Verberg de standaard browserfocusstijl nooit met `outline:none` zonder er een goede focusstijl voor in de plaats te zetten die rekening houdt met goede zichtbaarheid. Maak de focusrand ten minste 2 pixels dik, met een contrast van minimaal 3:1, zie [WACG-succescriterium 2.4.13 Focusweergave](/wcag/2.4.13).
+Verberg de standaard browserfocusstijl nooit met `outline:none` zonder er een goede focusstijl voor in de plaats te zetten die rekening houdt met goede zichtbaarheid. Maak de focusrand ten minste 2 pixels dik, met een contrast van minimaal 3:1, zie [WCAG-succescriterium 2.4.13 Focusweergave](/wcag/2.4.13).
 
 NL Design System richtlijnen:
 

--- a/docs/componenten/button/_wcag-2.4.7.md
+++ b/docs/componenten/button/_wcag-2.4.7.md
@@ -7,3 +7,5 @@ Verberg de standaard browserfocusstijl nooit met `outline:none` zonder er een go
 NL Design System richtlijnen:
 
 - [Maak toetsenbord focus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar/)
+- [Let op voorkeursinstellingen voor kleur](/richtlijnen/stijl/kleuren/voorkeuren)
+- [Zorg voor voldoende kleurcontrast voor niet-tekstuele content](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/componenten/button/_wcag-2.5.3.md
+++ b/docs/componenten/button/_wcag-2.5.3.md
@@ -8,7 +8,7 @@ Dit is het eenvoudigst te realiseren door een `button`-element te gebruiken met 
 <button>Ga naar stap 2</button>
 ```
 
-Pas op met het gebruik van `aria-label` om een naam te geven aan een button. Een `aria-label` overschrijft de tekstinhoud van een button. Zodoende kan een button een toegankelijke naam krijgen die anders is dan de zichtbare naam, waardoor mensen die hulpsoftware moeilijkheden kunnen krijgen met het bedienen van de button. Als je echt een `aria-label` nodig hebt, zorg dan dat de waarde van het `aria-label` begint met de exacte tekst die zichtbaar is in de button.
+Pas op met het gebruik van `aria-label` om een naam te geven aan een button. Een `aria-label` overschrijft de tekstinhoud van een button. Zodoende kan een button een toegankelijke naam krijgen die anders is dan de zichtbare naam, waardoor mensen die hulpsoftware gebruiken moeilijkheden kunnen krijgen met het bedienen van de button. Als je echt een `aria-label` nodig hebt, zorg dan dat de waarde van het `aria-label` begint met de exacte tekst die zichtbaar is in de button.
 
 NL Design System richtlijnen:
 

--- a/docs/componenten/button/_wcag-2.5.5.md
+++ b/docs/componenten/button/_wcag-2.5.5.md
@@ -5,3 +5,4 @@ Zorg ervoor dat de button een minimale grootte heeft van 44 bij 44 pixels. Defin
 NL Design System richtlijnen:
 
 - [Maak aanklikbare formuliervelden groot genoeg](/richtlijnen/formulieren/visueel-ontwerp/invoerveld-goed-aanklikbaar/)
+- [Reserveer ruimte tussen interactieve elementen](/richtlijnen/stijl/ruimte/interactieve-elementen)

--- a/docs/componenten/button/_wcag-3.2.4.md
+++ b/docs/componenten/button/_wcag-3.2.4.md
@@ -1,3 +1,7 @@
 <!-- @license CC0-1.0 -->
 
 Buttons met gelijke functies hebben hetzelfde uiterlijk en hetzelfde label.
+
+NL Design System richtlijnen:
+
+- [Respecteer conventies](/richtlijnen/stijl/iconen/respecteer-conventies)


### PR DESCRIPTION
Gerelateerd: https://github.com/nl-design-system/documentatie/issues/1375

Preview: https://documentatie-git-docs-linkfix-button-co-b33ac9-nl-design-system.vercel.app/button

Twee links klopten niet meer. Aantal links toevoegen nu Rian de stijlrichtlijnen opnieuw heeft ingedeeld.

