### PR TITLE
Update design-open-dag.mdx

### DIFF
--- a/docs/community/events/design-open-dag.mdx
+++ b/docs/community/events/design-open-dag.mdx
@@ -49,7 +49,7 @@ Dit is de voorlopige planning in 2024:
 - vrijdag 30 augustus (Utrecht)
 - vrijdag 20 september (Utrecht)
 - vrijdag 25 oktober (Utrecht)
-- vrijdag 22 november
+- vrijdag 22 november (Utrecht)
 - vrijdag 20 december
 
 ## Aanmelden


### PR DESCRIPTION
Deze PR zorgt ervoor dat duidelijk wordt dat de Design Open Dag van 22 november in Utecht is.