### PR TITLE
Docs: Aangeven welke WCAG 2.2 AAA succescriteria we ook aanhouden

### DIFF
--- a/docs/componenten/ac/_ac_intro.md
+++ b/docs/componenten/ac/_ac_intro.md
@@ -1,3 +1,3 @@
 Gebruik jij één van de implementaties van deze component of heb je je eigen component gemaakt? In beide gevallen geldt: met onderstaande acceptatiecriteria kun je nagaan of jouw gebruik van deze component klopt met NL Design System.
 
-Voor de toegankelijkheid houden we de succescriteria van **[WCAG](https://nldesignsystem.nl/wcag) 2.2 A** en **AA** aan. Daarnaast willen we ook voldoen aan de **AAA**-succescriteria [2.4.13 Focusweergave](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5).
+Als je implementatie voldoet aan de acceptatiecriteria voor dit component, kun je er vanuit gaan dat je gebruik van dit component voldoet aan WCAG, niveau A en AA, en voor twee succescriteria aan niveau AAA ([2.4.13 Focusweergave](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5)).

--- a/docs/componenten/ac/_ac_intro.md
+++ b/docs/componenten/ac/_ac_intro.md
@@ -1,0 +1,3 @@
+Gebruik jij één van de implementaties van deze component of heb je je eigen component gemaakt? In beide gevallen geldt: met onderstaande acceptatiecriteria kun je nagaan of jouw gebruik van deze component klopt met NL Design System.
+
+Voor de toegankelijkheid houden we de succescriteria van **[WCAG](https://nldesignsystem.nl/wcag) 2.2 A** en **AA** aan. Daarnaast willen we ook voldoen aan de **AAA**-succescriteria [2.4.13 Content bij hover of focus](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5).

--- a/docs/componenten/ac/_ac_intro.md
+++ b/docs/componenten/ac/_ac_intro.md
@@ -1,3 +1,3 @@
 Gebruik jij één van de implementaties van deze component of heb je je eigen component gemaakt? In beide gevallen geldt: met onderstaande acceptatiecriteria kun je nagaan of jouw gebruik van deze component klopt met NL Design System.
 
-Voor de toegankelijkheid houden we de succescriteria van **[WCAG](https://nldesignsystem.nl/wcag) 2.2 A** en **AA** aan. Daarnaast willen we ook voldoen aan de **AAA**-succescriteria [2.4.13 Content bij hover of focus](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5).
+Voor de toegankelijkheid houden we de succescriteria van **[WCAG](https://nldesignsystem.nl/wcag) 2.2 A** en **AA** aan. Daarnaast willen we ook voldoen aan de **AAA**-succescriteria [2.4.13 Focusweergave](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5).

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -47,6 +47,7 @@ HelpImproveComponent,
 Implementations,
 Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/\_ac_intro.md";
 import Wcag111 from '/docs/componenten/ac/\_wcag-1.1.1-button.md';
 import Wcag1411 from '/docs/componenten/ac/\_wcag-1.4.11-button.md';
 import Wcag1412 from '/docs/componenten/ac/\_wcag-1.4.12.md';
@@ -84,7 +85,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -20,6 +20,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-code-block.md";
 import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
@@ -46,7 +47,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -20,6 +20,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-code.md";
 import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
@@ -48,7 +49,7 @@ Let op: Gebruik de component [Code Block](/code-block) als de code meerdere rege
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -23,6 +23,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-color-sample.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-color-sample.md";
 import Wcag132 from "/docs/componenten/ac/_wcag-1.3.2-color-sample.md";
@@ -51,7 +52,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -48,6 +48,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-data-badge.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-data-badge.md";
 import Wcag141 from "/docs/componenten/ac/_wcag-1.4.1-data-badge.md";
@@ -76,7 +77,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -17,6 +17,7 @@ HelpImproveComponent,
 Implementations,
 Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/\_ac_intro.md";
 import Wcag131 from '/docs/componenten/ac/\_wcag-1.3.1-heading.md';
 import Wcag143 from '/docs/componenten/ac/\_wcag-1.4.3.md';
 import Wcag144 from '/docs/componenten/ac/\_wcag-1.4.4.md';
@@ -44,7 +45,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -18,6 +18,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-link.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
@@ -54,6 +55,8 @@ export const component = componentProgress.find((item) => item.number === issueN
 <Implementations component={component} headingLevel={3} />
 
 ## Acceptatiecriteria
+
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/login-link/index.mdx
+++ b/docs/componenten/login-link/index.mdx
@@ -22,6 +22,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-login-link.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
@@ -58,6 +59,8 @@ export const component = componentProgress.find((item) => item.number === issueN
 <Implementations component={component} headingLevel={3} />
 
 ## Acceptatiecriteria
+
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -21,6 +21,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-mark.md";
 import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
@@ -48,7 +49,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -18,6 +18,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-number-badge.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
@@ -44,7 +45,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -23,7 +23,6 @@ import {
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-paragraph.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag148 from "/docs/wcag/summaries/_1.4.8-summary.md";
 import Wcag1410 from "/docs/wcag/summaries/_1.4.10-summary.md";
 import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
@@ -56,12 +55,6 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "1.3.1",
       status: "",
       component: <Wcag131 />,
-    },
-    {
-      title: "De weergave van de paragraaftekst kan worden aangepast door hulpsoftware",
-      sc: "1.4.8",
-      status: "",
-      component: <Wcag148 />,
     },
     {
       title:

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -20,6 +20,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-paragraph.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
@@ -45,6 +46,8 @@ export const component = componentProgress.find((item) => item.number === issueN
 <Implementations component={component} headingLevel={3} />
 
 ## Acceptatiecriteria
+
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -18,6 +18,7 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
+import AcIntro from "/docs/componenten/ac/_ac_intro.md";
 import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
 import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
@@ -59,7 +60,7 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 ## Acceptatiecriteria
 
-{/* headingLevel is the heading of the items, the list is hardcoded as an H3 for now. */}
+<AcIntro />
 
 <CriteriaList
   headingLevel={4}

--- a/docs/richtlijnen/README.mdx
+++ b/docs/richtlijnen/README.mdx
@@ -26,9 +26,9 @@ Het NL Design System geeft richtlijnen voor het ontwikkelen van digitale dienste
 
 ### Toegankelijkheid
 
-De richtlijnen zijn gebaseerd op de Web Content Accessibility Guidelines, versie 2.2 niveau AA (WCAG 2.2 AA).
+De richtlijnen zijn gebaseerd op de [<span>Web Content Accessibility Guidelines</span>](https://www.w3.org/Translations/WCAG22-nl/), versie 2.2 niveau AA (WCAG 2.2 AA).
 
-Bij enkele richtlijnen is niveau AAA aangehouden, om een betere gebruikerservaring te garanderen. Bijvoorbeeld voor de minimale grootte van het aanklikbare gedeelte van links en formulierelementen.
+Bij enkele richtlijnen is WCAG-niveau AAA aangehouden: [2.4.13 Content bij hover of focus](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5). Dit zijn goede criteria om een betere gebruikerservaring te garanderen voor de zichtbaarheid en de minimale grootte van het aanklikbare gedeelte van links en formulierelementen.
 
 ### Gebruikersvriendelijkheid
 

--- a/docs/richtlijnen/README.mdx
+++ b/docs/richtlijnen/README.mdx
@@ -28,7 +28,7 @@ Het NL Design System geeft richtlijnen voor het ontwikkelen van digitale dienste
 
 De richtlijnen zijn gebaseerd op de [<span>Web Content Accessibility Guidelines</span>](https://www.w3.org/Translations/WCAG22-nl/), versie 2.2 niveau AA (WCAG 2.2 AA).
 
-Bij enkele richtlijnen is WCAG-niveau AAA aangehouden: [2.4.13 Content bij hover of focus](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5). Dit zijn goede criteria om een betere gebruikerservaring te garanderen voor de zichtbaarheid en de minimale grootte van het aanklikbare gedeelte van links en formulierelementen.
+Bij enkele richtlijnen is WCAG-niveau AAA aangehouden: [2.4.13 Focusweergave](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5). Dit zijn goede criteria om een betere gebruikerservaring te garanderen voor de zichtbaarheid en de minimale grootte van het aanklikbare gedeelte van links en formulierelementen.
 
 ### Gebruikersvriendelijkheid
 

--- a/docs/richtlijnen/stijl/colour/3-purpose/_guideline.md
+++ b/docs/richtlijnen/stijl/colour/3-purpose/_guideline.md
@@ -19,5 +19,4 @@ Uit een onderzoek van Gemeente Utrecht blijkt dat de kleur rood mensen die laagg
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.4.1)
 - [1.4.1 Gebruik van kleur](/wcag/1.4.1)
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
-- [1.4.8 Visuele presentatie](/wcag/1.4.3)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)

--- a/docs/richtlijnen/stijl/colour/4-dont-trust/_guideline.md
+++ b/docs/richtlijnen/stijl/colour/4-dont-trust/_guideline.md
@@ -19,5 +19,4 @@ Er zijn verschillende vormen van kleurenblindheid. Je kunt testen hoe jouw ontwe
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.4.1)
 - [1.4.1 Gebruik van kleur](/wcag/1.4.1)
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
-- [1.4.8 Visuele presentatie](/wcag/1.4.3)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)

--- a/docs/richtlijnen/stijl/colour/5-perception/_guideline.md
+++ b/docs/richtlijnen/stijl/colour/5-perception/_guideline.md
@@ -45,5 +45,4 @@ Daarom is het belangrijk dat informatie in eerste instantie duidelijk wordt door
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.4.1)
 - [1.4.1 Gebruik van kleur](/wcag/1.4.1)
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
-- [1.4.8 Visuele presentatie](/wcag/1.4.3)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)

--- a/docs/richtlijnen/stijl/colour/6-settings/_guideline.md
+++ b/docs/richtlijnen/stijl/colour/6-settings/_guideline.md
@@ -23,5 +23,4 @@ Door de media query [`prefers-contrast`](https://developer.mozilla.org/en-US/doc
 - [1.3.3 Zintuiglijke eigenschappen](/wcag/1.4.1)
 - [1.4.1 Gebruik van kleur](/wcag/1.4.1)
 - [1.4.3 Contrast (minimum)](/wcag/1.4.3)
-- [1.4.8 Visuele presentatie](/wcag/1.4.3)
 - [1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11)

--- a/docs/richtlijnen/stijl/space/4-relations/_guideline.md
+++ b/docs/richtlijnen/stijl/space/4-relations/_guideline.md
@@ -11,5 +11,3 @@ Dit is een van de [Gestalt principes](https://www.smashingmagazine.com/2014/03/d
 De ruimte tussen een voorgaande sectie en een koptekst moet groter zijn dan de ruimte tussen de koptekst en de eerste alinea na die koptekst.
 
 ![Screenshot van een artikel. Duidelijk is dat de witruimte boven kopteksten groter is dan onder de kopteksten.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_ruimte_relaties-typografie.png)
-
-[WCAG-succescriterium 1.4.8 Visuele weergave](/wcag/1.4.8) beschrijft dat de regelafstand van een alinea ten minste 1.5 zou moeten zijn. En dat de afstand tussen alinea’s ten minste 1,5 keer zo groot zou moeten zijn als de regelafstand.

--- a/docs/richtlijnen/stijl/space/README.mdx
+++ b/docs/richtlijnen/stijl/space/README.mdx
@@ -26,7 +26,6 @@ Ruimte (_Spacing_ in het Engels) helpt bij het organiseren van inhoud. Door ruim
 
 ## Gerelateerde WCAG-succescriteria:
 
-- [1.4.8 Visuele weergave](/wcag/1.4.8) (niveau AAA)
 - [1.4.12 Tekstafstand](/wcag/1.4.12) (niveau AA)
 - [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA)
 - [2.5.8 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA)


### PR DESCRIPTION
Duidelijk vermelden aan welke WCAG-succescriteria we willen voldoen, inclusief de AAA.

Gerelateerd:
- #1556
- #1742
