### PR TITLE
fix: Gebroken link en kromme zin bij de Opmekingen-include van de richtlijnen.

### DIFF
--- a/docs/richtlijnen/_footer_info.md
+++ b/docs/richtlijnen/_footer_info.md
@@ -4,4 +4,5 @@
 
 Deze richtlijnen worden onderhouden door het NL Design System en zijn op dit moment in _beta_.
 
-We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen? [Deel je mening op GitHub](https://github.com/nl-design-system/documentatie/discussions/473) met je suggesties.
+We willen graag van de community horen of ze werkbaar en nuttig zijn. Heb je vragen, aanvullingen of opmerkingen?
+[Open een issue op GitHub](https://github.com/nl-design-system/documentatie/issues) en deel je mening.


### PR DESCRIPTION
Gebroken link : “Deel je mening op GitHub met je suggesties” verwijst naar een gesloten discussie en de tekst is krom.
Nieuwe tekst: Open een issue op GitHub en deel je mening.