### PR TITLE
Geef focus terug aan zoekknop na sluiten zoekmodal (fixes #1733)

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -111,6 +111,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   }, [importDocSearchModalIfNeeded, setIsOpen]);
   const onClose = useCallback(() => {
     setIsOpen(false);
+    searchButtonRef.current?.focus();
     searchContainer.current?.remove();
   }, [setIsOpen]);
   const onInput = useCallback(


### PR DESCRIPTION
Known issue: wanneer je 'm sluit met een klik buiten de is de `focus-visible` stijl niet zichtbaar, terwijl die wel gebruikt wordt als je met keyboard sluit. Geverifieerd dat de focus zich ook in dat geval wel netjes verplaatsten je vanuit de button naar vorige/volgende elementen kunt tabben. 