### PR TITLE
Add anatomy + aliases for Heading, Link, Mark and Skip Link

### DIFF
--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -10,6 +10,7 @@ slug: /heading
 
 {/* @license CC0-1.0 */}
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
+import HeadingIllustration from "@nl-design-system-candidate/heading-docs/docs/anatomy/anatomy.svg";
 import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_intro.md";
 import Wcag131 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.3.1-heading.md';
 import Wcag1412 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-1.4.12.md';
@@ -18,6 +19,8 @@ import Wcag144 from '@nl-design-system-unstable/documentation/componenten/ac/\_w
 import Wcag246 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-2.4.6-heading.md';
 import Wcag312 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-3.1.2.md';
 import Wcag411 from '@nl-design-system-unstable/documentation/componenten/ac/\_wcag-4.1.1-heading.md';
+import { ComponentAliases } from "@site/src/components/ComponentAliases";
+import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
 DefinitionOfDone,
@@ -34,6 +37,12 @@ export const issueNumber = 114;
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
+
+<ComponentAliases component={component} />
+
+## Anatomie
+
+<ComponentAnatomy component={component} illustration={HeadingIllustration} />
 
 ## Definition of Done
 

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -12,6 +12,7 @@ slug: /link
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import LinkIllustration from "@nl-design-system-candidate/link-docs/docs/anatomy/anatomy.svg";
 import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-link.md";
 import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-link.md";
 import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
@@ -30,6 +31,8 @@ import Wcag145 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.
 import Wcag212 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.1.2-summary.md";
 import Wcag2411 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.11-summary.md";
 import Wcag244 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.4-summary.md";
+import { ComponentAliases } from "@site/src/components/ComponentAliases";
+import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -46,6 +49,12 @@ export const issueNumber = 118;
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
+
+<ComponentAliases component={component} />
+
+## Anatomie
+
+<ComponentAnatomy component={component} illustration={LinkIllustration} />
 
 ## Definition of Done
 

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -15,6 +15,7 @@ keywords:
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import MarkIllustration from "@nl-design-system-candidate/mark-docs/docs/anatomy/anatomy.svg";
 import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-mark.md";
 import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-mark.md";
 import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
@@ -22,6 +23,8 @@ import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wc
 import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
 import Wcag312 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-3.1.2.md";
 import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
+import { ComponentAliases } from "@site/src/components/ComponentAliases";
+import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -38,6 +41,12 @@ export const issueNumber = 333;
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
+
+<ComponentAliases component={component} />
+
+## Anatomie
+
+<ComponentAnatomy component={component} illustration={MarkIllustration} />
 
 ## Definition of Done
 

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -12,6 +12,7 @@ slug: /skip-link
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
+import SkipLinkIllustration from "@nl-design-system-candidate/skip-link-docs/docs/anatomy/anatomy.svg";
 import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
 import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
@@ -33,6 +34,8 @@ import Wcag243 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.
 import Wcag244 from "@nl-design-system-unstable/documentation/wcag/summaries/_2.4.4-summary.md";
 import Wcag321 from "@nl-design-system-unstable/documentation/wcag/summaries/_3.2.1-summary.md";
 import Wcag323 from "@nl-design-system-unstable/documentation/wcag/summaries/_3.2.3-summary.md";
+import { ComponentAliases } from "@site/src/components/ComponentAliases";
+import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
 import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
@@ -49,6 +52,12 @@ export const issueNumber = 74;
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
+
+<ComponentAliases component={component} />
+
+## Anatomie
+
+<ComponentAnatomy component={component} illustration={SkipLinkIllustration} />
 
 ## Definition of Done
 


### PR DESCRIPTION
Adds anatomy + aliases for heading, link, mark and skip link.

Not for number badge ([not public yet](https://github.com/nl-design-system/candidate/blob/main/packages/docs/number-badge-docs/package.json#L23), [PR pending](https://github.com/nl-design-system/candidate/pull/343)), paragraph (paths are not consistent with the others, see [same PR](https://github.com/nl-design-system/candidate/pull/343)) or heading 1 t/m 6 (we haven't added their anatomy, aliases yet; added in [PR 344](https://github.com/nl-design-system/candidate/pull/344)).