### PR TITLE
docs: improve communitybijeenkomst with discription

### DIFF
--- a/docs/community/events/community-bijeenkomst-2.mdx
+++ b/docs/community/events/community-bijeenkomst-2.mdx
@@ -10,7 +10,14 @@ import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
 
 # Communitybijeenkomst
 
-Kom je ook naar de NL Design System communitybijeenkomst op 18 oktober 2024?
+Volgende week vrijdag 18 oktober is de 2e communitybijeenkomst van NL Design System, ben jij er ook?
+NL Design System bestaat uit een groep enthousiaste Designers, Developers, Accessibility specialisten, Product Owners en Design System liefhebbers die voornamelijk online samenwerken.
+
+Deze Communitybijeenkomst is dé kans om elkaar te ontmoeten, kennis uit te wisselen en samenwerking te vieren onder het genot van een drankje en een hapje.
+
+- 📆 **Wanneer**: 18 oktober van 16:00 uur tot 18:30 uur.
+- 🌍 **Waar**: [Bar Danel](https://danel-utrecht.nl), direct naast Utrecht Centraal.
+- 🫵 **Voor wie?**: Iedereen die met ons samenwerkt én alle nieuwe mensen die graag mee willen doen met de NL Design System Community.
 
 <NewsletterSignUp
   listId="w6sbgdln0j"


### PR DESCRIPTION
Nu we het linkje steeds delen in de Teams chat tijdens de Design Systems week is het goed om de pagina wat meer context te geven als je er later op terecht komt.

Zowel Rian als Savi (van Frameless) merkten dit op.