### PR TITLE
fix: use 4.5:1 contrast for placeholder color and background

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,6 +57,8 @@
   --navbar-inner-min-height: 64px;
   --utrecht-button-group-inline-gap: 1ch;
   --utrecht-button-icon-gap: 1ch;
+  --docsearch-muted-color: #757575 !important;
+  --docsearch-modal-width: 50em !important;
 }
 
 .utrecht-form-field--checkbox {
@@ -943,4 +945,9 @@ pre {
 /* Temporary fix for accordion spacing */
 .utrecht-accordion__header {
   margin: 0;
+}
+
+.DocSearch-Label {
+  font-size: 0.9em !important;
+  line-height: 1 !important;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,8 +57,6 @@
   --navbar-inner-min-height: 64px;
   --utrecht-button-group-inline-gap: 1ch;
   --utrecht-button-icon-gap: 1ch;
-  --docsearch-muted-color: #757575 !important;
-  --docsearch-modal-width: 50em !important;
 }
 
 .utrecht-form-field--checkbox {
@@ -947,7 +945,11 @@ pre {
   margin: 0;
 }
 
-.DocSearch-Label {
-  font-size: 0.9em !important;
-  line-height: 1 !important;
+.DocSearch {
+  --docsearch-muted-color: #757575;
+  --docsearch-modal-width: 50em;
+}
+.DocSearch .DocSearch-Label {
+  font-size: 0.9em;
+  line-height: 1;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -953,3 +953,6 @@ pre {
   font-size: 0.9em;
   line-height: 1;
 }
+.docs-doc-page ul {
+  margin: auto 0;
+}


### PR DESCRIPTION
fixes #412 

extra's: vergroot ook de font-size van de keyboard short cut en de breedte van de modal.