### PR TITLE
Haal niet-zichtbare menu-items uit DOM en tabvolgorde

### DIFF
--- a/src/theme/Navbar/MobileSidebar/Layout/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Layout/index.tsx
@@ -40,13 +40,12 @@ export default function NavbarMobileSidebarLayout({ header, primaryMenu, seconda
   return (
     <dialog className={clsx('navbar-sidebar', styles['navbar-sidebar'])} ref={navbarModalDialog}>
       {header}
-      <div
-        className={clsx('navbar-sidebar__items', {
-          'navbar-sidebar__items--show-secondary': secondaryMenuShown,
-        })}
-      >
-        <div className="navbar-sidebar__item menu">{primaryMenu}</div>
-        <div className="navbar-sidebar__item menu">{secondaryMenu}</div>
+      <div className={clsx('navbar-sidebar__items')}>
+        {secondaryMenuShown ? (
+          <div className="navbar-sidebar__item menu">{secondaryMenu}</div>
+        ) : (
+          <div className="navbar-sidebar__item menu these-no-need-when">{primaryMenu}</div>
+        )}
       </div>
     </dialog>
   );


### PR DESCRIPTION
Als je de mobiele nav van een pagina met submenu opende, zag je alleen het submenu, maar kon je tabben door hoofdmenu + submenu. Dat is een 2.4.7 probleem. 

De bestaande code zorgde met CSS dat je hoofdmenu en submenu niet tegelijk zag. Met deze PR rendereren we überhaupt alleen hoofdnav of alleen subnav.

fixes #1728