### PR TITLE
refactor: import from npm package instead of docusaurus magic

### DIFF
--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -40,6 +40,25 @@ keywords:
 
 {/* @license CC0-1.0 */}
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_intro.md";
+import Wcag111 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.1.1-button.md';
+import Wcag1411 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.11-button.md';
+import Wcag1412 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.12.md';
+import Wcag143 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.3.md';
+import Wcag144 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.4.md';
+import Wcag145 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.5.md';
+import Wcag211 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.1.1.md';
+import Wcag2413 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.4.13.md';
+import Wcag246 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.4.6-button.md';
+import Wcag247 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.4.7.md';
+import Wcag252 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.5.2.md';
+import Wcag253 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.5.3-button.md';
+import Wcag255 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.5.5.md';
+import Wcag312 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-3.1.2.md';
+import Wcag324 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-3.2.4.md';
+import Wcag412 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-4.1.2-button.md';
+import Wcag212 from '@nl-design-system-unstable/documentation/wcag/summaries/\_2.1.2-summary.md';
+import Wcag2411 from '@nl-design-system-unstable/documentation/wcag/summaries/\_2.4.11-summary.md';
 import { CriteriaList } from '@site/src/components/ComponentCriteriaList';
 import {
 DefinitionOfDone,
@@ -47,25 +66,6 @@ HelpImproveComponent,
 Implementations,
 Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/\_ac_intro.md";
-import Wcag111 from '/docs/componenten/ac/\_wcag-1.1.1-button.md';
-import Wcag1411 from '/docs/componenten/ac/\_wcag-1.4.11-button.md';
-import Wcag1412 from '/docs/componenten/ac/\_wcag-1.4.12.md';
-import Wcag143 from '/docs/componenten/ac/\_wcag-1.4.3.md';
-import Wcag144 from '/docs/componenten/ac/\_wcag-1.4.4.md';
-import Wcag145 from '/docs/componenten/ac/\_wcag-1.4.5.md';
-import Wcag211 from '/docs/componenten/ac/\_wcag-2.1.1.md';
-import Wcag212 from '/docs/wcag/summaries/\_2.1.2-summary.md';
-import Wcag2411 from '/docs/wcag/summaries/\_2.4.11-summary.md';
-import Wcag2413 from '/docs/componenten/ac/\_wcag-2.4.13.md';
-import Wcag246 from '/docs/componenten/ac/\_wcag-2.4.6-button.md';
-import Wcag247 from '/docs/componenten/ac/\_wcag-2.4.7.md';
-import Wcag252 from '/docs/componenten/ac/\_wcag-2.5.2.md';
-import Wcag253 from '/docs/componenten/ac/\_wcag-2.5.3-button.md';
-import Wcag255 from '/docs/componenten/ac/\_wcag-2.5.5.md';
-import Wcag312 from '/docs/componenten/ac/\_wcag-3.1.2.md';
-import Wcag324 from '/docs/componenten/ac/\_wcag-3.2.4.md';
-import Wcag412 from '/docs/componenten/ac/\_wcag-4.1.2-button.md';
 
 {/* Add name and description for the component */}
 export const title = "Button";

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -13,6 +13,13 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-code-block.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-code.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -20,13 +27,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-code-block.md";
-import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-code.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 
 {/* Add name and description for the component */}
 export const title = "Code Block";

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -13,6 +13,13 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-code.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-code.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -20,13 +27,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-code.md";
-import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-code.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 
 {/* Add name and description for the component */}
 export const title = "Code";

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -16,6 +16,15 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-color-sample.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-color-sample.md";
+import Wcag132 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.2-color-sample.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-color-sample.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.5-color-sample.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.3-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -23,15 +32,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-color-sample.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-color-sample.md";
-import Wcag132 from "/docs/componenten/ac/_wcag-1.3.2-color-sample.md";
-import Wcag143 from "/docs/wcag/summaries/_1.4.3-summary.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/componenten/ac/_wcag-1.4.5-color-sample.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-color-sample.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
 
 {/* Add name and description for the component */}
 export const title = "Color Sample";

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -41,6 +41,15 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-data-badge.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-data-badge.md";
+import Wcag141 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.1-data-badge.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.5.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -48,15 +57,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-data-badge.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-data-badge.md";
-import Wcag141 from "/docs/componenten/ac/_wcag-1.4.1-data-badge.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/componenten/ac/_wcag-1.4.5.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
 
 {/* Add name and description for the component */}
 export const title = "Data Badge";

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -10,6 +10,14 @@ slug: /heading
 
 {/* @license CC0-1.0 */}
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_intro.md";
+import Wcag131 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.3.1-heading.md';
+import Wcag1412 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.12.md';
+import Wcag143 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.3.md';
+import Wcag144 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.4.md';
+import Wcag246 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.4.6-heading.md';
+import Wcag312 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-3.1.2.md';
+import Wcag411 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-4.1.1-heading.md';
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
 DefinitionOfDone,
@@ -17,14 +25,6 @@ HelpImproveComponent,
 Implementations,
 Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/\_ac_intro.md";
-import Wcag131 from '/docs/componenten/ac/\_wcag-1.3.1-heading.md';
-import Wcag143 from '/docs/componenten/ac/\_wcag-1.4.3.md';
-import Wcag144 from '/docs/componenten/ac/\_wcag-1.4.4.md';
-import Wcag1412 from '/docs/componenten/ac/\_wcag-1.4.12.md';
-import Wcag246 from '/docs/componenten/ac/\_wcag-2.4.6-heading.md';
-import Wcag312 from '/docs/componenten/ac/\_wcag-3.1.2.md';
-import Wcag411 from '/docs/componenten/ac/\_wcag-4.1.1-heading.md';
 
 {/* Add name and description for the component */}
 export const title = "Heading";

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -11,6 +11,25 @@ slug: /link
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-link.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-link.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag211 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.1.1-link.md";
+import Wcag2413 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.13.md";
+import Wcag247 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.7.md";
+import Wcag252 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.2.md";
+import Wcag253 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.3-link.md";
+import Wcag255 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.5.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
+import Wcag324 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.2.4.md";
+import Wcag412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-4.1.2-link.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.5-summary.md";
+import Wcag212 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.1.2-summary.md";
+import Wcag2411 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.11-summary.md";
+import Wcag244 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.4-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -18,25 +37,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-link.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-link.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag211 from "/docs/componenten/ac/_wcag-2.1.1-link.md";
-import Wcag212 from "/docs/wcag/summaries/_2.1.2-summary.md";
-import Wcag244 from "/docs/wcag/summaries/_2.4.4-summary.md";
-import Wcag247 from "/docs/componenten/ac/_wcag-2.4.7.md";
-import Wcag2411 from "/docs/wcag/summaries/_2.4.11-summary.md";
-import Wcag2413 from "/docs/componenten/ac/_wcag-2.4.13.md";
-import Wcag252 from "/docs/componenten/ac/_wcag-2.5.2.md";
-import Wcag253 from "/docs/componenten/ac/_wcag-2.5.3-link.md";
-import Wcag255 from "/docs/componenten/ac/_wcag-2.5.5.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
-import Wcag324 from "/docs/componenten/ac/_wcag-3.2.4.md";
-import Wcag412 from "/docs/componenten/ac/_wcag-4.1.2-link.md";
 
 {/* Add name and description for the component */}
 export const title = "Link";

--- a/docs/componenten/login-link/index.mdx
+++ b/docs/componenten/login-link/index.mdx
@@ -15,6 +15,25 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-login-link.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-link.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag211 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.1.1-link.md";
+import Wcag2413 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.13.md";
+import Wcag247 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.7.md";
+import Wcag252 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.2.md";
+import Wcag253 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.3-link.md";
+import Wcag255 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.5.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
+import Wcag324 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.2.4-login-link.md";
+import Wcag412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-4.1.2-link.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.5-summary.md";
+import Wcag212 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.1.2-summary.md";
+import Wcag2411 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.11-summary.md";
+import Wcag244 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.4-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -22,25 +41,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag111 from "/docs/componenten/ac/_wcag-1.1.1-login-link.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-link.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag211 from "/docs/componenten/ac/_wcag-2.1.1-link.md";
-import Wcag212 from "/docs/wcag/summaries/_2.1.2-summary.md";
-import Wcag244 from "/docs/wcag/summaries/_2.4.4-summary.md";
-import Wcag247 from "/docs/componenten/ac/_wcag-2.4.7.md";
-import Wcag2411 from "/docs/wcag/summaries/_2.4.11-summary.md";
-import Wcag2413 from "/docs/componenten/ac/_wcag-2.4.13.md";
-import Wcag252 from "/docs/componenten/ac/_wcag-2.5.2.md";
-import Wcag253 from "/docs/componenten/ac/_wcag-2.5.3-link.md";
-import Wcag255 from "/docs/componenten/ac/_wcag-2.5.5.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
-import Wcag324 from "/docs/componenten/ac/_wcag-3.2.4-login-link.md";
-import Wcag412 from "/docs/componenten/ac/_wcag-4.1.2-link.md";
 
 {/* Add name and description for the component */}
 export const title = "Login Link";

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -14,6 +14,14 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-mark.md";
+import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-mark.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
+import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -21,14 +29,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-mark.md";
-import Wcag141 from "/docs/wcag/summaries/_1.4.1-summary.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag1411 from "/docs/componenten/ac/_wcag-1.4.11-mark.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
 
 {/* Add name and description for the component */}
 export const title = "Mark";

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -11,6 +11,13 @@ slug: /number-badge
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-number-badge.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.5.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -18,13 +25,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-number-badge.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/componenten/ac/_wcag-1.4.5.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
 
 {/* Add name and description for the component */}
 export const title = "Number Badge";

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -13,6 +13,13 @@ tags:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-paragraph.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
+import Wcag1410 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.10-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -20,13 +27,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag131 from "/docs/componenten/ac/_wcag-1.3.1-paragraph.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag1410 from "/docs/wcag/summaries/_1.4.10-summary.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
 
 {/* Add name and description for the component */}
 export const title = "Paragraph";

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -11,6 +11,28 @@ slug: /skip-link
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
+import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
+import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
+import Wcag211 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.1.1-link.md";
+import Wcag2413 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.13.md";
+import Wcag247 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.7-skip-link.md"; // voor Toegankelijkheid visueel ontwerp en Toegankelijkheid toetsenbord
+import Wcag252 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.2.md";
+import Wcag253 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.3-link.md";
+import Wcag255 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.5.md"; // voor Toegankelijkheid algemeen en Toegankelijkheid visueel ontwerp
+import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
+import Wcag324 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.2.4-link.md";
+import Wcag412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-4.1.2-link.md";
+import Wcag1410 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.10-summary.md";
+import Wcag145 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.5-summary.md";
+import Wcag212 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.1.2-summary.md";
+import Wcag241 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.1-summary.md";
+import Wcag2411 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.11-summary.md";
+import Wcag243 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.3-summary.md";
+import Wcag244 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.4-summary.md";
+import Wcag321 from "@nl-design-system-unstable/documentation/wcag/summaries/_3.2.1-summary.md";
+import Wcag323 from "@nl-design-system-unstable/documentation/wcag/summaries/_3.2.3-summary.md";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -18,28 +40,6 @@ import {
   Implementations,
   Introduction,
 } from "@site/src/components/ComponentPage";
-import AcIntro from "/docs/componenten/ac/_ac_intro.md";
-import Wcag143 from "/docs/componenten/ac/_wcag-1.4.3.md";
-import Wcag144 from "/docs/componenten/ac/_wcag-1.4.4.md";
-import Wcag145 from "/docs/wcag/summaries/_1.4.5-summary.md";
-import Wcag1410 from "/docs/wcag/summaries/_1.4.10-summary.md";
-import Wcag1412 from "/docs/componenten/ac/_wcag-1.4.12.md";
-import Wcag211 from "/docs/componenten/ac/_wcag-2.1.1-link.md";
-import Wcag212 from "/docs/wcag/summaries/_2.1.2-summary.md";
-import Wcag241 from "/docs/wcag/summaries/_2.4.1-summary.md";
-import Wcag243 from "/docs/wcag/summaries/_2.4.3-summary.md";
-import Wcag244 from "/docs/wcag/summaries/_2.4.4-summary.md";
-import Wcag247 from "/docs/componenten/ac/_wcag-2.4.7-skip-link.md"; // voor Toegankelijkheid visueel ontwerp en Toegankelijkheid toetsenbord
-import Wcag2411 from "/docs/wcag/summaries/_2.4.11-summary.md";
-import Wcag2413 from "/docs/componenten/ac/_wcag-2.4.13.md";
-import Wcag252 from "/docs/componenten/ac/_wcag-2.5.2.md";
-import Wcag253 from "/docs/componenten/ac/_wcag-2.5.3-link.md";
-import Wcag255 from "/docs/componenten/ac/_wcag-2.5.5.md"; // voor Toegankelijkheid algemeen en Toegankelijkheid visueel ontwerp
-import Wcag312 from "/docs/componenten/ac/_wcag-3.1.2.md";
-import Wcag321 from "/docs/wcag/summaries/_3.2.1-summary.md";
-import Wcag323 from "/docs/wcag/summaries/_3.2.3-summary.md";
-import Wcag324 from "/docs/componenten/ac/_wcag-3.2.4-link.md";
-import Wcag412 from "/docs/componenten/ac/_wcag-4.1.2-link.md";
 
 {/* Add name and description for the component */}
 export const title = "Skip Link";

--- a/docs/richtlijnen/README.mdx
+++ b/docs/richtlijnen/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* <!-- @license CC0-1.0 --> */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System
 

--- a/docs/richtlijnen/formulieren/README.mdx
+++ b/docs/richtlijnen/formulieren/README.mdx
@@ -11,8 +11,8 @@ keywords:
   - formulier
 ---
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Introductie richtlijnen NL Design System voor formulieren
 

--- a/docs/richtlijnen/formulieren/button/1-keyboard/README.mdx
+++ b/docs/richtlijnen/formulieren/button/1-keyboard/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/2-submit/README.mdx
+++ b/docs/richtlijnen/formulieren/button/2-submit/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/3-placement/README.mdx
+++ b/docs/richtlijnen/formulieren/button/3-placement/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/4-text/README.mdx
+++ b/docs/richtlijnen/formulieren/button/4-text/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/5-accessible-name/README.mdx
+++ b/docs/richtlijnen/formulieren/button/5-accessible-name/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/6-image-as-button/README.mdx
+++ b/docs/richtlijnen/formulieren/button/6-image-as-button/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/7-disabled/README.mdx
+++ b/docs/richtlijnen/formulieren/button/7-disabled/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/button/README.mdx
+++ b/docs/richtlijnen/formulieren/button/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor buttons in een formulier
 

--- a/docs/richtlijnen/formulieren/confirmation/1-success/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/1-success/README.mdx
@@ -16,8 +16,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/confirmation/2-accessibility/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/2-accessibility/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/confirmation/3-next-steps/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/3-next-steps/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/confirmation/4-contact/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/4-contact/README.mdx
@@ -16,8 +16,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/confirmation/README.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor de bevestigingspagina van een formulier
 

--- a/docs/richtlijnen/formulieren/description/1-associated/README.mdx
+++ b/docs/richtlijnen/formulieren/description/1-associated/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/2-placement/README.mdx
+++ b/docs/richtlijnen/formulieren/description/2-placement/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/3-multiple/README.mdx
+++ b/docs/richtlijnen/formulieren/description/3-multiple/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/4-fieldset/README.mdx
+++ b/docs/richtlijnen/formulieren/description/4-fieldset/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/5-target-size/README.mdx
+++ b/docs/richtlijnen/formulieren/description/5-target-size/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/6-length/README.mdx
+++ b/docs/richtlijnen/formulieren/description/6-length/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/description/README.mdx
+++ b/docs/richtlijnen/formulieren/description/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor descriptions in een formulier
 

--- a/docs/richtlijnen/formulieren/error/1-timing/README.mdx
+++ b/docs/richtlijnen/formulieren/error/1-timing/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/error/2-description/README.mdx
+++ b/docs/richtlijnen/formulieren/error/2-description/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
+++ b/docs/richtlijnen/formulieren/error/3-clarity/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/error/4-location/README.mdx
+++ b/docs/richtlijnen/formulieren/error/4-location/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/error/5-no-native-validation/README.mdx
+++ b/docs/richtlijnen/formulieren/error/5-no-native-validation/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/error/6-summary/README.mdx
+++ b/docs/richtlijnen/formulieren/error/6-summary/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/error/7-feedback/README.mdx
+++ b/docs/richtlijnen/formulieren/error/7-feedback/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/error/README.mdx
+++ b/docs/richtlijnen/formulieren/error/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor foutmeldingen in een formulier
 

--- a/docs/richtlijnen/formulieren/help/1-show-required/README.mdx
+++ b/docs/richtlijnen/formulieren/help/1-show-required/README.mdx
@@ -15,6 +15,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { Markdown } from "@site/src/components/Markdown";
 import Guideline from "./_guideline.md";
 import MarkOptionalCode from "./_mark-optional-fields-code.mdx";
@@ -23,7 +24,6 @@ import MarkRequiredCode from "./_mark-required-fields-code.mdx";
 import MarkRequired from "./_mark-required-fields.md";
 import ScreenReaderFeedbackCode from "./_screen-reader-feedback-code.mdx";
 import ScreenReaderFeedback from "./_screen-reader-feedback.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/2-allow-copy-paste/README.mdx
+++ b/docs/richtlijnen/formulieren/help/2-allow-copy-paste/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/3-approve/README.mdx
+++ b/docs/richtlijnen/formulieren/help/3-approve/README.mdx
@@ -15,13 +15,13 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { Markdown } from "@site/src/components/Markdown";
 import EmailCode from "./_email-code.mdx";
 import Email from "./_email.md";
 import Guideline from "./_guideline.md";
 import MixedInputCode from "./_mixed-input-code.mdx";
 import MixedInput from "./_mixed-input.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/4-show-values/README.mdx
+++ b/docs/richtlijnen/formulieren/help/4-show-values/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/5-autocomplete/README.mdx
+++ b/docs/richtlijnen/formulieren/help/5-autocomplete/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/6-autofill/README.mdx
+++ b/docs/richtlijnen/formulieren/help/6-autofill/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/7-error-prevention/README.mdx
+++ b/docs/richtlijnen/formulieren/help/7-error-prevention/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
 import GuidelineCode from "./_guideline.mdx";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 

--- a/docs/richtlijnen/formulieren/help/README.mdx
+++ b/docs/richtlijnen/formulieren/help/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor het voorkomen van fouten
 

--- a/docs/richtlijnen/formulieren/keyboard-behaviour/1-keyboard/README.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour/1-keyboard/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/keyboard-behaviour/2-tabindex/README.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour/2-tabindex/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/keyboard-behaviour/README.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor toetsenbordtoegankelijkheid
 

--- a/docs/richtlijnen/formulieren/label/1-accessible-name/README.mdx
+++ b/docs/richtlijnen/formulieren/label/1-accessible-name/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/2-visible-acccessible-name/README.mdx
+++ b/docs/richtlijnen/formulieren/label/2-visible-acccessible-name/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/3-above-field/README.mdx
+++ b/docs/richtlijnen/formulieren/label/3-above-field/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/4-always-visible/README.mdx
+++ b/docs/richtlijnen/formulieren/label/4-always-visible/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/5-only-text/README.mdx
+++ b/docs/richtlijnen/formulieren/label/5-only-text/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/6-text/README.mdx
+++ b/docs/richtlijnen/formulieren/label/6-text/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/label/README.mdx
+++ b/docs/richtlijnen/formulieren/label/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor labels in een formulier
 

--- a/docs/richtlijnen/formulieren/link/1-above-field/README.mdx
+++ b/docs/richtlijnen/formulieren/link/1-above-field/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/link/2-not-in-label/README.mdx
+++ b/docs/richtlijnen/formulieren/link/2-not-in-label/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/link/3-in-new-tab/README.mdx
+++ b/docs/richtlijnen/formulieren/link/3-in-new-tab/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/link/README.mdx
+++ b/docs/richtlijnen/formulieren/link/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor links in een formulier
 

--- a/docs/richtlijnen/formulieren/multistep/1-step-count/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/1-step-count/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/multistep/2-location/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/2-location/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/multistep/3-consistency/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/3-consistency/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/multistep/4-last-check/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/4-last-check/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/multistep/5-timing/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/5-timing/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/multistep/README.mdx
+++ b/docs/richtlijnen/formulieren/multistep/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor meerdere stappen in een formulier
 

--- a/docs/richtlijnen/formulieren/placeholder/1-label/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/1-label/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/placeholder/2-search/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/2-search/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/placeholder/3-clarity/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/3-clarity/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/placeholder/4-colour-contrast/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/4-colour-contrast/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/placeholder/README.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor placeholders in een formulier
 

--- a/docs/richtlijnen/formulieren/questions/1-why/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/1-why/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/questions/2-needed/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/2-needed/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/questions/3-contact/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/3-contact/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/4-avoid-duplicate-work/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/questions/5-min-max/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/5-min-max/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/questions/README.mdx
+++ b/docs/richtlijnen/formulieren/questions/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor uit te vragen informatie in een formulier
 

--- a/docs/richtlijnen/formulieren/status/1-screenreaders/README.mdx
+++ b/docs/richtlijnen/formulieren/status/1-screenreaders/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/status/2-zoomed-in/README.mdx
+++ b/docs/richtlijnen/formulieren/status/2-zoomed-in/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
+++ b/docs/richtlijnen/formulieren/status/3-enough-time/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/status/README.mdx
+++ b/docs/richtlijnen/formulieren/status/README.mdx
@@ -17,8 +17,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor statusberichten in een formulier
 

--- a/docs/richtlijnen/formulieren/visual-design/1-field-contrast/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/1-field-contrast/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/visual-design/2-text-contrast/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/2-text-contrast/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/visual-design/4-focus-visible/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/4-focus-visible/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/visual-design/5-field-size/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/5-field-size/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/visual-design/6-use-of-color/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/6-use-of-color/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/visual-design/7-no-image-buttons/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/7-no-image-buttons/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/visual-design/8-order/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/8-order/README.mdx
@@ -15,8 +15,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <FooterInfo />

--- a/docs/richtlijnen/formulieren/visual-design/README.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor het visueel ontwerp van een formulier
 

--- a/docs/richtlijnen/formulieren/when-which/1-compat/README.mdx
+++ b/docs/richtlijnen/formulieren/when-which/1-compat/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/when-which/2-usability/README.mdx
+++ b/docs/richtlijnen/formulieren/when-which/2-usability/README.mdx
@@ -15,9 +15,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/formulieren/when-which/README.mdx
+++ b/docs/richtlijnen/formulieren/when-which/README.mdx
@@ -16,9 +16,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { FragmentRedirect } from "@site/src/components/FragmentRedirect";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor wanneer je welk formulierelement gebruikt
 

--- a/docs/richtlijnen/stijl/README.mdx
+++ b/docs/richtlijnen/stijl/README.mdx
@@ -14,8 +14,8 @@ keywords:
   - typografie
 ---
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Introductie richtlijnen NL Design System voor stijl
 

--- a/docs/richtlijnen/stijl/colour/1-contrast-text/README.mdx
+++ b/docs/richtlijnen/stijl/colour/1-contrast-text/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg voor voldoende kleurcontrast voor tekst tegen de achtergrond
 

--- a/docs/richtlijnen/stijl/colour/2-contrast-non-text/README.mdx
+++ b/docs/richtlijnen/stijl/colour/2-contrast-non-text/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg voor voldoende kleurcontrast voor niet-tekstuele content
 

--- a/docs/richtlijnen/stijl/colour/3-purpose/README.mdx
+++ b/docs/richtlijnen/stijl/colour/3-purpose/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Gebruik kleur met een doel
 

--- a/docs/richtlijnen/stijl/colour/4-dont-trust/README.mdx
+++ b/docs/richtlijnen/stijl/colour/4-dont-trust/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Vertrouw niet alleen op kleur
 

--- a/docs/richtlijnen/stijl/colour/5-perception/README.mdx
+++ b/docs/richtlijnen/stijl/colour/5-perception/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Let op verschillen in waarneming van kleur
 

--- a/docs/richtlijnen/stijl/colour/6-settings/README.mdx
+++ b/docs/richtlijnen/stijl/colour/6-settings/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Let op voorkeursinstellingen voor kleur
 

--- a/docs/richtlijnen/stijl/colour/README.mdx
+++ b/docs/richtlijnen/stijl/colour/README.mdx
@@ -14,8 +14,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor kleuren
 

--- a/docs/richtlijnen/stijl/icons/1-functional/README.mdx
+++ b/docs/richtlijnen/stijl/icons/1-functional/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Maak functionele iconen simpel van vorm
 

--- a/docs/richtlijnen/stijl/icons/2-toptasks/README.mdx
+++ b/docs/richtlijnen/stijl/icons/2-toptasks/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Toptaak iconen kunnen gedetailleerd zijn
 

--- a/docs/richtlijnen/stijl/icons/3-position/README.mdx
+++ b/docs/richtlijnen/stijl/icons/3-position/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Positioneer iconen binnen een vierkant grid
 

--- a/docs/richtlijnen/stijl/icons/4-size/README.mdx
+++ b/docs/richtlijnen/stijl/icons/4-size/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Stem de grootte van je iconen af op je lettergrootte
 

--- a/docs/richtlijnen/stijl/icons/5-line-width/README.mdx
+++ b/docs/richtlijnen/stijl/icons/5-line-width/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Laat de lijndikte meeschalen
 

--- a/docs/richtlijnen/stijl/icons/6-colour-contrast/README.mdx
+++ b/docs/richtlijnen/stijl/icons/6-colour-contrast/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg ook bij iconen voor voldoende contrast
 

--- a/docs/richtlijnen/stijl/icons/7-conventions/README.mdx
+++ b/docs/richtlijnen/stijl/icons/7-conventions/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Respecteer conventies
 

--- a/docs/richtlijnen/stijl/icons/8-svg/README.mdx
+++ b/docs/richtlijnen/stijl/icons/8-svg/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Gebruik SVG voor iconen en geen font
 

--- a/docs/richtlijnen/stijl/icons/README.mdx
+++ b/docs/richtlijnen/stijl/icons/README.mdx
@@ -13,8 +13,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor iconen
 

--- a/docs/richtlijnen/stijl/space/1-spacing-scale/README.mdx
+++ b/docs/richtlijnen/stijl/space/1-spacing-scale/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Maak gebruik van een spacing scale
 

--- a/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
+++ b/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Werk en denk vanuit het box model
 

--- a/docs/richtlijnen/stijl/space/3-spacing-concepts/README.mdx
+++ b/docs/richtlijnen/stijl/space/3-spacing-concepts/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Maak gebruik van de spacing concepten
 

--- a/docs/richtlijnen/stijl/space/4-relations/README.mdx
+++ b/docs/richtlijnen/stijl/space/4-relations/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Gebruik ruimte om relaties te creëren tussen elementen
 

--- a/docs/richtlijnen/stijl/space/5-hierarchie/README.mdx
+++ b/docs/richtlijnen/stijl/space/5-hierarchie/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Gebruik ruimte om hiërarchie te creëren tussen elementen
 

--- a/docs/richtlijnen/stijl/space/6-function/README.mdx
+++ b/docs/richtlijnen/stijl/space/6-function/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Stem het gebruik van ruimte af op de functie en inhoud van de dienst
 

--- a/docs/richtlijnen/stijl/space/7-interactive/README.mdx
+++ b/docs/richtlijnen/stijl/space/7-interactive/README.mdx
@@ -13,9 +13,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Reserveer ruimte tussen interactieve elementen
 

--- a/docs/richtlijnen/stijl/space/README.mdx
+++ b/docs/richtlijnen/stijl/space/README.mdx
@@ -13,8 +13,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor ruimte
 

--- a/docs/richtlijnen/stijl/typography/1-fontsize/README.mdx
+++ b/docs/richtlijnen/stijl/typography/1-fontsize/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg ervoor dat letters groot genoeg zijn
 

--- a/docs/richtlijnen/stijl/typography/2-line-spacing/README.mdx
+++ b/docs/richtlijnen/stijl/typography/2-line-spacing/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg voor een comfortabele regelafstand
 

--- a/docs/richtlijnen/stijl/typography/3-line-length/README.mdx
+++ b/docs/richtlijnen/stijl/typography/3-line-length/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Zorg voor een comfortabele regellengte
 

--- a/docs/richtlijnen/stijl/typography/4-font/README.mdx
+++ b/docs/richtlijnen/stijl/typography/4-font/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Kies een goed lettertype
 

--- a/docs/richtlijnen/stijl/typography/5-markup/README.mdx
+++ b/docs/richtlijnen/stijl/typography/5-markup/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Gebruik betekenisvolle opmaak voor tekst
 

--- a/docs/richtlijnen/stijl/typography/6-settings/README.mdx
+++ b/docs/richtlijnen/stijl/typography/6-settings/README.mdx
@@ -12,9 +12,9 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Let op voorkeursinstellingen voor typografie
 

--- a/docs/richtlijnen/stijl/typography/README.mdx
+++ b/docs/richtlijnen/stijl/typography/README.mdx
@@ -13,8 +13,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
-import FooterInfo from "/docs/richtlijnen/_footer_info.md";
 
 # Richtlijnen NL Design System voor typografie
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@fontsource/open-sans": "5.1.0",
     "@fontsource/source-sans-pro": "5.1.0",
     "@mdx-js/react": "3.0.1",
+    "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "1.0.0-alpha.151",
     "@nl-design-system/component-progress": "1.0.1-alpha.78",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@mdx-js/react':
         specifier: 3.0.1
         version: 3.0.1(@types/react@18.2.55)(react@18.3.1)
+      '@nl-design-system-unstable/documentation':
+        specifier: workspace:*
+        version: link:docs
       '@nl-design-system-unstable/nlds-design-tokens':
         specifier: workspace:*
         version: link:packages/nlds-design-tokens


### PR DESCRIPTION
this will help with rendering the documentation pages without relying on Docusaurus directly