### PR TITLE
refactor: avoid default imports in MDX

### DIFF
--- a/docs/community/events/community-bijeenkomst-2.mdx
+++ b/docs/community/events/community-bijeenkomst-2.mdx
@@ -6,7 +6,7 @@ unlisted: true
 slug: /events/communitybijeenkomst-18-10-2024
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Communitybijeenkomst
 

--- a/docs/community/events/design-open-dag.mdx
+++ b/docs/community/events/design-open-dag.mdx
@@ -7,7 +7,7 @@ pagination_label: Tijdens de Design Open Dag komen designers bij elkaar om samen
 slug: /events/design-open-dag
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Design Open Dag
 

--- a/docs/community/events/design-open-hour/aanmelden.mdx
+++ b/docs/community/events/design-open-hour/aanmelden.mdx
@@ -7,7 +7,7 @@ pagination_label: In de Design Open Hour wisselen designers informatie, inzichte
 slug: /events/design-open-hour/aanmelden
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Meld je aan voor de Design Open Hour
 

--- a/docs/community/events/design-systems-week-2023/1-programma.md
+++ b/docs/community/events/design-systems-week-2023/1-programma.md
@@ -7,7 +7,7 @@ pagination_label: Programma
 slug: /events/design-systems-week-2023/programma
 ---
 
-import DSWSession from "@site/src/components/DSWSession";
+import { DSWSession } from "@site/src/components/DSWSession";
 import speakers from "./speakers.json";
 import { Link } from '@utrecht/component-library-react/dist/css-module';
 

--- a/docs/community/events/design-systems-week-2023/english/1-program.md
+++ b/docs/community/events/design-systems-week-2023/english/1-program.md
@@ -8,7 +8,7 @@ pagination_label: Program
 slug: /events/design-systems-week-2023/en/program
 ---
 
-import DSWSession from '@site/src/components/DSWSession'
+import { DSWSession } from '@site/src/components/DSWSession'
 import speakers from '../speakers.json'
 import { Link, Paragraph } from '@utrecht/component-library-react/dist/css-module';
 

--- a/docs/community/events/design-systems-week-2024/english/program.mdx
+++ b/docs/community/events/design-systems-week-2024/english/program.mdx
@@ -10,7 +10,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 ---
 
 import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
-import DSWSession from "../../../../../src/components/DSWSession";
+import { DSWSession } from "@site/src/components/DSWSession";
 import sessions from "../sessions.json";
 import speakers from "../speakers.json";
 

--- a/docs/community/events/design-systems-week-2024/programma.mdx
+++ b/docs/community/events/design-systems-week-2024/programma.mdx
@@ -12,7 +12,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
 import sessions from "./sessions.json";
 import speakers from "./speakers.json";
-import DSWSession from "../../../../src/components/DSWSession";
+import { DSWSession } from "@site/src/components/DSWSession";
 
 # Programma Design Systems Week 2024
 

--- a/docs/community/events/design-systems-week/aanmelden.mdx
+++ b/docs/community/events/design-systems-week/aanmelden.mdx
@@ -7,7 +7,7 @@ pagination_label: Meld je aan voor Design Systems Week
 slug: /events/design-systems-week/aanmelden
 ---
 
-import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Meld je aan voor Design Systems Week 2024
 

--- a/docs/community/events/design-systems-week/sign-up.mdx
+++ b/docs/community/events/design-systems-week/sign-up.mdx
@@ -7,7 +7,7 @@ pagination_label: Sign up for Design Systems Week
 slug: /events/design-systems-week/sign-up
 ---
 
-import NewsletterSignUp from "../../../../src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Sign up for Design Systems Week 2024
 

--- a/docs/community/events/developer-open-hour/aanmelden.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden.mdx
@@ -7,7 +7,7 @@ pagination_label: In het Developer Open Hour wisselen developers informatie, inz
 slug: /events/developer-open-hour/aanmelden
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Meld je aan voor het Developer Open Hour
 

--- a/docs/community/events/estafettemodeldag.mdx
+++ b/docs/community/events/estafettemodeldag.mdx
@@ -7,7 +7,7 @@ pagination_label: In het Design Open Hour wisselen designers informatie, inzicht
 slug: /community/events/estafettemodeldag
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Estafettemodeldag
 

--- a/docs/community/events/heartbeat/aanmelden.mdx
+++ b/docs/community/events/heartbeat/aanmelden.mdx
@@ -7,7 +7,7 @@ pagination_label: 2 wekelijkse updates van het kernteam en community
 slug: /events/heartbeat/aanmelden
 ---
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Meld je aan voor de Heartbeat
 

--- a/docs/community/sluit-je-aan.mdx
+++ b/docs/community/sluit-je-aan.mdx
@@ -11,7 +11,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 De NL Design System community brengt specialisten bij elkaar, zoals designers, developers, researchers en toegankelijkheidsspecialisten. Samen met het [kernteam](/project/kernteam) verzamelt de community de beste richtlijnen, componenten en voorbeelden om robuuste websites en webapplicaties voor de digitale overheid te bouwen.
 

--- a/docs/project/blijf-op-de-hoogte.mdx
+++ b/docs/project/blijf-op-de-hoogte.mdx
@@ -13,7 +13,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import NewsletterSignUp from "@site/src/components/NewsletterSignUp";
+import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
 
 # Op de hoogte blijven
 

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -128,5 +128,3 @@ export const DSWSession = ({
     )}
   </article>
 );
-
-export default DSWSession;

--- a/src/components/NewsletterSignUp.tsx
+++ b/src/components/NewsletterSignUp.tsx
@@ -224,5 +224,3 @@ export const NewsletterSignUp = ({
     </form>
   );
 };
-
-export default NewsletterSignUp;


### PR DESCRIPTION
Default imports appear to cause various issues, depending on the mdx processor