### PR TITLE
feat: use dialog element for mobile nav

### DIFF
--- a/src/theme/Navbar/Layout/index.tsx
+++ b/src/theme/Navbar/Layout/index.tsx
@@ -4,11 +4,7 @@ import { useHideableNavbar, useNavbarMobileSidebar } from '@docusaurus/theme-com
 import type { Props } from '@theme/Navbar/Layout';
 import NavbarMobileSidebar from '@theme/Navbar/MobileSidebar';
 import clsx from 'clsx';
-import React, { type ComponentProps } from 'react';
-
-function NavbarBackdrop(props: ComponentProps<'div'>) {
-  return <div role="presentation" {...props} className={clsx('navbar-sidebar__backdrop', props.className)} />;
-}
+import React from 'react';
 
 export default function NavbarLayout({ children }: Props): React.Element {
   const {
@@ -32,7 +28,6 @@ export default function NavbarLayout({ children }: Props): React.Element {
       })}
     >
       {children}
-      <NavbarBackdrop onClick={mobileSidebar.toggle} />
       <NavbarMobileSidebar />
     </nav>
   );

--- a/src/theme/Navbar/MobileSidebar/Layout/Layout.module.css
+++ b/src/theme/Navbar/MobileSidebar/Layout/Layout.module.css
@@ -1,3 +1,14 @@
 .navbar-sidebar {
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  bottom: 0;
+  border: 0;
+  height: 100%;
+  max-height: 100%;
   background-color: var(--nlds-mobile-sidebar-background-color);
+  color: white;
+}
+.navbar-sidebar::backdrop {
+  background-color: #0009;
 }

--- a/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -1,13 +1,44 @@
-import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
+import { useNavbarMobileSidebar, useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
 import type { Props } from '@theme/Navbar/MobileSidebar/Layout';
 import clsx from 'clsx';
-import React from 'react';
+import { React, useEffect, useRef } from 'react';
 import styles from './Layout.module.css';
 
 export default function NavbarMobileSidebarLayout({ header, primaryMenu, secondaryMenu }: Props): React.Element {
   const { shown: secondaryMenuShown } = useNavbarSecondaryMenu();
+  const navbarModalDialog = useRef(null);
+  const { shown, toggle } = useNavbarMobileSidebar();
+
+  useEffect(() => {
+    const dialogEl = navbarModalDialog.current;
+
+    if (shown) {
+      dialogEl.showModal();
+    } else {
+      dialogEl.close();
+    }
+  });
+
+  useEffect(() => {
+    const dialogEl = navbarModalDialog.current;
+
+    function toggleOnEscape(e) {
+      if (e.key === 'Escape') {
+        if (shown) {
+          toggle();
+        }
+      }
+    }
+
+    dialogEl.addEventListener('keydown', toggleOnEscape);
+
+    return () => {
+      dialogEl.removeEventListener('keydown', toggleOnEscape);
+    };
+  }, [shown]);
+
   return (
-    <div className={clsx('navbar-sidebar', styles['navbar-sidebar'])}>
+    <dialog className={clsx('navbar-sidebar', styles['navbar-sidebar'])} ref={navbarModalDialog}>
       {header}
       <div
         className={clsx('navbar-sidebar__items', {
@@ -17,6 +48,6 @@ export default function NavbarMobileSidebarLayout({ header, primaryMenu, seconda
         <div className="navbar-sidebar__item menu">{primaryMenu}</div>
         <div className="navbar-sidebar__item menu">{secondaryMenu}</div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Toggle/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 export default function MobileSidebarToggle(): React.Element {
   const { toggle, shown } = useNavbarMobileSidebar();
+
   return (
     <Button
       appearance="subtle-button"


### PR DESCRIPTION
Wat is anders: 

- mobile nav nu niet meer een `div` maar een `dialog`
- om mobile nav te openen gebruiken we nu `showModal()`, via `useEffect` hook om zeker te weten dat er altijd als er een `dialog` is er de juiste methodes aangeroepen worden
- we checken ook op `Escape`: sluiten krijg je gratis van de browser, maar we willen ook de `shown` state bijwerken zodat het bij volgende menu-button-klik ook weer werkt

Known issues: 

- Op pagina's met submenu's zoals Handboek zijn er nog steeds een paar onzichtbare tab stops, die zijn er ook live, dus geen regressie, en zitten in de mobile nav zelf; to be fixed in een andere PR

fixes #413