### PR TITLE
Add Design Systems Week 2024 videos

### DIFF
--- a/docs/community/events/design-systems-week-2024/english/index.mdx
+++ b/docs/community/events/design-systems-week-2024/english/index.mdx
@@ -10,41 +10,30 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 ---
 
 import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 <div lang="en">
 
 # Design Systems Week 2024
 
 <Paragraph lead>
-  From 14 to 17 October 2024, NL Design System organises the 4th edition of Design Systems Week. Join us for short talks
-  about the **how** and **why** of design systems, from managing design systems to user research and accessibility. This
-  year there will be talks both in Dutch and English. Will you join us?
+  From 14 to 17 October 2024, NL Design System organised the 4th edition of Design Systems Week. There were short talks
+  about the **how** and **why** of design systems, from managing design systems to user research and accessibility. In
+  2024, we had talks both in Dutch and English.
 </Paragraph>
-
-<Paragraph>All talks are online and free to attend. They are about 30 minutes each, including Q&A.</Paragraph>
 
 <ActionGroup>
   <DocusaurusLink
-    href="/events/design-systems-week/sign-up"
+    href="/events/design-systems-week-2024/en/program"
     className="utrecht-button-link utrecht-button-link--primary-action"
   >
-    {"Sign up"}
+    {"Watch the videos"}
     <IconChevronRight />
   </DocusaurusLink>
-  <DocusaurusLink
-    href="/events/design-systems-week-2024/en/program"
-    className="utrecht-button-link utrecht-button-link--secondary-action"
-  >
-    {"View the program"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Add to your calendar"}
-    <IconCalendarPlus />
-  </ButtonLink>
 </ActionGroup>
+
+---
 
 ## Organisation
 

--- a/docs/community/events/design-systems-week-2024/english/program.mdx
+++ b/docs/community/events/design-systems-week-2024/english/program.mdx
@@ -49,7 +49,7 @@ Amy will share plain-language accessibility tests the USWDS team has created for
 
 </DSWSession>
 
-<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} organisation="Chromatic" lang="en" headingLevel={2}>
+<DSWSession title="Testing UI" speakers={[speakers.GertHengeveld]} lang="en" headingLevel={2}  session={sessions.find((session)=> session.uuid === 'C0639355-E372-422F-8EC9-B069C08CDEEA')}>
 
 <Paragraph>
   Building a Design System is exciting. But once your system is out there being used to power production applications,
@@ -60,7 +60,7 @@ Amy will share plain-language accessibility tests the USWDS team has created for
 
 </DSWSession>
 
-<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en" headingLevel={2} session={sessions.find((session)=> session.uuid === 'C0639355-E372-422F-8EC9-B069C08CDEEA')}>
+<DSWSession title="Design Systems: Choose your own adventure" speakers={[speakers.GeriReid]} organisation="Just Eat Takeaway" lang="en" headingLevel={2} session={sessions.find((session)=> session.uuid === '3A80C3A1-4657-42F8-908D-F9B7565CAF69')}>
 
 Join Geri, a seasoned design systems explorer with 8 years of adventures under her belt, as she navigates the uncharted territories of accessibility in a major product org. With no playbook in hand, Geri’s quest is one we can all relate to: figuring it out as we go along.
 

--- a/docs/community/events/design-systems-week-2024/english/program.mdx
+++ b/docs/community/events/design-systems-week-2024/english/program.mdx
@@ -9,9 +9,7 @@ slug: /events/design-systems-week-2024/en/program
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24-en.png
 ---
 
-import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 import DSWSession from "../../../../../src/components/DSWSession";
 import sessions from "../sessions.json";
 import speakers from "../speakers.json";
@@ -21,27 +19,9 @@ import speakers from "../speakers.json";
 # Program Design Systems Week 2024
 
 <Paragraph lead>
-  Design Systems Week features a number of short talks about the how and why of design systems. All online. This year,
-  we'll cover subjects like managing design systems, integrating accessibility, user research and code.
+  Design Systems Week featured a number of short talks about the how and why of design systems. All online. In 2024,
+  we've covered subjects like managing design systems, integrating accessibility, user research and code.
 </Paragraph>
-
-- Some of the talks are in Dutch, others are in English. This page lists the talks that are in English.
-- All sessions can be joined online for free.
-- Each talk will take about 30 minutes, including time for questions.
-
-<ActionGroup>
-  <DocusaurusLink
-    href="/events/design-systems-week/sign-up"
-    className="utrecht-button-link utrecht-button-link--primary-action"
-  >
-    {"Sign up"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Add to your calendar"}
-    <IconCalendarPlus />
-  </ButtonLink>
-</ActionGroup>
 
 <DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} lang="en" organisation="US Web Design System" headingLevel={2} session={sessions.find((session)=> session.uuid === 'FE871D75-D5C2-4842-A100-71A8A7069FAD')}>
 

--- a/docs/community/events/design-systems-week-2024/english/timetable.mdx
+++ b/docs/community/events/design-systems-week-2024/english/timetable.mdx
@@ -8,14 +8,7 @@ pagination_label: Timetable
 slug: /events/design-systems-week-2024/en/timetable
 ---
 
-import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Link,
-  Paragraph,
-} from "@utrecht/component-library-react/dist/css-module";
+import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 import { SessionTable } from "../../../../../src/components/SessionTable";
 
 <div lang="en">
@@ -23,29 +16,13 @@ import { SessionTable } from "../../../../../src/components/SessionTable";
 # Timetable Design Systems Week 2024
 
 <Paragraph lead>
-  From 2 to 5 October NL Design System organises the third edition of Design Systems Week. Speakers from various
-  organisations will join us for short talks about the how and why of design systems. This year there will be talks both
-  in Dutch and English. For convenience we also have a{" "}
-  <Link href="/events/design-systems-week-2024/en/program">program of all talks that will be in English</Link>.
+  From 2 to 5 October 2024 NL Design System organised the fourth edition of Design Systems Week. Speakers from various
+  organisations joined us for short talks about the how and why of design systems. In 2024, there were talks both in
+  Dutch and English. For convenience, you can view a{" "}
+  <Link href="/events/design-systems-week-2024/en/program">program of all talks that were in English</Link>.
 </Paragraph>
 
-All sessions can be joined online for free. You will receive a link after sign-up. This link is valid for all talks during the week. Each talk will take about 30 minutes, including time for questions.
-
-These are all timeslots with talks in English <a href="/events/design-systems-week-2024/tijdschema" hrefLang="nl-NL">the Dutch timetable</a> shows the complete Design Systems Week 2024 timetable.
-
-<ActionGroup>
-  <DocusaurusLink
-    href="/events/design-systems-week/sign-up"
-    className="utrecht-button-link utrecht-button-link--primary-action"
-  >
-    {"Sign up"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Add to your calendar"}
-    <IconCalendarPlus />
-  </ButtonLink>
-</ActionGroup>
+This page has timeslots with talks in English, while <a href="/events/design-systems-week-2024/tijdschema" hrefLang="nl-NL">the Dutch timetable</a> shows the complete Design Systems Week 2024 timetable.
 
 ## Monday 14 October
 

--- a/docs/community/events/design-systems-week-2024/index.mdx
+++ b/docs/community/events/design-systems-week-2024/index.mdx
@@ -10,40 +10,24 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 ---
 
 import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 # Design Systems Week 2024
 
 <Paragraph lead>
-  NL Design System organiseert dit jaar voor de 4e keer de Design Systems Week. Van **14 tot en met 17 oktober** zijn er
-  dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems** te volgen.
-</Paragraph>
-
-<Paragraph>
-  Dus werk jij aan digitale diensten bij de overheid? Meld je dan aan en we houden je op de hoogte van alle sessies.
-  Alle sessies zijn gratis (online) bij te wonen en duren ongeveer 30 minuten.
+  NL Design System organiseerde in 2024 voor de 4e keer de Design Systems Week. Van **14 tot en met 17 oktober** waren
+  er dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems** te volgen.
 </Paragraph>
 
 <ActionGroup>
   <DocusaurusLink
-    href="/events/design-systems-week/aanmelden"
+    href="/events/design-systems-week-2024/programma"
     className="utrecht-button-link utrecht-button-link--primary-action"
   >
-    {"Meld je aan"}
+    {"Bekijk de video's"}
     <IconChevronRight />
   </DocusaurusLink>
-  <DocusaurusLink
-    href="/events/design-systems-week-2024/programma"
-    className="utrecht-button-link utrecht-button-link--secondary-action"
-  >
-    {"Bekijk het programma"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Zet in je agenda"}
-    <IconCalendarPlus />
-  </ButtonLink>
 </ActionGroup>
 
 ---

--- a/docs/community/events/design-systems-week-2024/programma.mdx
+++ b/docs/community/events/design-systems-week-2024/programma.mdx
@@ -9,14 +9,7 @@ slug: /events/design-systems-week-2024/programma
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24.png
 ---
 
-import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Link,
-  Paragraph,
-} from "@utrecht/component-library-react/dist/css-module";
+import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 import sessions from "./sessions.json";
 import speakers from "./speakers.json";
 import DSWSession from "../../../../src/components/DSWSession";
@@ -24,29 +17,10 @@ import DSWSession from "../../../../src/components/DSWSession";
 # Programma Design Systems Week 2024
 
 <Paragraph lead>
-  Tijdens Design Systems Week kun je 4 dagen lang meerdere korte talks per dag volgen over het hoe en waarom van design
+  Tijdens Design Systems Week kon je 4 dagen lang meerdere korte talks per dag volgen over het hoe en waarom van design
   systems. Online. Dit jaar bijvoorbeeld over het managen van design systems, toegankelijkheid, gebruikersonderzoek en
   code.
 </Paragraph>
-
-- Alle sessies zijn gratis online bij te wonen.
-- Sessies duren ongeveer 30 minuten, inclusief tijd voor vragen.
-- Bij Nederlandstalige sessies is een schrijftolk aanwezig.
-- Sommige sessies worden in het Engels gegeven, dit wordt per sessie aangegeven.
-
-<ActionGroup>
-  <DocusaurusLink
-    href="/events/design-systems-week/aanmelden"
-    className="utrecht-button-link utrecht-button-link--primary-action"
-  >
-    {"Meld je aan"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Zet in je agenda"}
-    <IconCalendarPlus />
-  </ButtonLink>
-</ActionGroup>
 
 <DSWSession title="Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams" speakers={[speakers.AmyCole]} organisation="US Web Design System" headingLevel={2} session={sessions.find((session)=> session.uuid === 'FE871D75-D5C2-4842-A100-71A8A7069FAD')}>
 
@@ -277,7 +251,7 @@ Internationalisatie is meer dan alleen het vertalen van content op je website in
 
 </DSWSession>
 
-<DSWSession title="Live coden met Robbert" speakers={[speakers.RobbertBroersma]} organisation="NL Design System" headingLevel={2} captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" session={sessions.find((session)=> session.uuid === 'A980E371-ED8E-4EA4-A22C-CA1A212150F7')}>
+<DSWSession title="Aan de slag met NL Design System" speakers={[speakers.RobbertBroersma]} organisation="NL Design System" headingLevel={2} captioned captionLink="https://text-on-tap.live/index.html#e=k2TzZqdqZZ" session={sessions.find((session)=> session.uuid === 'A980E371-ED8E-4EA4-A22C-CA1A212150F7')}>
 
 <Paragraph>
   Bryan de Jong liet het al even zien in de Heartbeat, er zijn bij NL Design System al een heleboel componenten

--- a/docs/community/events/design-systems-week-2024/sessions.json
+++ b/docs/community/events/design-systems-week-2024/sessions.json
@@ -11,7 +11,8 @@
     "subject": "Testing UI",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#testing-ui",
     "icalLink": "/dsweek-2024/gert-hengeveld.ics",
-    "language": { "abbr": "EN", "description": "English" }
+    "language": { "abbr": "EN", "description": "English" },
+    "videoId": "0_Xq74LkMY4"
   },
   {
     "uuid": "3A80C3A1-4657-42F8-908D-F9B7565CAF69",
@@ -25,6 +26,7 @@
     "subject": "Design Systems: Choose your own adventure",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#design-systems:-choose-your-own-adventure",
     "icalLink": "/dsweek-2024/geri-reid.ics",
+    "videoId": "lAy-dOhw2bU",
     "language": { "abbr": "EN", "description": "English" }
   },
   {
@@ -38,6 +40,7 @@
     ],
     "subject": "Werken op schaal",
     "icalLink": "/dsweek-2024/thijs-louisse.ics",
+    "videoId": "5yThQMZ4cs0",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#werken-op-schaal",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
@@ -52,6 +55,7 @@
     ],
     "subject": "De voordelen van open werken met design systems bij de overheid",
     "icalLink": "/dsweek-2024/mike-gifford.ics",
+    "videoId": "lxLmK2NOFd4",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#de-voordelen-van-open-werken-met-design-systems-bij-de-overheid",
     "language": { "abbr": "EN", "description": "English" }
   },
@@ -67,6 +71,7 @@
     "subject": "Tips voor toegankelijke diensten",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#tips-voor-toegankelijke-dienstverlening",
     "icalLink": "/dsweek-2024/kim-denie.ics",
+    "videoId": "0k0C0pRFaP8",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -93,6 +98,7 @@
     "subject": "Heartbeat: Design Systems Week editie",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#heartbeat:-de-design-systems-week-lightning-talks-editie",
     "icalLink": "/dsweek-2024/heartbeat.ics",
+    "videoId": "jMMxxZxCB4o",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -106,6 +112,7 @@
     ],
     "subject": "Je eerste gebruikersonderzoek doen, hoe doe je dat?",
     "icalLink": "/dsweek-2024/jeroen-du-chatinier.ics",
+    "videoId": "m-qn8NQ1xh0",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#je-eerste-gebruikersonderzoek-doen,-hoe-doe-je-dat?",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
@@ -143,6 +150,7 @@
     "subject": "Vlaams Design System: 10 jaar lessons learned",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#vlaams-design-system:-10-jaar-lessons-learned",
     "icalLink": "/dsweek-2024/vlaanderen.ics",
+    "videoId": "RN7BDhoU8Dc",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -157,6 +165,7 @@
     "subject": "Unmeasurable Accessibility: Beyond conformance",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#unmeasurable-accessibility:-beyond-conformance",
     "icalLink": "/dsweek-2024/darice-de-cuba.ics",
+    "videoId": "LckUy3t7mUg",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -171,6 +180,7 @@
     "subject": "Wat je allemaal niet weet over je CSS",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#wat-je-allemaal-niet-weet-over-je-css",
     "icalLink": "/dsweek-2024/bart-veneman.ics",
+    "videoId": "ySJjj9CISD4",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -185,6 +195,7 @@
     "subject": "Using USWDS Accessibility Tests to Develop Accessibility Skills Across Government Teams",
     "icalLink": "/dsweek-2024/amy-cole.ics",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#using-uswds-accessibility-tests-to-develop-accessibility-skills-across-government-teams",
+    "videoId": "WYTKw_l3IXE",
     "language": { "abbr": "EN", "description": "English" }
   },
   {
@@ -196,8 +207,9 @@
         "organisation": "NL Design System"
       }
     ],
-    "subject": "Live coden",
+    "subject": "Aan de slag met NL Design System",
     "icalLink": "/dsweek-2024/robbert-broersma.ics",
+    "videoId": "ZozbnQpcBu8",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#live-coden-met-robbert",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
@@ -213,6 +225,7 @@
     "subject": "CSS for internationalisation",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#css-for-internationalisation",
     "icalLink": "/dsweek-2024/chen-hui-jing.ics",
+    "videoId": "wpypfDnrw78",
     "language": { "abbr": "EN", "description": "Engels" }
   },
   {
@@ -227,6 +240,7 @@
     "subject": "Inclusief gebruikersonderzoek bij de Belastingdienst, een blik achter de schermen",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#inclusief-gebruikersonderzoek-bij-de-belastingdienst,-een-blik-achter-de-schermen",
     "icalLink": "/dsweek-2024/lotte-bijl.ics",
+    "videoId": "GMmDJOMBUx0",
     "language": { "abbr": "NL", "description": "Nederlands" }
   },
   {
@@ -241,6 +255,7 @@
     "subject": "Common direction, boring magic",
     "sessionLink": "https://nldesignsystem.nl/events/design-systems-week-2024/programma#common-direction,-boring-magic",
     "icalLink": "/dsweek-2024/steve-messer.ics",
+    "videoId": "1xhZnqF6dc8",
     "language": { "abbr": "EN", "description": "Engels" }
   }
 ]

--- a/docs/community/events/design-systems-week-2024/tijdschema-per-dag.mdx
+++ b/docs/community/events/design-systems-week-2024/tijdschema-per-dag.mdx
@@ -8,34 +8,18 @@ sidebar_position: 3
 slug: /events/design-systems-week-2024/tijdschema
 ---
 
-import DocusaurusLink from "@docusaurus/Link";
-import { IconCalendarPlus, IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup, ButtonLink, Paragraph } from "@utrecht/component-library-react";
+import { Paragraph } from "@utrecht/component-library-react";
 import sessions from "./sessions.json";
 import { SessionTable } from "../../../../src/components/SessionTable";
 
 # Tijdschema Design Systems Week 2024
 
 <Paragraph lead>
-  NL Design System organiseert dit jaar voor de 4e keer de Design Systems Week. Van **14 tot 17 oktober** zijn er
+  NL Design System organiseerde in 2024 voor de 4e keer de Design Systems Week. Van **14 tot 17 oktober** waren er
   dagelijks meerdere korte sessies van diverse organisaties over het **hoe en waarom van design systems**.
 </Paragraph>
 
-Dit jaar hebben we nationale én internationale sprekers. We richten ons op verschillende thema's: het managen van design systems, technische deep dives, toegankelijkheid en gebruikersvriendelijkheid.
-
-<ActionGroup>
-  <DocusaurusLink
-    href="/events/design-systems-week/aanmelden"
-    className="utrecht-button-link utrecht-button-link--primary-action"
-  >
-    {"Meld je aan"}
-    <IconChevronRight />
-  </DocusaurusLink>
-  <ButtonLink href="/dsweek-2024/dsweek-2024.ics" appearance="secondary-action-button">
-    {"Zet in je agenda"}
-    <IconCalendarPlus />
-  </ButtonLink>
-</ActionGroup>
+Er waren nationale én internationale sprekers. We richtten ons op verschillende thema's: het managen van design systems, technische deep dives, toegankelijkheid en gebruikersvriendelijkheid.
 
 ## Maandag 14 oktober
 

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -7,6 +7,9 @@ import style from './DSWSession.module.css';
 import { Session } from './SessionTable';
 import { VideoPlayer } from './VideoPlayer';
 
+const date = new Date();
+const dateNow = date.toISOString();
+
 interface DSWSessionProps {
   headingLevel: 2 | 3 | 4 | 5 | 6;
   title: string;
@@ -49,15 +52,20 @@ export const DSWSession = ({
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
       {title}
     </Heading>
-    {videoId ? (
-      <VideoPlayer videoId={videoId} width="100%" height="100%" className={clsx(style['dsw-session__video'])} />
+    {session.videoId || videoId ? (
+      <VideoPlayer
+        videoId={session.videoId || videoId}
+        width="100%"
+        height="100%"
+        className={clsx(style['dsw-session__video'])}
+      />
     ) : (
       <Paragraph className={clsx(style['dsw-session__subtitle'])} lead>
         {speakers.map((speaker) => speaker.name).join(' & ')}
         {organisation ? ', ' + organisation : ''}
       </Paragraph>
     )}
-    {session && session.isoDateTime && session.icalLink && !videoId ? (
+    {session && session.isoDateTime && session.isoDateTime > dateNow && session.icalLink && !videoId ? (
       <Paragraph>
         <ButtonLink
           href={session.icalLink}

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -52,9 +52,9 @@ export const DSWSession = ({
     <Heading level={headingLevel} className={clsx(style['dsw-session__title'])}>
       {title}
     </Heading>
-    {session.videoId || videoId ? (
+    {videoId || session?.videoId ? (
       <VideoPlayer
-        videoId={session.videoId || videoId}
+        videoId={videoId ? videoId : session?.videoId}
         width="100%"
         height="100%"
         className={clsx(style['dsw-session__video'])}


### PR DESCRIPTION
Updates aan content:

- DSW 2024 tekst herschreven naar de verleden tijd
- call to actions aangepast naar dat je video's kunt kijken (in de toekomst evt nog uitbreiden met generieke DSW nieuwsbrief aanmelding oid)
- Robbert's sessienaam aangepast naar “Aan de slag met NL Design System”
- in Robberts omschrijving de `<Link>` aangepast naar `<a>` zodat de Prettier-Markdown-combo de link niet per ongeluk in een `<p>` wrapt

Updates aan data:

- heb videoId's in de `sessions.json` gezet
- Geri's UUID goed gezet (woops)

Updates aan componenten:

- datum + icallink weergeven bij sessie in `DSWSession` doen we nu alleen als die in de toekomst ligt 
- videoweergave bij een sessie werkt nu in `DSWSession` met videoId op het component zelf, of met videoId in de `sessions.json` (voor backwards compat met 2022, 2023 sites)