### PR TITLE
docs: clarify the description for community events

### DIFF
--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design Open Hour
 pagination_label: In de Design Open Hour wisselen designers informatie, inzichten en tips met elkaar uit.
-description: Wat is Design Open Hour?
+description: Wat is Design Open Hour, hoe meld ik mij aan, en op welke momenten is het?
 slug: /events/design-open-hour
 ---
 

--- a/docs/community/events/developer-open-hour/developer-open-hour.mdx
+++ b/docs/community/events/developer-open-hour/developer-open-hour.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Developer Open Hour
 pagination_label: In het Developer Open Hour wisselen developers informatie, inzichten en tips met elkaar uit.
-description: Wat is Developer Open Hour?
+description: Wat is Developer Open Hour, hoe meld ik mij aan, en op welke momenten is het?
 slug: /events/developer-open-hour
 ---
 

--- a/docs/community/events/heartbeat/heartbeat.mdx
+++ b/docs/community/events/heartbeat/heartbeat.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Heartbeat
 pagination_label: 2 wekelijkse updates van het kernteam en community
-description: Wat is de Heartbeat?
+description: Wat is de Heartbeat, hoe meld ik mij aan, en op welke momenten is het?
 slug: /events/heartbeat
 ---
 


### PR DESCRIPTION
this way the links posted in Slack will have a more effective description

before:

<img width="596" alt="Screenshot 2024-12-05 at 08 53 41" src="https://github.com/user-attachments/assets/7b191ebc-a04d-4f53-8b30-d02c308ca449">
