### PR TITLE
feat: add anchors for implementation of community components

### DIFF
--- a/src/components/CardGroup.tsx
+++ b/src/components/CardGroup.tsx
@@ -34,7 +34,14 @@ interface CardProps {
   component?: 'article' | 'section' | 'div';
 }
 
-export const Card = ({ href, appearance, className, component = 'div', children }: PropsWithChildren<CardProps>) => {
+export const Card = ({
+  href,
+  appearance,
+  className,
+  component = 'div',
+  children,
+  ...restProps
+}: PropsWithChildren<CardProps>) => {
   const Wrapper = (props: PropsWithChildren<HTMLAttributes<HTMLElement>>) => {
     if (component === 'article') return <article {...props} />;
     if (component === 'section') return <section {...props} />;
@@ -42,7 +49,10 @@ export const Card = ({ href, appearance, className, component = 'div', children 
   };
 
   const card = (
-    <Wrapper className={clsx(style['cardgroup__card'], style[`cardgroup__card--${appearance}`], className)}>
+    <Wrapper
+      className={clsx(style['cardgroup__card'], style[`cardgroup__card--${appearance}`], className)}
+      {...restProps}
+    >
       {children}
     </Wrapper>
   );

--- a/src/components/ComponentPage.tsx
+++ b/src/components/ComponentPage.tsx
@@ -124,8 +124,11 @@ export const Implementations = ({ component, headingLevel }: ComponentPageSectio
             ({ name, value }) => urlMap.has(name) && URL.canParse(value) && new URL(value).protocol === 'https:',
           );
 
+          const slugify = (arg: string): string => arg.replace(/[^a-z0-9-]+/g, '');
+          const slug = slugify(alias);
+
           return (
-            <Card key={project.title} className={clsx(style['implementation-card'])}>
+            <Card key={project.title} className={clsx(style['implementation-card'])} id={slug}>
               <CardContent>
                 <Heading level={headingLevel}>{project.title}</Heading>
                 <Paragraph>


### PR DESCRIPTION
This allows me to link to the NL Design System website, instead of to the Utrecht Storybook URL. I'm hoping this URL will be more future proof.