### PR TITLE
Update toegankelijkheidsverklaring

### DIFF
--- a/docs/footer/toegankelijkheidsverklaring.md
+++ b/docs/footer/toegankelijkheidsverklaring.md
@@ -28,11 +28,15 @@ Wanneer tenminste twéé organisaties in de community een component van elkaar h
 
 We streven ernaar voor de website nldesignsystem.nl te voldoen aan de [WCAG 2.2 AA richtlijnen](https://www.w3.org/TR/WCAG22/), zoals opgesteld door het W3C.
 
-Op 20 november 2023 is de website nldesignsystem.nl geaudit ([Auditrapport 2023](/toegankelijkheidsverklaring/rapport-2023)).
-De problemen die uit deze audit kwamen worden nu aangepakt. Het streven is om uiterlijk eind 2024 (liefst eerder) alle problemen opgelost te hebben.
-
 Ondervind je een probleem bij het gebruik van deze website of heb je hier een vraag over?
 Neem dan [contact](https://nldesignsystem.nl/project/kernteam) met ons op.
+
+### Rapporten
+
+- [Auditrapport v2 (26 november 2024)](/toegankelijkheidsverklaring/rapport-2024).
+- [Auditrapport v1 (20 november 2023)](/toegankelijkheidsverklaring/rapport-2023).
+
+### Huidige status
 
 <p>
 <a href="https://www.toegankelijkheidsverklaring.nl/register/12250">

--- a/docs/footer/wcag-em-rapport-2023.md
+++ b/docs/footer/wcag-em-rapport-2023.md
@@ -11,62 +11,803 @@ Dit is het [WCAG EM Auditrapport](https://www.w3.org/WAI/test-evaluate/conforman
 Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsverklaring).
 
 <div class="wcag-em">
-<h2>Over deze evaluatie</h2>
+  <h2>Over deze evaluatie</h2>
 
-<dl><dt>Rapport auteur </dt><dd>Rian Rietveld en Hidde de Vries </dd><dt>Evaluatie opdrachtgever </dt><dd>NL Design System </dd><dt>Evaluatiedatum </dt><dd>20 november 2023</dd></dl>
+  <dl>
+    <dt>Rapport auteur</dt>
+    <dd>Rian Rietveld en Hidde de Vries</dd>
+    <dt>Evaluatie opdrachtgever</dt>
+    <dd>NL Design System</dd>
+    <dt>Evaluatiedatum</dt>
+    <dd>20 november 2023</dd>
+  </dl>
 
-<h2>Managementsamenvatting</h2>
+  <h2>Managementsamenvatting</h2>
 
-<p>Het menu in desktop en mobiele weergave heeft problemen met de toetsenbordnavigatie, resize en reflow. Dit is de meest ingrijpende aanpassing die moet gebeuren. Daarnaast moet er een goede responsive weergave voor tabellen komen. De overige afkeuringen zijn makkelijker op te lossen.</p>
+  <p>
+    Het menu in desktop en mobiele weergave heeft problemen met de
+    toetsenbordnavigatie, resize en reflow. Dit is de meest ingrijpende
+    aanpassing die moet gebeuren. Daarnaast moet er een goede responsive
+    weergave voor tabellen komen. De overige afkeuringen zijn makkelijker op te
+    lossen.
+  </p>
 
-<h2>Scope van de evaluatie</h2>
+  <h2>Scope van de evaluatie</h2>
 
-<dl>
-<dt>Website naam </dt>
-<dd>NL Design System </dd>
-<dt>Scope van de website </dt>
-<dd>Alle webcontent van de publieke website van het NL Design System op nldesignsystem.nl </dd>
-<dt>WCAG Versie </dt>
-<dd>2.1 </dd>
-<dt>Conformiteitsdoel </dt>
-<dd>AA </dd>
-<dt>Basisniveau van toegankelijkheid-ondersteuning </dt>
-<dd>Safari 14 met VoiceOver, Chrome Version 119.0.6045.123 (Official Build) (arm64), FireFox 119.0.1 (64-bit), iOS 16.7.2 </dd>
-<dt>Verdere onderzoeksvereisten </dt>
-<dd>In dit rapport worden alleen de gevonden problemen vermeld en geen oplossingen geboden.</dd>
-</dl>
+  <dl>
+    <dt>Website naam</dt>
+    <dd>NL Design System</dd>
+    <dt>Scope van de website</dt>
+    <dd>
+      Alle webcontent van de publieke website van het NL Design System op
+      nldesignsystem.nl
+    </dd>
+    <dt>WCAG Versie</dt>
+    <dd>2.1</dd>
+    <dt>Conformiteitsdoel</dt>
+    <dd>AA</dd>
+    <dt>Basisniveau van toegankelijkheid-ondersteuning</dt>
+    <dd>
+      Safari 14 met VoiceOver, Chrome Version 119.0.6045.123 (Official Build)
+      (arm64), FireFox 119.0.1 (64-bit), iOS 16.7.2
+    </dd>
+    <dt>Verdere onderzoeksvereisten</dt>
+    <dd>
+      In dit rapport worden alleen de gevonden problemen vermeld en geen
+      oplossingen geboden.
+    </dd>
+  </dl>
 
-<h2>Uitgebreide toetsresultaten</h2>
-<h3>Samenvatting</h3>
-<p>Gerapporteerd over 50 van 50 WCAG 2.1 AA Success Criteria.</p>
+  <h2>Uitgebreide toetsresultaten</h2>
+  <h3>Samenvatting</h3>
+  <p>Gerapporteerd over 50 van 50 WCAG 2.1 AA Success Criteria.</p>
 
-<ul><li><span>24</span> <span>Voldoende</span></li><li><span>11</span> <span>Onvoldoende</span></li><li><span>0</span> <span>Onbekend</span></li><li><span>15</span> <span>Niet van toepassing</span></li><li><span>0</span> <span>Niet getoetst</span></li></ul>  <h3>Alle resultaten</h3> <h4>1 Waarneembaar</h4> <h5 id="guideline-11">1.1 Tekstalternatieven</h5> <table aria-labelledby="guideline-11"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-111">1.1.1: Niet-tekstuele content</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Pagina: <a href="https://nldesignsystem.nl/project/kernteam">https://nldesignsystem.nl/project/kernteam</a></p>
-<p>De SVG’s met de afbeeldingen van de teamleden hebben geen alternatief.</p>
- </td>  </tr></tbody> </table><h5 id="guideline-12">1.2 Op tijd gebaseerde media</h5> <table aria-labelledby="guideline-12"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-121">1.2.1: Louter-geluid en louter-videobeeld (vooraf opgenomen)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Pagina: <a href="https://nldesignsystem.nl/events/heartbeat">https://nldesignsystem.nl/events/heartbeat</a></p>
-<p>Vimeo video's hebben geen ondertiteling.</p>
- </td>  </tr><tr><th scope="row" id="criterion-122">1.2.2: Ondertitels voor doven en slechthorenden (vooraf opgenomen)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Pagina: <a href="https://nldesignsystem.nl/events/heartbeat">https://nldesignsystem.nl/events/heartbeat</a></p>
-<p>Vimeo video's hebben geen ondertiteling.</p>
- </td>  </tr><tr><th scope="row" id="criterion-123">1.2.3: Audiodescriptie of media-alternatief (vooraf opgenomen)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-124">1.2.4: Ondertitels voor doven en slechthorenden (live)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-125">1.2.5: Audiodescriptie (vooraf opgenomen)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-13">1.3 Aanpasbaar</h5> <table aria-labelledby="guideline-13"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-131">1.3.1: Info en relaties</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td>  </td>  </tr><tr><th scope="row" id="criterion-132">1.3.2: Betekenisvolle volgorde</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-133">1.3.3: Zintuiglijke eigenschappen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-134">1.3.4: Weergavestand</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-135">1.3.5: Identificeer het doel van de input</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-14">1.4 Onderscheidbaar</h5> <table aria-labelledby="guideline-14"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-141">1.4.1: Gebruik van kleur</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-142">1.4.2: Geluidsbediening</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-143">1.4.3: Contrast (minimum)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Zoekoptie in de menubalk.</p>
-<p>De tekst en de placeholder in het zoek-modal hebben te weinig contrast.</p>
- </td>  </tr><tr><th scope="row" id="criterion-144">1.4.4: Herschalen van tekst</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>In het menu op alle pagina’s.</p>
-<p>Het menu hakt af bij schalen naar 200% alleen tekst.</p>
- </td>  </tr><tr><th scope="row" id="criterion-145">1.4.5: Afbeeldingen van tekst</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-1410">1.4.10: Reflow</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Pagina <a href="https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/">https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/</a>.</p>
-<p>Tabellen op Tijdschema · NL Design System hakken af bij een kleiner scherm. En er is geen horizontale scrollbar (zou kunnen bij tabel).</p>
-<p>Pagina <a href="https://nldesignsystem.nl/events/design-systems-week-2022">https://nldesignsystem.nl/events/design-systems-week-2022</a>
-Op Design Systems Week 2022 valt het submenu links over de tekst bij een kleiner beeldscherm.</p>
- </td>  </tr><tr><th scope="row" id="criterion-1411">1.4.11: Contrast van niet-tekstuele content</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-1412">1.4.12: Tekstafstand</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-1413">1.4.13: Content bij hover of focus</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr></tbody> </table><h4>2 Bedienbaar</h4> <h5 id="guideline-21">2.1 Toetsenbordtoegankelijk</h5> <table aria-labelledby="guideline-21"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-211">2.1.1: Toetsenbord</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-212">2.1.2: Geen toetsenbordval</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-214">2.1.4: Enkel teken sneltoetsen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>Pagina: <a href="https://nldesignsystem.nl/events/heartbeat">https://nldesignsystem.nl/events/heartbeat</a></p>
-<p>Keyboard shortcuts zijn niet disabled voor de Vimeo player (Disable shortcuts voor vimeo video, keyboard="false").</p>
- </td>  </tr></tbody> </table><h5 id="guideline-22">2.2 Genoeg tijd</h5> <table aria-labelledby="guideline-22"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-221">2.2.1: Timing aanpasbaar</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-222">2.2.2: Pauzeren, stoppen, verbergen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-23">2.3 Toevallen en fysieke reacties</h5> <table aria-labelledby="guideline-23"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-231">2.3.1: Drie flitsen of beneden drempelwaarde</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-24">2.4 Navigeerbaar</h5> <table aria-labelledby="guideline-24"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-241">2.4.1: Blokken omzeilen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-242">2.4.2: Paginatitel</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-243">2.4.3: Focus volgorde</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>In het menu op alle pagina’s.</p>
-<p>De toetsenbordfocus komt op onzichtbare items bij het mobiele menu waardoor de volgorde anders is dan de zichtbare volgorde.</p>
- </td>  </tr><tr><th scope="row" id="criterion-244">2.4.4: Linkdoel (in context)</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>In het logo in de header op alle pagina’s.</p>
-<p>De linktekst op het logo is onduidelijk en verwijst niet naar de voorpagina.</p>
- </td>  </tr><tr><th scope="row" id="criterion-245">2.4.5: Meerdere manieren</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-246">2.4.6: Koppen en labels</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-247">2.4.7: Focus zichtbaar</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>In het menu op alle pagina’s.</p>
-<p>Wanneer navigatie kleine schermen “open” staat is focus soms onzichtbaar (want mogelijk om buiten navigatie te tabben).</p>
- </td>  </tr></tbody> </table><h5 id="guideline-25">2.5 Input Modaliteiten</h5> <table aria-labelledby="guideline-25"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-251">2.5.1: Aanwijzergebaren</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-252">2.5.2: Aanwijzerannulering</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-253">2.5.3: Label in naam</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Onvoldoende</p> </td> <td><h6>Hele sample</h6> <p>Bevindingen:</p> <p>In het menu op alle pagina’s.</p>
-<p>Het label van de menuknop komt niet overeen met de visuele tekst.</p>
- </td>  </tr><tr><th scope="row" id="criterion-254">2.5.4: Bewegingsactivering</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table><h4>3 Begrijpelijk</h4> <h5 id="guideline-31">3.1 Leesbaar</h5> <table aria-labelledby="guideline-31"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-311">3.1.1: Taal van de pagina</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-312">3.1.2: Taal van onderdelen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-32">3.2 Voorspelbaar</h5> <table aria-labelledby="guideline-32"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-321">3.2.1: Bij focus</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-322">3.2.2: Bij input</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-323">3.2.3: Consistente navigatie</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-324">3.2.4: Consistente identificatie</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr></tbody> </table><h5 id="guideline-33">3.3 Assistentie bij invoer</h5> <table aria-labelledby="guideline-33"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-331">3.3.1: Foutidentificatie</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-332">3.3.2: Labels of instructies</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-333">3.3.3: Foutsuggestie</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-334">3.3.4: Foutpreventie (wettelijk, financieel, gegevens</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table><h4>4 Robuust</h4> <h5 id="guideline-41">4.1 Compatibel</h5> <table aria-labelledby="guideline-41"><tbody><tr><th scope="col">Success Criterium</th> <th scope="col">Uitkomst</th> <th scope="col">Bevindingen</th> </tr> <tr><th scope="row" id="criterion-411">4.1.1: Parsen</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-412">4.1.2: Naam, rol, waarde</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Voldoende</p> </td> <td> </td>  </tr><tr><th scope="row" id="criterion-413">4.1.3: Statusberichten</th> <td><h6>Hele sample</h6> <p><span>Uitkomst:</span> Niet van toepassing</p> </td> <td> </td>  </tr></tbody> </table> <h2>Sample met getoetste webpagina&amp;#39;s</h2> <ol><li><span>Voorpagina</span> - <span>https://nldesignsystem.nl/</span> </li><li><span>Documentatie</span> - <span>https://nldesignsystem.nl/documentatie</span> </li><li><span>Richtlijnen</span> - <span>https://nldesignsystem.nl/richtlijnen</span> </li><li><span>Formulierenoverzicht</span> - <span>https://nldesignsystem.nl/richtlijnen/formulieren/overzicht</span> </li><li><span>Toegankelijkheid</span> - <span>https://nldesignsystem.nl/richtlijnen/formulieren/toegankelijk</span> </li><li><span>Componenten</span> - <span>https://nldesignsystem.nl/componenten/)</span> </li><li><span>Onderzoek</span> - <span>https://nldesignsystem.nl/onderzoek/</span> </li><li><span>Project</span> - <span>https://nldesignsystem.nl/project</span> </li><li><span>Kernteam</span> - <span>https://nldesignsystem.nl/project/kernteam</span> </li><li><span>Blog</span> - <span>https://nldesignsystem.nl/project/blog</span> </li><li><span>Blogpost</span> - <span>https://nldesignsystem.nl/project/blog/design-systems-week-2023-komt-eraan</span> </li><li><span>Events met Engelse content</span> - <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/overview</span> </li><li><span>Timetable met Engelse content</span> - <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/timetable</span> </li><li><span> Met Video</span> - <span>https://nldesignsystem.nl/events/design-systems-week-2023/programma/</span> </li><li><span>Event Heartbeat</span> - <span>(https://nldesignsystem.nl/events/heartbeat</span> </li><li><span>Tijdschema (met tabel)</span> - <span>https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema</span> </li><li><span>404 pagina</span> - <span>(https://nldesignsystem.nl/asdasdasd</span> </li><li><span>Links</span> - <span>https://nldesignsystem.nl/project/links</span> </li><li><span>Toegankelijkheidsverklaring</span> - <span>https://nldesignsystem.nl/toegankelijkheidsverklaring</span> </li></ol>
+  <ul>
+    <li><span>24</span> <span>Voldoende</span></li>
+    <li><span>11</span> <span>Onvoldoende</span></li>
+    <li><span>0</span> <span>Onbekend</span></li>
+    <li><span>15</span> <span>Niet van toepassing</span></li>
+    <li><span>0</span> <span>Niet getoetst</span></li>
+  </ul>
+  <h3>Alle resultaten</h3>
+  <h4>1 Waarneembaar</h4>
+  <h5 id="guideline-11">1.1 Tekstalternatieven</h5>
+  <table aria-labelledby="guideline-11">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-111">1.1.1: Niet-tekstuele content</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/project/kernteam"
+              >https://nldesignsystem.nl/project/kernteam</a>
+          </p>
+          <p>
+            De SVG’s met de afbeeldingen van de teamleden hebben geen
+            alternatief.
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-12">1.2 Op tijd gebaseerde media</h5>
+  <table aria-labelledby="guideline-12">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-121">
+          1.2.1: Louter-geluid en louter-videobeeld (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>Vimeo video's hebben geen ondertiteling.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-122">
+          1.2.2: Ondertitels voor doven en slechthorenden (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>Vimeo video's hebben geen ondertiteling.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-123">
+          1.2.3: Audiodescriptie of media-alternatief (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-124">
+          1.2.4: Ondertitels voor doven en slechthorenden (live)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-125">
+          1.2.5: Audiodescriptie (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-13">1.3 Aanpasbaar</h5>
+  <table aria-labelledby="guideline-13">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-131">1.3.1: Info en relaties</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-132">1.3.2: Betekenisvolle volgorde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-133">
+          1.3.3: Zintuiglijke eigenschappen
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-134">1.3.4: Weergavestand</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-135">
+          1.3.5: Identificeer het doel van de input
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-14">1.4 Onderscheidbaar</h5>
+  <table aria-labelledby="guideline-14">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-141">1.4.1: Gebruik van kleur</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-142">1.4.2: Geluidsbediening</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-143">1.4.3: Contrast (minimum)</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>Zoekoptie in de menubalk.</p>
+          <p>
+            De tekst en de placeholder in het zoek-modal hebben te weinig
+            contrast.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-144">1.4.4: Herschalen van tekst</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>Het menu hakt af bij schalen naar 200% alleen tekst.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-145">1.4.5: Afbeeldingen van tekst</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1410">1.4.10: Reflow</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina
+            <a
+              href="https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/"
+              >https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/</a>.
+          </p>
+          <p>
+            Tabellen op Tijdschema · NL Design System hakken af bij een kleiner
+            scherm. En er is geen horizontale scrollbar (zou kunnen bij tabel).
+          </p>
+          <p>
+            Pagina
+            <a href="https://nldesignsystem.nl/events/design-systems-week-2022"
+              >https://nldesignsystem.nl/events/design-systems-week-2022</a>
+            Op Design Systems Week 2022 valt het submenu links over de tekst bij
+            een kleiner beeldscherm.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1411">
+          1.4.11: Contrast van niet-tekstuele content
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1412">1.4.12: Tekstafstand</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1413">
+          1.4.13: Content bij hover of focus
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>2 Bedienbaar</h4>
+  <h5 id="guideline-21">2.1 Toetsenbordtoegankelijk</h5>
+  <table aria-labelledby="guideline-21">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-211">2.1.1: Toetsenbord</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-212">2.1.2: Geen toetsenbordval</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-214">2.1.4: Enkel teken sneltoetsen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>
+            Keyboard shortcuts zijn niet disabled voor de Vimeo player (Disable
+            shortcuts voor vimeo video, keyboard="false").
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-22">2.2 Genoeg tijd</h5>
+  <table aria-labelledby="guideline-22">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-221">2.2.1: Timing aanpasbaar</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-222">
+          2.2.2: Pauzeren, stoppen, verbergen
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-23">2.3 Toevallen en fysieke reacties</h5>
+  <table aria-labelledby="guideline-23">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-231">
+          2.3.1: Drie flitsen of beneden drempelwaarde
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-24">2.4 Navigeerbaar</h5>
+  <table aria-labelledby="guideline-24">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-241">2.4.1: Blokken omzeilen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-242">2.4.2: Paginatitel</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-243">2.4.3: Focus volgorde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            De toetsenbordfocus komt op onzichtbare items bij het mobiele menu
+            waardoor de volgorde anders is dan de zichtbare volgorde.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-244">2.4.4: Linkdoel (in context)</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het logo in de header op alle pagina’s.</p>
+          <p>
+            De linktekst op het logo is onduidelijk en verwijst niet naar de
+            voorpagina.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-245">2.4.5: Meerdere manieren</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-246">2.4.6: Koppen en labels</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-247">2.4.7: Focus zichtbaar</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            Wanneer navigatie kleine schermen “open” staat is focus soms
+            onzichtbaar (want mogelijk om buiten navigatie te tabben).
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-25">2.5 Input Modaliteiten</h5>
+  <table aria-labelledby="guideline-25">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-251">2.5.1: Aanwijzergebaren</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-252">2.5.2: Aanwijzerannulering</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-253">2.5.3: Label in naam</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            Het label van de menuknop komt niet overeen met de visuele tekst.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-254">2.5.4: Bewegingsactivering</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>3 Begrijpelijk</h4>
+  <h5 id="guideline-31">3.1 Leesbaar</h5>
+  <table aria-labelledby="guideline-31">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-311">3.1.1: Taal van de pagina</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-312">3.1.2: Taal van onderdelen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-32">3.2 Voorspelbaar</h5>
+  <table aria-labelledby="guideline-32">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-321">3.2.1: Bij focus</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-322">3.2.2: Bij input</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-323">3.2.3: Consistente navigatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-324">3.2.4: Consistente identificatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-33">3.3 Assistentie bij invoer</h5>
+  <table aria-labelledby="guideline-33">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-331">3.3.1: Foutidentificatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-332">3.3.2: Labels of instructies</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-333">3.3.3: Foutsuggestie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-334">
+          3.3.4: Foutpreventie (wettelijk, financieel, gegevens
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>4 Robuust</h4>
+  <h5 id="guideline-41">4.1 Compatibel</h5>
+  <table aria-labelledby="guideline-41">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-411">4.1.1: Parsen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-412">4.1.2: Naam, rol, waarde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-413">4.1.3: Statusberichten</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>Sample met getoetste webpagina&amp;#39;s</h2>
+  <ol>
+    <li><span>Voorpagina</span> - <span>https://nldesignsystem.nl/</span></li>
+    <li>
+      <span>Documentatie</span> -
+      <span>https://nldesignsystem.nl/documentatie</span>
+    </li>
+    <li>
+      <span>Richtlijnen</span> -
+      <span>https://nldesignsystem.nl/richtlijnen</span>
+    </li>
+    <li>
+      <span>Formulierenoverzicht</span> -
+      <span>https://nldesignsystem.nl/richtlijnen/formulieren/overzicht</span>
+    </li>
+    <li>
+      <span>Toegankelijkheid</span> -
+      <span
+        >https://nldesignsystem.nl/richtlijnen/formulieren/toegankelijk</span>
+    </li>
+    <li>
+      <span>Componenten</span> -
+      <span>https://nldesignsystem.nl/componenten/)</span>
+    </li>
+    <li>
+      <span>Onderzoek</span> - <span>https://nldesignsystem.nl/onderzoek/</span>
+    </li>
+    <li>
+      <span>Project</span> - <span>https://nldesignsystem.nl/project</span>
+    </li>
+    <li>
+      <span>Kernteam</span> -
+      <span>https://nldesignsystem.nl/project/kernteam</span>
+    </li>
+    <li>
+      <span>Blog</span> - <span>https://nldesignsystem.nl/project/blog</span>
+    </li>
+    <li>
+      <span>Blogpost</span> -
+      <span>https://nldesignsystem.nl/project/blog/design-systems-week-2023-komt-eraan</span>
+    </li>
+    <li>
+      <span>Events met Engelse content</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/overview</span>
+    </li>
+    <li>
+      <span>Timetable met Engelse content</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/timetable</span>
+    </li>
+    <li>
+      <span>Met Video</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/programma/</span>
+    </li>
+    <li>
+      <span>Event Heartbeat</span> -
+      <span>(https://nldesignsystem.nl/events/heartbeat</span>
+    </li>
+    <li>
+      <span>Tijdschema (met tabel)</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema</span>
+    </li>
+    <li>
+      <span>404 pagina</span> -
+      <span>(https://nldesignsystem.nl/asdasdasd</span>
+    </li>
+    <li>
+      <span>Links</span> - <span>https://nldesignsystem.nl/project/links</span>
+    </li>
+    <li>
+      <span>Toegankelijkheidsverklaring</span> -
+      <span>https://nldesignsystem.nl/toegankelijkheidsverklaring</span>
+    </li>
+  </ol>
 
   <h2>Webtechnologie</h2>
   <p>HTML,CSS,WAI-ARIA,JavaScript,SVG</p>
-
 </div>

--- a/docs/footer/wcag-em-rapport-2024.md
+++ b/docs/footer/wcag-em-rapport-2024.md
@@ -1,0 +1,813 @@
+---
+title: Audit toegankelijkheid NLDesignSystem.nl versie 1.0
+hide_title: false
+hide_table_of_contents: false
+pagination_label: Toegankelijkheid
+slug: /toegankelijkheidsverklaring/rapport-2023
+---
+
+Dit is het [WCAG EM Auditrapport](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) van NLDesignSystem.nl.
+
+Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsverklaring).
+
+<div class="wcag-em">
+  <h2>Over deze evaluatie</h2>
+
+  <dl>
+    <dt>Rapport auteur</dt>
+    <dd>Rian Rietveld en Hidde de Vries</dd>
+    <dt>Evaluatie opdrachtgever</dt>
+    <dd>NL Design System</dd>
+    <dt>Evaluatiedatum</dt>
+    <dd>20 november 2023</dd>
+  </dl>
+
+  <h2>Managementsamenvatting</h2>
+
+  <p>
+    Het menu in desktop en mobiele weergave heeft problemen met de
+    toetsenbordnavigatie, resize en reflow. Dit is de meest ingrijpende
+    aanpassing die moet gebeuren. Daarnaast moet er een goede responsive
+    weergave voor tabellen komen. De overige afkeuringen zijn makkelijker op te
+    lossen.
+  </p>
+
+  <h2>Scope van de evaluatie</h2>
+
+  <dl>
+    <dt>Website naam</dt>
+    <dd>NL Design System</dd>
+    <dt>Scope van de website</dt>
+    <dd>
+      Alle webcontent van de publieke website van het NL Design System op
+      nldesignsystem.nl
+    </dd>
+    <dt>WCAG Versie</dt>
+    <dd>2.1</dd>
+    <dt>Conformiteitsdoel</dt>
+    <dd>AA</dd>
+    <dt>Basisniveau van toegankelijkheid-ondersteuning</dt>
+    <dd>
+      Safari 14 met VoiceOver, Chrome Version 119.0.6045.123 (Official Build)
+      (arm64), FireFox 119.0.1 (64-bit), iOS 16.7.2
+    </dd>
+    <dt>Verdere onderzoeksvereisten</dt>
+    <dd>
+      In dit rapport worden alleen de gevonden problemen vermeld en geen
+      oplossingen geboden.
+    </dd>
+  </dl>
+
+  <h2>Uitgebreide toetsresultaten</h2>
+  <h3>Samenvatting</h3>
+  <p>Gerapporteerd over 50 van 50 WCAG 2.1 AA Success Criteria.</p>
+
+  <ul>
+    <li><span>24</span> <span>Voldoende</span></li>
+    <li><span>11</span> <span>Onvoldoende</span></li>
+    <li><span>0</span> <span>Onbekend</span></li>
+    <li><span>15</span> <span>Niet van toepassing</span></li>
+    <li><span>0</span> <span>Niet getoetst</span></li>
+  </ul>
+  <h3>Alle resultaten</h3>
+  <h4>1 Waarneembaar</h4>
+  <h5 id="guideline-11">1.1 Tekstalternatieven</h5>
+  <table aria-labelledby="guideline-11">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-111">1.1.1: Niet-tekstuele content</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/project/kernteam"
+              >https://nldesignsystem.nl/project/kernteam</a>
+          </p>
+          <p>
+            De SVG’s met de afbeeldingen van de teamleden hebben geen
+            alternatief.
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-12">1.2 Op tijd gebaseerde media</h5>
+  <table aria-labelledby="guideline-12">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-121">
+          1.2.1: Louter-geluid en louter-videobeeld (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>Vimeo video's hebben geen ondertiteling.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-122">
+          1.2.2: Ondertitels voor doven en slechthorenden (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>Vimeo video's hebben geen ondertiteling.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-123">
+          1.2.3: Audiodescriptie of media-alternatief (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-124">
+          1.2.4: Ondertitels voor doven en slechthorenden (live)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-125">
+          1.2.5: Audiodescriptie (vooraf opgenomen)
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-13">1.3 Aanpasbaar</h5>
+  <table aria-labelledby="guideline-13">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-131">1.3.1: Info en relaties</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-132">1.3.2: Betekenisvolle volgorde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-133">
+          1.3.3: Zintuiglijke eigenschappen
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-134">1.3.4: Weergavestand</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-135">
+          1.3.5: Identificeer het doel van de input
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-14">1.4 Onderscheidbaar</h5>
+  <table aria-labelledby="guideline-14">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-141">1.4.1: Gebruik van kleur</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-142">1.4.2: Geluidsbediening</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-143">1.4.3: Contrast (minimum)</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>Zoekoptie in de menubalk.</p>
+          <p>
+            De tekst en de placeholder in het zoek-modal hebben te weinig
+            contrast.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-144">1.4.4: Herschalen van tekst</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>Het menu hakt af bij schalen naar 200% alleen tekst.</p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-145">1.4.5: Afbeeldingen van tekst</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1410">1.4.10: Reflow</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina
+            <a
+              href="https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/"
+              >https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/</a>.
+          </p>
+          <p>
+            Tabellen op Tijdschema · NL Design System hakken af bij een kleiner
+            scherm. En er is geen horizontale scrollbar (zou kunnen bij tabel).
+          </p>
+          <p>
+            Pagina
+            <a href="https://nldesignsystem.nl/events/design-systems-week-2022"
+              >https://nldesignsystem.nl/events/design-systems-week-2022</a>
+            Op Design Systems Week 2022 valt het submenu links over de tekst bij
+            een kleiner beeldscherm.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1411">
+          1.4.11: Contrast van niet-tekstuele content
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1412">1.4.12: Tekstafstand</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-1413">
+          1.4.13: Content bij hover of focus
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>2 Bedienbaar</h4>
+  <h5 id="guideline-21">2.1 Toetsenbordtoegankelijk</h5>
+  <table aria-labelledby="guideline-21">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-211">2.1.1: Toetsenbord</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-212">2.1.2: Geen toetsenbordval</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-214">2.1.4: Enkel teken sneltoetsen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>
+            Pagina:
+            <a href="https://nldesignsystem.nl/events/heartbeat"
+              >https://nldesignsystem.nl/events/heartbeat</a>
+          </p>
+          <p>
+            Keyboard shortcuts zijn niet disabled voor de Vimeo player (Disable
+            shortcuts voor vimeo video, keyboard="false").
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-22">2.2 Genoeg tijd</h5>
+  <table aria-labelledby="guideline-22">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-221">2.2.1: Timing aanpasbaar</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-222">
+          2.2.2: Pauzeren, stoppen, verbergen
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-23">2.3 Toevallen en fysieke reacties</h5>
+  <table aria-labelledby="guideline-23">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-231">
+          2.3.1: Drie flitsen of beneden drempelwaarde
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-24">2.4 Navigeerbaar</h5>
+  <table aria-labelledby="guideline-24">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-241">2.4.1: Blokken omzeilen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-242">2.4.2: Paginatitel</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-243">2.4.3: Focus volgorde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            De toetsenbordfocus komt op onzichtbare items bij het mobiele menu
+            waardoor de volgorde anders is dan de zichtbare volgorde.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-244">2.4.4: Linkdoel (in context)</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het logo in de header op alle pagina’s.</p>
+          <p>
+            De linktekst op het logo is onduidelijk en verwijst niet naar de
+            voorpagina.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-245">2.4.5: Meerdere manieren</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-246">2.4.6: Koppen en labels</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-247">2.4.7: Focus zichtbaar</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            Wanneer navigatie kleine schermen “open” staat is focus soms
+            onzichtbaar (want mogelijk om buiten navigatie te tabben).
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-25">2.5 Input Modaliteiten</h5>
+  <table aria-labelledby="guideline-25">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-251">2.5.1: Aanwijzergebaren</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-252">2.5.2: Aanwijzerannulering</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-253">2.5.3: Label in naam</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Onvoldoende</p>
+        </td>
+        <td>
+          <h6>Hele sample</h6>
+          <p>Bevindingen:</p>
+          <p>In het menu op alle pagina’s.</p>
+          <p>
+            Het label van de menuknop komt niet overeen met de visuele tekst.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-254">2.5.4: Bewegingsactivering</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>3 Begrijpelijk</h4>
+  <h5 id="guideline-31">3.1 Leesbaar</h5>
+  <table aria-labelledby="guideline-31">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-311">3.1.1: Taal van de pagina</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-312">3.1.2: Taal van onderdelen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-32">3.2 Voorspelbaar</h5>
+  <table aria-labelledby="guideline-32">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-321">3.2.1: Bij focus</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-322">3.2.2: Bij input</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-323">3.2.3: Consistente navigatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-324">3.2.4: Consistente identificatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h5 id="guideline-33">3.3 Assistentie bij invoer</h5>
+  <table aria-labelledby="guideline-33">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-331">3.3.1: Foutidentificatie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-332">3.3.2: Labels of instructies</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-333">3.3.3: Foutsuggestie</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-334">
+          3.3.4: Foutpreventie (wettelijk, financieel, gegevens
+        </th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h4>4 Robuust</h4>
+  <h5 id="guideline-41">4.1 Compatibel</h5>
+  <table aria-labelledby="guideline-41">
+    <tbody>
+      <tr>
+        <th scope="col">Success Criterium</th>
+        <th scope="col">Uitkomst</th>
+        <th scope="col">Bevindingen</th>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-411">4.1.1: Parsen</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-412">4.1.2: Naam, rol, waarde</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Voldoende</p>
+        </td>
+        <td></td>
+      </tr>
+      <tr>
+        <th scope="row" id="criterion-413">4.1.3: Statusberichten</th>
+        <td>
+          <h6>Hele sample</h6>
+          <p><span>Uitkomst:</span> Niet van toepassing</p>
+        </td>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>Sample met getoetste webpagina&amp;#39;s</h2>
+  <ol>
+    <li><span>Voorpagina</span> - <span>https://nldesignsystem.nl/</span></li>
+    <li>
+      <span>Documentatie</span> -
+      <span>https://nldesignsystem.nl/documentatie</span>
+    </li>
+    <li>
+      <span>Richtlijnen</span> -
+      <span>https://nldesignsystem.nl/richtlijnen</span>
+    </li>
+    <li>
+      <span>Formulierenoverzicht</span> -
+      <span>https://nldesignsystem.nl/richtlijnen/formulieren/overzicht</span>
+    </li>
+    <li>
+      <span>Toegankelijkheid</span> -
+      <span
+        >https://nldesignsystem.nl/richtlijnen/formulieren/toegankelijk</span>
+    </li>
+    <li>
+      <span>Componenten</span> -
+      <span>https://nldesignsystem.nl/componenten/)</span>
+    </li>
+    <li>
+      <span>Onderzoek</span> - <span>https://nldesignsystem.nl/onderzoek/</span>
+    </li>
+    <li>
+      <span>Project</span> - <span>https://nldesignsystem.nl/project</span>
+    </li>
+    <li>
+      <span>Kernteam</span> -
+      <span>https://nldesignsystem.nl/project/kernteam</span>
+    </li>
+    <li>
+      <span>Blog</span> - <span>https://nldesignsystem.nl/project/blog</span>
+    </li>
+    <li>
+      <span>Blogpost</span> -
+      <span>https://nldesignsystem.nl/project/blog/design-systems-week-2023-komt-eraan</span>
+    </li>
+    <li>
+      <span>Events met Engelse content</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/overview</span>
+    </li>
+    <li>
+      <span>Timetable met Engelse content</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/en/timetable</span>
+    </li>
+    <li>
+      <span>Met Video</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/programma/</span>
+    </li>
+    <li>
+      <span>Event Heartbeat</span> -
+      <span>(https://nldesignsystem.nl/events/heartbeat</span>
+    </li>
+    <li>
+      <span>Tijdschema (met tabel)</span> -
+      <span>https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema</span>
+    </li>
+    <li>
+      <span>404 pagina</span> -
+      <span>(https://nldesignsystem.nl/asdasdasd</span>
+    </li>
+    <li>
+      <span>Links</span> - <span>https://nldesignsystem.nl/project/links</span>
+    </li>
+    <li>
+      <span>Toegankelijkheidsverklaring</span> -
+      <span>https://nldesignsystem.nl/toegankelijkheidsverklaring</span>
+    </li>
+  </ol>
+
+  <h2>Webtechnologie</h2>
+  <p>HTML,CSS,WAI-ARIA,JavaScript,SVG</p>
+</div>

--- a/docs/footer/wcag-em-rapport-2024.md
+++ b/docs/footer/wcag-em-rapport-2024.md
@@ -1,9 +1,9 @@
 ---
-title: Audit toegankelijkheid NLDesignSystem.nl versie 1.0
+title: Audit toegankelijkheid NLDesignSystem.nl versie 2.0
 hide_title: false
 hide_table_of_contents: false
 pagination_label: Toegankelijkheid
-slug: /toegankelijkheidsverklaring/rapport-2023
+slug: /toegankelijkheidsverklaring/rapport-2024
 ---
 
 Dit is het [WCAG EM Auditrapport](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) van NLDesignSystem.nl.
@@ -19,18 +19,14 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
     <dt>Evaluatie opdrachtgever</dt>
     <dd>NL Design System</dd>
     <dt>Evaluatiedatum</dt>
-    <dd>20 november 2023</dd>
+    <dd>Origineel: 20 november 2023; bijgewerkt: 26 september 2024</dd>
   </dl>
 
   <h2>Managementsamenvatting</h2>
 
-  <p>
-    Het menu in desktop en mobiele weergave heeft problemen met de
-    toetsenbordnavigatie, resize en reflow. Dit is de meest ingrijpende
-    aanpassing die moet gebeuren. Daarnaast moet er een goede responsive
-    weergave voor tabellen komen. De overige afkeuringen zijn makkelijker op te
-    lossen.
-  </p>
+  <p>Dit rapport is een hertest van [v1](/toegankelijkheidsverklaring/rapport-2023).</p>
+
+  <p>De problemen uit rapport v1 zijn inmiddels verholpen, met uitzondering van het ontbreken van ondertiteling (1.2.1, 1.2.2). Video's van voor 2023 zijn nog niet ondertiteld.</p>
 
   <h2>Scope van de evaluatie</h2>
 
@@ -63,8 +59,8 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
   <p>Gerapporteerd over 50 van 50 WCAG 2.1 AA Success Criteria.</p>
 
   <ul>
-    <li><span>24</span> <span>Voldoende</span></li>
-    <li><span>11</span> <span>Onvoldoende</span></li>
+    <li><span>33</span> <span>Voldoende</span></li>
+    <li><span>2</span> <span>Onvoldoende</span></li>
     <li><span>0</span> <span>Onbekend</span></li>
     <li><span>15</span> <span>Niet van toepassing</span></li>
     <li><span>0</span> <span>Niet getoetst</span></li>
@@ -72,7 +68,7 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
   <h3>Alle resultaten</h3>
   <h4>1 Waarneembaar</h4>
   <h5 id="guideline-11">1.1 Tekstalternatieven</h5>
-  <table aria-labelledby="guideline-11">
+  <table aria-labelledby="guideline-11" width="100%">
     <tbody>
       <tr>
         <th scope="col">Success Criterium</th>
@@ -81,23 +77,8 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
       </tr>
       <tr>
         <th scope="row" id="criterion-111">1.1.1: Niet-tekstuele content</th>
-        <td>
-          <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
-        </td>
-        <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>
-            Pagina:
-            <a href="https://nldesignsystem.nl/project/kernteam"
-              >https://nldesignsystem.nl/project/kernteam</a>
-          </p>
-          <p>
-            De SVG’s met de afbeeldingen van de teamleden hebben geen
-            alternatief.
-          </p>
-        </td>
+        <td>Voldoende</td>
+        <td>Geen</td>
       </tr>
     </tbody>
   </table>
@@ -125,7 +106,7 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
             <a href="https://nldesignsystem.nl/events/heartbeat"
               >https://nldesignsystem.nl/events/heartbeat</a>
           </p>
-          <p>Vimeo video's hebben geen ondertiteling.</p>
+          <p>YouTube video's van voor 2023 hebben geen ondertiteling.</p>
         </td>
       </tr>
       <tr>
@@ -144,7 +125,7 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
             <a href="https://nldesignsystem.nl/events/heartbeat"
               >https://nldesignsystem.nl/events/heartbeat</a>
           </p>
-          <p>Vimeo video's hebben geen ondertiteling.</p>
+          <p>YouTube video's van voor 2023 hebben geen ondertiteling.</p>
         </td>
       </tr>
       <tr>
@@ -261,29 +242,18 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-143">1.4.3: Contrast (minimum)</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>Zoekoptie in de menubalk.</p>
-          <p>
-            De tekst en de placeholder in het zoek-modal hebben te weinig
-            contrast.
-          </p>
         </td>
       </tr>
       <tr>
         <th scope="row" id="criterion-144">1.4.4: Herschalen van tekst</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>In het menu op alle pagina’s.</p>
-          <p>Het menu hakt af bij schalen naar 200% alleen tekst.</p>
         </td>
       </tr>
       <tr>
@@ -298,28 +268,9 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-1410">1.4.10: Reflow</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>
-            Pagina
-            <a
-              href="https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/"
-              >https://nldesignsystem.nl/events/design-systems-week-2023/tijdschema/</a>.
-          </p>
-          <p>
-            Tabellen op Tijdschema · NL Design System hakken af bij een kleiner
-            scherm. En er is geen horizontale scrollbar (zou kunnen bij tabel).
-          </p>
-          <p>
-            Pagina
-            <a href="https://nldesignsystem.nl/events/design-systems-week-2022"
-              >https://nldesignsystem.nl/events/design-systems-week-2022</a>
-            Op Design Systems Week 2022 valt het submenu links over de tekst bij
-            een kleiner beeldscherm.
-          </p>
         </td>
       </tr>
       <tr>
@@ -381,20 +332,9 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-214">2.1.4: Enkel teken sneltoetsen</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>
-            Pagina:
-            <a href="https://nldesignsystem.nl/events/heartbeat"
-              >https://nldesignsystem.nl/events/heartbeat</a>
-          </p>
-          <p>
-            Keyboard shortcuts zijn niet disabled voor de Vimeo player (Disable
-            shortcuts voor vimeo video, keyboard="false").
-          </p>
         </td>
       </tr>
     </tbody>
@@ -475,32 +415,18 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-243">2.4.3: Focus volgorde</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>In het menu op alle pagina’s.</p>
-          <p>
-            De toetsenbordfocus komt op onzichtbare items bij het mobiele menu
-            waardoor de volgorde anders is dan de zichtbare volgorde.
-          </p>
         </td>
       </tr>
       <tr>
         <th scope="row" id="criterion-244">2.4.4: Linkdoel (in context)</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>In het logo in de header op alle pagina’s.</p>
-          <p>
-            De linktekst op het logo is onduidelijk en verwijst niet naar de
-            voorpagina.
-          </p>
         </td>
       </tr>
       <tr>
@@ -523,16 +449,9 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-247">2.4.7: Focus zichtbaar</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>In het menu op alle pagina’s.</p>
-          <p>
-            Wanneer navigatie kleine schermen “open” staat is focus soms
-            onzichtbaar (want mogelijk om buiten navigatie te tabben).
-          </p>
         </td>
       </tr>
     </tbody>
@@ -565,15 +484,9 @@ Gerelateerd: [toegankelijkheidsverklaring NLDesignSystem.nl](/toegankelijkheidsv
         <th scope="row" id="criterion-253">2.5.3: Label in naam</th>
         <td>
           <h6>Hele sample</h6>
-          <p><span>Uitkomst:</span> Onvoldoende</p>
+          <p><span>Uitkomst:</span> Voldoende</p>
         </td>
         <td>
-          <h6>Hele sample</h6>
-          <p>Bevindingen:</p>
-          <p>In het menu op alle pagina’s.</p>
-          <p>
-            Het label van de menuknop komt niet overeen met de visuele tekst.
-          </p>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Deze PR doet twee dingen: 

- voegt hertest toe: dit is een kopie van het rapport dat we in 2023 plaatsen, met daarin alle problemen die inmiddels zijn opgelost weggehaald, en de status aangepast naar voldoende als er daardoor geen problemen meer over waren. In [deze commit](https://github.com/nl-design-system/documentatie/commit/30f396d68474f2090fc89fb8b34356243c6d4a0a) zie je het verschil tussen 2024 en 2023
- [update toegankelijkheidsverklaring pagina](https://github.com/nl-design-system/documentatie/commit/b2ccc5b4e5b6ef06c9b5daecb437c3d8475387bf); dit is een eerste poging om twee rapporten te laten zien. Wil ik graag checken met team a11y wat de meest logische manier is om dit te presenteren, is het duidelijk genoeg dat v2 eigenlijk v1 is, maar dan met de gefixte problemen eruit?

Ik heb ook Prettier gegooid op beide versies van het rapport zodat we het beter kunnen lezen.