### PR TITLE
docs: WCAG 2.1.2 Geen toetsenbordval toevoegen aan AC componenten Button, Link en Login Link

### DIFF
--- a/.changeset/ac-keybordtrap.md
+++ b/.changeset/ac-keybordtrap.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+WCAG 2.1.2 Geen toetsenbordval toegevoegd aan de acceptatiecriteria voor de componenten Button, Login Link en Link.

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -54,6 +54,7 @@ import Wcag143 from '/docs/componenten/ac/\_wcag-1.4.3.md';
 import Wcag144 from '/docs/componenten/ac/\_wcag-1.4.4.md';
 import Wcag145 from '/docs/componenten/ac/\_wcag-1.4.5.md';
 import Wcag211 from '/docs/componenten/ac/\_wcag-2.1.1.md';
+import Wcag212 from '/docs/wcag/summaries/\_2.1.2-summary.md';
 import Wcag2413 from '/docs/componenten/ac/\_wcag-2.4.13.md';
 import Wcag246 from '/docs/componenten/ac/\_wcag-2.4.6-button.md';
 import Wcag247 from '/docs/componenten/ac/\_wcag-2.4.7.md';
@@ -188,6 +189,12 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.1.1",
       status: "",
       component: <Wcag211 />,
+    },
+    {
+      title: "De functionaliteit van de button veroorzaakt geen toetsenbordval",
+      sc: "2.1.2",
+      status: "",
+      component: <Wcag212 />,
     },
     {
       title:

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -25,6 +25,7 @@ import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
 import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-link.md";
 import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 import Wcag211 from "/docs/componenten/ac/_wcag-2.1.1-link.md";
+import Wcag212 from "/docs/wcag/summaries/_2.1.2-summary.md";
 import Wcag244 from "/docs/wcag/summaries/_2.4.4-summary.md";
 import Wcag247 from "/docs/componenten/ac/_wcag-2.4.7.md";
 import Wcag2413 from "/docs/componenten/ac/_wcag-2.4.13.md";
@@ -152,6 +153,12 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.1.1",
       status: "",
       component: <Wcag211 />,
+    },
+    {
+      title: "De functionaliteit van de Link veroorzaakt geen toetsenbordval",
+      sc: "2.1.2",
+      status: "",
+      component: <Wcag212 />,
     },
     {
       title: "Wanneer de Link de toetsenbordfocus krijgt is de focus zichtbaar",

--- a/docs/componenten/login-link/index.mdx
+++ b/docs/componenten/login-link/index.mdx
@@ -29,6 +29,7 @@ import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
 import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-link.md";
 import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 import Wcag211 from "/docs/componenten/ac/_wcag-2.1.1-link.md";
+import Wcag212 from "/docs/wcag/summaries/_2.1.2-summary.md";
 import Wcag244 from "/docs/wcag/summaries/_2.4.4-summary.md";
 import Wcag247 from "/docs/componenten/ac/_wcag-2.4.7.md";
 import Wcag2413 from "/docs/componenten/ac/_wcag-2.4.13.md";
@@ -157,6 +158,12 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.1.1",
       status: "",
       component: <Wcag211 />,
+    },
+    {
+      title: "De functionaliteit van de Login Link veroorzaakt geen toetsenbordval",
+      sc: "2.1.2",
+      status: "",
+      component: <Wcag212 />,
     },
     {
       title: "Wanneer de Login Link de toetsenbordfocus krijgt is de focus zichtbaar",


### PR DESCRIPTION
Rerelateerd issue: https://github.com/nl-design-system/documentatie/issues/1635

Previews
- [Button](https://documentatie-git-docs-components-adds-k-3bf871-nl-design-system.vercel.app/button)
- [Login Link](https://documentatie-git-docs-components-adds-k-3bf871-nl-design-system.vercel.app/login-link)
- [Link](https://documentatie-git-docs-components-adds-k-3bf871-nl-design-system.vercel.app/link)