### PR TITLE
chore: packagemanager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    ignore:
+      - dependency-name: "@types/node"
+        update-type:
+          - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "private": true,
   "license": "EUPL-1.2",
-  "packageManager": "pnpm@9.12.1",
+  "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228",
   "engines": {
     "node": "^20",
     "pnpm": "^9"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "EUPL-1.2",
   "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228",
   "engines": {
+    "//": "Update @types/node when updating the node version here",
     "node": "^20",
     "pnpm": "^9"
   },
@@ -93,7 +94,7 @@
     "@nl-design-system/component-progress": "1.0.1-alpha.70",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.47.1",
-    "@types/node": "22.5.5",
+    "@types/node": "20.14.14",
     "@typescript-eslint/eslint-plugin": "8.5.0",
     "@typescript-eslint/parser": "8.5.0",
     "@utrecht/component-library-css": "4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: 1.47.1
         version: 1.47.1
       '@types/node':
-        specifier: 22.5.5
-        version: 22.5.5
+        specifier: 20.14.14
+        version: 20.14.14
       '@typescript-eslint/eslint-plugin':
         specifier: 8.5.0
         version: 8.5.0(@typescript-eslint/parser@8.5.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
@@ -197,7 +197,7 @@ importers:
         version: 1.56.0(react@18.3.1)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.5.5)(typescript@5.6.2)
+        version: 10.9.2(@types/node@20.14.14)(typescript@5.6.2)
       typescript:
         specifier: 5.6.2
         version: 5.6.2
@@ -16399,14 +16399,14 @@ snapshots:
     dependencies:
       typescript: 5.6.2
 
-  ts-node@10.9.2(@types/node@22.5.5)(typescript@5.6.2):
+  ts-node@10.9.2(@types/node@20.14.14)(typescript@5.6.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.5.5
+      '@types/node': 20.14.14
       acorn: 8.11.2
       acorn-walk: 8.3.1
       arg: 4.1.3


### PR DESCRIPTION
- update package.json#packageManager to include hash
- align @types/node with the node version in the repo and prevent Dependabot from updating @types/node to a new major version