### PR TITLE
docs: update community stappenplan

### DIFF
--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -32,7 +32,7 @@ Doel: Het wordt duidelijk naar welk community component is gekeken.
 
 Selecteer naar welk organisatiebord je hebt gekeken voor de Definition of Done van 'Community' status.
 
-**🚩 Checkpoint**: Welke bord
+**🚩 Checkpoint**: Welk bord
 
 ## Beschikbaar in CSS
 
@@ -40,9 +40,9 @@ Doel: De component kan ingezet worden in een framework naar keuze.
 
 De component moet beschikbaar zijn in code. Minimaal als HTML/CSS.
 
-Tenminste één organisatie heeft zijn `GitHub URL (CSS)` ingevuld. Bekijk hiervoor de [Communityborden](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+community+components).
+Check of de gekozen organisatie hieraan voldoet. Dit doe je door de component te bekijken via de 'GitHub URL (CSS)' die in het Communitybord is ingevuld.
 
-De GitHub omgeving moet te bekijken zijn zonder te hoeven inloggen.
+De GitHub omgeving moet te bekijken zijn zonder dat je moet inloggen.
 
 **🚩 Checkpoint**: GitHub (CSS)
 
@@ -52,9 +52,7 @@ Doel: Men kan de component vinden, bekijken, gebruiken, forken en verbeteren.
 
 De component moet publiek beschikbaar zijn in Storybook.
 
-Plaats de component in de Storybook omgeving van jouw organisatie. Of controleer de Storybook omgevingen van organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
-
-Tenminste één organisatie heeft zijn `Storybook URL (CSS)` ingevuld. Bekijk hiervoor de [Communityborden](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+community+components).
+Check of de gekozen organisatie hieraan voldoet. Dit doe je door de component te bekijken via de 'Storybook URL (CSS)' die in het Communitybord is ingevuld.
 
 De Storybook omgeving moet te bekijken zijn zonder te hoeven inloggen.
 
@@ -64,11 +62,11 @@ De Storybook omgeving moet te bekijken zijn zonder te hoeven inloggen.
 
 Doel: De component is de component dat we als kernteam verwachten.
 
-In de GitHub Discussion van de component staan de naam en de beschrijving genoteerd. Check of de implementatie van de gekozen organisatie hieraan voldoet. Dit doe je door de component te bekijken via de Storybook URL die in het Communitybord is ingevuld.
+In de GitHub Discussion van de component staan de naam en de beschrijving genoteerd. Check of de implementatie van de gekozen organisatie hieraan voldoet. Dit doe je door de component te bekijken via de 'Storybook URL (CSS)' die in het Communitybord is ingevuld.
 
 Vervolgens heb je twee opties:
 
-- Komt de naam van de component overeen met de naam uit de Github Discussion? Dan selecteer je 'Done'.
+- Komt de naam van de component overeen met de naam uit de GitHub Discussion? Dan selecteer je 'Done'.
 - Komt de naam niet overeen maar voldoet de implementatie verder wel? Dan selecteer je 'Done met Alias'.
 
 **Tip!** Met implementatie bedoelen we bijvoorbeeld `utrecht-button` of `ams-button`. Een specifiek type van een implementatie, bijvoorbeeld `zonnedael-sparkly-button`, noemen we een variant.
@@ -81,9 +79,11 @@ Doel: Meerdere organisaties kunnen de component naar hun huisstijl omzetten.
 
 Door met [design tokens](/handboek/design-tokens/) te werken zorgen we ervoor dat meerdere organisaties de component van een eigen huisstijl kunnen voorzien. Minimaal zouden er design tokens beschikbaar moeten zijn om kleur en typografie beslissingen door te voeren.
 
-Zorg ervoor dat de component van jouw organisatie gebruik maakt van design tokens. Of controleer de implementaties van organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Check of de implementatie van de gekozen organisatie hieraan voldoet. Dit doe je door de component te bekijken via de 'Storybook URL (CSS)' die in het Communitybord is ingevuld.
 
 **Tip!** Om te controleren of er design tokens zijn toegepast kun je gebruik maken van de 'Inspect' functionaliteit van je browser. Wanneer je in de CSS verwijzingen ziet naar CSS variabelen zoals bijvoorbeeld `--denhaag-button-primary-action-background-color` of `--ams-button-font-family` kun je er vanuit gaan dat er design tokens zijn gebruikt.
+
+**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan een design tokens voor font-family bij de componenten Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
 
 **🚩 Checkpoint**: Minimale design tokens
 
@@ -93,11 +93,11 @@ Doel: Organisaties kunnen componenten naast elkaar gebruiken zonder dat deze met
 
 Om componenten van elkaar te kunnen gebruiken is het toevoegen van een prefix zoals bijvoorbeeld `utrecht-` of `ams-` verplicht.
 
-Zorg ervoor dat de prefix van jouw organisatie is toegevoegd aan onderstaande onderdelen. Of controleer de organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Check of de prefix van de gekozen organisatie is toegevoegd aan onderstaande onderdelen:
 
 - CSS class selectors.
-- Design tokens in JSON.
 - CSS variables.
+- Design tokens in JSON.
 
 **🚩 Checkpoint**: Prefix
 
@@ -107,7 +107,7 @@ Doel: Een voorspelbare naamgeving van design tokens.
 
 Voor NL Design System zijn er afspraken gemaakt voor duidelijke en voorspelbare namen. De beschikbare design tokens van een component moeten voldoen aan [de naamgeving conventie van NL Design System](https://www.nldesignsystem.nl/handboek/design-tokens/#naamgeving). Zo is een component herbruikbaar voor alle verschillende thema's.
 
-Zorg ervoor dat de design tokens van de component van jouw organisatie voldoen aan de naamgeving conventie. Of controleer de implementaties van organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Check of de implementatie van de gekozen organisatie hieraan voldoet.
 
 **🚩 Checkpoint**: Naamgeving design tokens
 
@@ -117,7 +117,7 @@ Doel: De component mag door andere organisaties gebruikt worden. Producten die e
 
 Binnen het NL Design System werken we voor componenten met de [Openbare Licentie van de Europese Unie (EUPL-1.2)](https://nldesignsystem.nl/open-source/eupl/).
 
-Zorg ervoor dat jouw organisatie naar de EUPL-1.2 licentie verwijst op de onderstaande posities. Of controleer de organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Check of de gekozen organisatie naar de EUPL-1.2 licentie verwijst op de onderstaande posities:
 
 - **GitHub repository**: Als één van de repository details onder 'About' in de sidebar.
 - **Package in npm**: Onder 'License' in de sidebar.
@@ -132,7 +132,7 @@ Doel: De documentatie van een component mag door andere organisaties hergebruikt
 
 Binnen het NL Design System werken we voor de documentatie met de [Creative Commons 0 licentie (CC0)](https://nldesignsystem.nl/open-source/cc0).
 
-Zorg ervoor dat jouw organisatie de CC0 licentie benoemt in het README.md bestand van de component in GitHub. Of controleer de organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Check of de gekozen organisatie de CC0 licentie benoemt in het README.md bestand van de component in GitHub.
 
 **Tip!** Door de 'Code' of 'Raw' weergave van het README.md bestand te bekijken zou je bovenaan `<!-- @license CC0-1.0 -->` moeten zien staan.
 
@@ -142,9 +142,7 @@ Zorg ervoor dat jouw organisatie de CC0 licentie benoemt in het README.md bestan
 
 Doel: De component wordt beter vindbaar voor andere organisaties en kan makkelijk worden voorzien van een eigen thema.
 
-[Neem contact op met het kernteam](/project/kernteam) om deze stap uit te voeren.
-
-Het kernteam maakt de component beschikbaar in de ['Themes' repository](https://github.com/nl-design-system/themes), waardoor deze terug te vinden is in de [Storybook met alle NL Design System thema's](https://nl-design-system.github.io/themes/). Andere organisaties kunnen vervolgens de component gaan gebruiken.
+Als kernteam maken we de component beschikbaar in de ['Themes' repository](https://github.com/nl-design-system/themes), waardoor deze terug te vinden is in de [Storybook met alle NL Design System thema's](https://nl-design-system.github.io/themes/). Andere organisaties kunnen de component vervolgens gaan gebruiken.
 
 **🚩 Checkpoint**: Storybook thema's
 
@@ -161,28 +159,16 @@ Doel: De component wordt voorzien van het Voorbeeld thema, en organisaties worde
 
 Doel: De component wordt beschikbaar in de [NL Design System Figma bibliotheek](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=450-4121&t=AKzhgDPYAKNI1gaT-1). Designers van andere organisaties kunnen de component overnemen en gaan gebruiken.
 
-[Neem contact op met het kernteam](/project/kernteam) om deze stap uit te voeren.
-
-Het kernteam neemt de component over uit de Figma omgeving van jouw organisatie, inclusief bijbehorende design tokens, en plaatst deze in de NL Design System Figma bibliotheek. Daarbij wordt de component voorzien van het Voorbeeld thema. Als er geen Figma component is, dan ontwikkelt het kernteam dit zelf.
+- Als kernteam nemen we de component over uit de Figma omgeving van de gekozen organisatie. Inclusief bijbehorende design tokens. We plaatsen de component in de NL Design System Figma bibliotheek. Daarbij wordt de component voorzien van het Voorbeeld thema.
+- Heeft de gekozen organisatie geen Figma component? Dan ontwikkelen we deze als kernteam zelf.
 
 Organisaties die de NL Design System Figma bibliotheek vanaf dat moment dupliceren, krijgen de component direct meegeleverd. Organisaties die de NL Design System Figma bibliotheek al hadden gedupliceerd, worden tijdens de volgende 'Bieb sync video' geïnformeerd over hoe ze dit component ook kunnen overnemen.
 
-Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page). Kun je dat niet doen, vraag dan iemand met edit rechten om de URL.
+- Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page).
+- Plak de URL in de kolom 'Figma URL' van het [Community projectbord](https://github.com/orgs/nl-design-system/projects/29/views/1).
+- Had de gekozen organisatie zelf geen Figma component? Plak de URL dan óók in het projectbord voor deze organisatie.
 
 **🚩 Checkpoint**: Figma URL
-
-## Informatie van de component beschikbaar op nldesignsystem.nl
-
-Doel: Op nldesignsystem.nl zijn er verwijzingen beschikbaar naar de component met het Voorbeeld thema.
-
-Het kernteam maakt de laatste informatie van de GitHub projectborden beschikbaar in het npm pakketje `@nl-design-system/component-progress`.
-
-- Publiceer een nieuwe versie van het `component-progress` package door op `Run Workflow` te klikken op [GitHub Actions van de Index repository](https://github.com/nl-design-system/index/actions/workflows/update-component-progress.yml). Kies hierbij voor de `main` branch.
-- Wacht tot [component-progress op npm](https://www.npmjs.com/package/@nl-design-system/component-progress) is bijgewerkt. Dat zie je door naar `Last publish` te kijken.
-- Update `@nl-design-system/component-progress` in de documentatie repository. Dat doe je door lokaal in een nieuwe branch `pnpm install @nl-design-system/component-progress@latest --save-dev -w` te draaien. Dit update de devDependency en de lockfile.
-- Push je branch naar GitHub en maak er een pull request voor aan.
-
-**🚩 Checkpoint**: nldesignsystem.nl
 
 ## Beschikbaar in de NL Design System Component assessment (Figma)
 
@@ -190,7 +176,7 @@ Doel: Organisaties worden bij een onboarding snel naar de juiste component verwe
 
 Het kernteam voegt een 'Component sticker' toe aan het Figma bestand '[NL Design System Component assessment](https://www.figma.com/design/NLbNbckFo9manEihRFeJmR/NL-Design-System---Component-Assessment?m=auto&t=J0gWvRWoyCJhSqot-6)'. Deze sticker linkt naar de documentatiepagina van de component op nldesignsystem.nl.
 
-Door deze 'Component stickers' op screenshots te plakken, kan het kernteam geïnteresseerde organisaties inzicht bieden welke componenten beschikbaar zijn om hun website of applicatie mee op te bouwen.
+Door deze 'Component stickers' op screenshots te plakken, kunnen we geïnteresseerde organisaties inzicht bieden welke componenten beschikbaar zijn om hun website of applicatie mee op te bouwen.
 
 **🚩 Checkpoint**: Component assessment
 
@@ -198,11 +184,9 @@ Door deze 'Component stickers' op screenshots te plakken, kan het kernteam geïn
 
 Doel: iedereen kan zien dat de component nu richting Candidate wil.
 
-Deze stap kan enkel worden uitgevoerd door het kernteam.
-
-- Verander het 'Help Wanted' label van het backlog issue naar 'Community'.
-- Verander het 'Help Wanted' label van de GitHub Discussion naar 'Community'.
-- Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door op `Component: {naam-component}` te zoeken.
+- Verander het 'Community' label van het backlog issue naar 'Candidate'.
+- Verander het 'Community' label van de GitHub Discussion naar 'Candidate'.
+- Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door op `{naam-component}` te zoeken.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.
 
@@ -213,63 +197,99 @@ Help je mee hem door de Candidate stappen te krijgen?
 [{naam-component} op het Candidate bord]({url-candidate-bord})
 ```
 
-**🚩 Checkpoint**: Status naar Community
+**🚩 Checkpoint**: Status
+
+## Over promotie
+
+Zet het checkpoint 'Promotie' op 'Done' vóór de promotie heeft plaats gevonden. Dit doen we omdat de de status 'Community' alleen zichtbaar is nadat alle checkpoint zijn behaald.
+
+**🚩 Checkpoint**: Promotie
+
+## Informatie van de component bijgewerkt op nldesignsystem.nl
+
+Doel: Op nldesignsystem.nl wordt de meest recente informatie van de component beschikbaar.
+
+- Open de [documentatie repository](https://github.com/nl-design-system/documentatie) in Visual Studio Code.
+- Maak een nieuwe branch aan gebruik hiervoor de volgende naam:
+
+**Branch**
+
+```
+build/update-component-progress-{datum-of-versienummer}
+```
+
+- Publiceer een nieuwe versie van het `component-progress` package door op `Run Workflow` te klikken in [GitHub Actions van de Index repository](https://github.com/nl-design-system/index/actions/workflows/update-component-progress.yml). Kies hierbij voor de `main` branch.
+- Wacht tot [component-progress op npm](https://www.npmjs.com/package/@nl-design-system/component-progress) is bijgewerkt. Je kunt dit controleren door te kijken naar de datum bij `Last publish`.
+- Update `@nl-design-system/component-progress` in de documentatie repository. Dat doe je door lokaal in de branch `pnpm install @nl-design-system/component-progress@latest --save-dev -w` te draaien. Dit update de devDependency en de lockfile.
+- Maak een commit en gebruik hierbij het volgende bericht:
+
+**Commit Message**
+
+```
+build: update component progress {versienummer}
+```
+
+- Publiceer je branch naar GitHub om een pull request (PR) aan te maken.
+- Ga naar GitHub en gebruik de volgende opzet voor je PR:
+
+**Title**
+
+```
+build: update component progress {versienummer}
+```
+
+**Description**
+
+```
+This PR will update the component progress to version {versienummer}.
+```
+
+- Klik op 'Create Pull Request'
+- Geef een developer uit het kernteam via Slack een seintje dat de PR klaar staat.
+
+**🚩 Checkpoint**: nldesignsystem.nl
 
 ## Gebruik van component uit de community gepromoot
 
 Doel: Credits geven aan mensen die hebben bijgedragen vanuit de community. De rest van community informeren en enthousiasmeren om ook naar Community, Candidate en Hall of Fame toe te werken.
 
-Deze stap kan enkel worden uitgevoerd door het kernteam.
+- Voeg het '📣 Promotion' label toe aan het backlog issue.
+- Selecteer bij ‘Projects’ het project 'Communicatie & PR'.
 
-- Voeg de component toe aan het `Communicatie & PR` project. Zo wordt hij meegenomen in de volgende Heartbeat, Nieuwsbrief en op LinkedIn
-- We zetten het checkpoint op Done vóór de promotie echt is gedaan, omdat de component pas na die statusaanpassing dan als “Community” op de website staat.
+### Communityleden selecteren voor credits
 
-**🚩 Checkpoint**: Promotie
-
-## Website geupdate met nieuwe status
-
-- [@nl-design-system/component-progress](https://www.npmjs.com/package/@nl-design-system/component-progress) updaten met [GitHub action](https://github.com/nl-design-system/index/actions/workflows/update-component-progress.yml).
-- Maak een Pull Request in de documentatie repository met de geupdate index: `pnpm install --save-dev @nl-design-system/component-progress@latest`
+Het kernteam selecteert communityleden om credits aan uit te delen. Denk bijvoorbeeld aan de maintainer van Storybook en de betrokken designer. Dat kan door activiteit in de Discussion te zien of naar commits te kijken in de code van het community component.
 
 ### Slack
 
-- Zeg het volgende in #nl-design-system.
+Plaats dit bericht in #nl-design-system, vul aan waar nodig.
 
 ```md
 ✨ {naam-component} is nu Community ✨
 
-[Bekijk {naam-component}]({link-naar-component-op-nldesignsystem.nl}): {beschrijving van de component}
+Met dank aan {persoon/personen} van {organisatie} is {naam-component} beschikbaar in de Community!
 
-Help ons de component naar Candidate te brengen door ons in de [GitHub Discussion voor de {naam-component} component]({link-naar-discussion}) te laten weten waar je het gebruikt.
-```
+[Bekijk {naam-component}]({url-nldesignsystem.nl}): {beschrijving-component}
 
-### Communityleden selecteren voor credits
-
-Het kernteam selecteert communityleden om credits aan uit te delen. Denk bijvoorbeeld aan de maintainer van Storybook en de betrokken designer. Dat kan door activiteit in de Discussion te zien en naar commits te kijken in de code van het community component.
-
-### Nieuwe status bevestigen met credit
-
-Plaats na het selecteren een comment in het issue voor dit component. Meld dat de component nu Community status heeft en bedank de betrokkenen, bijvoorbeeld:
-
-```md
-Met dank aan {persoon/personen} van {organisatie} is {component} nu beschikbaar in de Community!
-
-[Bekijk {naam-component} op nldesignsystem.nl]({link-naar-component-op-nldesignsystem.nl})
+Help je mee {naam-component} naar Candidate te brengen? Dat doe je bijvoorbeeld door ons in de [GitHub Discussion voor de {naam-component} component]({url-github-discussion}) te laten weten waar je {naam-component} component gebruikt.
 ```
 
 ### Heartbeat, Nieuwsbrief en LinkedIn
 
-Het kernteam benadert de organisatie die de component heeft ontwikkeld. We vragen of zij de component tijdens een Heartbeat willen presenteren. Mocht dit niet mogelijk zijn doen wij dit als kernteam zelf.
+Vanuit het kernteam benaderen we de organisatie die de component heeft ontwikkeld. We vragen of zij de component tijdens een Heartbeat willen presenteren. Mocht dit niet mogelijk zijn doen wij dit als kernteam zelf.
 
-Daarnaast plaatsen we een bericht in de nieuwsbrief en op LinkedIn. Daarin nemen we de volgende elementen in op:
+Daarnaast plaatsen we een bericht in de nieuwsbrief en op LinkedIn.
 
-- Link naar component op nldesignsystem.nl.
-- Link naar GitHub Discussion.
-- Credits.
-- Eventueel in combinatie met een kort interview.
+Promoties hoeven niet altijd dezelfde vorm aan te houden. Gebruik onderstaande punten als voorzet:
 
-De updates in de Heartbeat, nieuwsbrief en op LinkedIn kunnen worden gecombineerd als er meerdere componenten van status veranderen.
+- Naam van de component.
+- Beschrijving van de component.
+- URL van de component op nldesignsystem.nl
+- URL van de GitHub Discussion.
+- Credits: persoon/personen van organisatie, eventueel in combinatie met een kort interview.
+
+Promoties kunnen gecombineerd worden als er meerdere componenten van status veranderen.
 
 ## 🏁 Finish
 
-Zo wat een werk! Je hebt alle stappen genomen en je hebt alle checkpoints kunnen afvinken die nodig zijn voor de ['Community' status](https://github.com/orgs/nl-design-system/projects/29/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). De component gaat nu door voor de 'Candidate' status.
+Zo wat een werk! Je hebt alle stappen genomen en zo alle checkpoints behaald die nodig zijn voor de ['Community' status](https://github.com/orgs/nl-design-system/projects/29/views/1) van het [Estafettemodel](https://www.nldesignsystem.nl/componenten/definition-of-done). De component gaat nu door voor de 'Candidate' status.

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -83,7 +83,7 @@ Check of de implementatie van de gekozen organisatie hieraan voldoet. Dit doe je
 
 **Tip!** Om te controleren of er design tokens zijn toegepast kun je gebruik maken van de 'Inspect' functionaliteit van je browser. Wanneer je in de CSS verwijzingen ziet naar CSS variabelen zoals bijvoorbeeld `--denhaag-button-primary-action-background-color` of `--ams-button-font-family` kun je er vanuit gaan dat er design tokens zijn gebruikt.
 
-**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan een design tokens voor font-family bij de componenten Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
+**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan design tokens voor font-family bij componenten zoals Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
 
 **🚩 Checkpoint**: Minimale design tokens
 
@@ -93,7 +93,7 @@ Doel: Organisaties kunnen componenten naast elkaar gebruiken zonder dat deze met
 
 Om componenten van elkaar te kunnen gebruiken is het toevoegen van een prefix zoals bijvoorbeeld `utrecht-` of `ams-` verplicht.
 
-Check of de prefix van de gekozen organisatie is toegevoegd aan onderstaande onderdelen:
+Check of de prefix van de gekozen organisatie is toegevoegd aan de onderstaande onderdelen:
 
 - CSS class selectors.
 - CSS variables.
@@ -142,7 +142,7 @@ Check of de gekozen organisatie de CC0 licentie benoemt in het README.md bestand
 
 Doel: De component wordt beter vindbaar voor andere organisaties en kan makkelijk worden voorzien van een eigen thema.
 
-Als kernteam maken we de component beschikbaar in de ['Themes' repository](https://github.com/nl-design-system/themes), waardoor deze terug te vinden is in de [Storybook met alle NL Design System thema's](https://nl-design-system.github.io/themes/). Andere organisaties kunnen de component vervolgens gaan gebruiken.
+Als kernteam maken we de component beschikbaar in de ['Themes' repository](https://github.com/nl-design-system/themes), zodat deze terug te vinden is in de [Storybook met alle NL Design System thema's](https://nl-design-system.github.io/themes/). Andere organisaties kunnen de component vervolgens gebruiken.
 
 **🚩 Checkpoint**: Storybook thema's
 
@@ -159,12 +159,12 @@ Doel: De component wordt voorzien van het Voorbeeld thema, en organisaties worde
 
 Doel: De component wordt beschikbaar in de [NL Design System Figma bibliotheek](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=450-4121&t=AKzhgDPYAKNI1gaT-1). Designers van andere organisaties kunnen de component overnemen en gaan gebruiken.
 
-- Als kernteam nemen we de component over uit de Figma omgeving van de gekozen organisatie. Inclusief bijbehorende design tokens. We plaatsen de component in de NL Design System Figma bibliotheek. Daarbij wordt de component voorzien van het Voorbeeld thema.
+- Als kernteam nemen we de component over uit de Figma omgeving van de gekozen organisatie, inclusief de bijbehorende design tokens. We plaatsen de component in de NL Design System Figma bibliotheek en voorzien deze van het Voorbeeld thema.
 - Heeft de gekozen organisatie geen Figma component? Dan ontwikkelen we deze als kernteam zelf.
 
 Organisaties die de NL Design System Figma bibliotheek vanaf dat moment dupliceren, krijgen de component direct meegeleverd. Organisaties die de NL Design System Figma bibliotheek al hadden gedupliceerd, worden tijdens de volgende 'Bieb sync video' geïnformeerd over hoe ze dit component ook kunnen overnemen.
 
-- Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page).
+- Kopieer de URL van de componentpagina door in Figma met de rechtermuisknop op de component in de sidebar te klikken en 'Copy link to page' te selecteren.
 - Plak de URL in de kolom 'Figma URL' van het [Community projectbord](https://github.com/orgs/nl-design-system/projects/29/views/1).
 - Had de gekozen organisatie zelf geen Figma component? Plak de URL dan óók in het projectbord voor deze organisatie.
 
@@ -184,9 +184,9 @@ Door deze 'Component stickers' op screenshots te plakken, kunnen we geïnteresse
 
 Doel: iedereen kan zien dat de component nu richting Candidate wil.
 
-- Verander het 'Community' label van het backlog issue naar 'Candidate'.
-- Verander het 'Community' label van de GitHub Discussion naar 'Candidate'.
-- Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door op `{naam-component}` te zoeken.
+- Verander het label 'Community' van het backlog issue naar 'Candidate'.
+- Verander het label 'Community' van de GitHub Discussion naar 'Candidate'.
+- Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door te zoeken op `{naam-component}`.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.
 
@@ -201,7 +201,7 @@ Help je mee hem door de Candidate stappen te krijgen?
 
 ## Over promotie
 
-Zet het checkpoint 'Promotie' op 'Done' vóór de promotie heeft plaats gevonden. Dit doen we omdat de de status 'Community' alleen zichtbaar is nadat alle checkpoint zijn behaald.
+Zet het checkpoint 'Promotie' op 'Done' vóór de promotie heeft plaatsgevonden. Dit doen we omdat de status 'Community' pas zichtbaar wordt nadat alle checkpoint zijn behaald.
 
 **🚩 Checkpoint**: Promotie
 
@@ -210,7 +210,7 @@ Zet het checkpoint 'Promotie' op 'Done' vóór de promotie heeft plaats gevonden
 Doel: Op nldesignsystem.nl wordt de meest recente informatie van de component beschikbaar.
 
 - Open de [documentatie repository](https://github.com/nl-design-system/documentatie) in Visual Studio Code.
-- Maak een nieuwe branch aan gebruik hiervoor de volgende naam:
+- Maak een nieuwe branch aan en gebruik de volgende naam:
 
 **Branch**
 
@@ -253,21 +253,21 @@ This PR will update the component progress to version {versienummer}.
 
 Doel: Credits geven aan mensen die hebben bijgedragen vanuit de community. De rest van community informeren en enthousiasmeren om ook naar Community, Candidate en Hall of Fame toe te werken.
 
-- Voeg het '📣 Promotion' label toe aan het backlog issue.
+- Voeg het label '📣 Promotion' toe aan het backlog issue.
 - Selecteer bij ‘Projects’ het project 'Communicatie & PR'.
 
 ### Communityleden selecteren voor credits
 
-Het kernteam selecteert communityleden om credits aan uit te delen. Denk bijvoorbeeld aan de maintainer van Storybook en de betrokken designer. Dat kan door activiteit in de Discussion te zien of naar commits te kijken in de code van het community component.
+Het kernteam selecteert communityleden om credits toe te kennen. Dit kan bijvoorbeeld de maintainer van Storybook zijn of de betrokken designer. Activiteit in de Discussion of commits in de code van het community component kunnen hierbij als basis dienen.
 
 ### Slack
 
-Plaats dit bericht in #nl-design-system, vul aan waar nodig.
+Plaats dit bericht in #nl-design-system en vul het aan waar nodig.
 
 ```md
 ✨ {naam-component} is nu Community ✨
 
-Met dank aan {persoon/personen} van {organisatie} is {naam-component} beschikbaar in de Community!
+Met dank aan {persoon/personen} van {organisatie} is {naam-component} nu beschikbaar in de Community!
 
 [Bekijk {naam-component}]({url-nldesignsystem.nl}): {beschrijving-component}
 
@@ -276,7 +276,7 @@ Help je mee {naam-component} naar Candidate te brengen? Dat doe je bijvoorbeeld 
 
 ### Heartbeat, Nieuwsbrief en LinkedIn
 
-Vanuit het kernteam benaderen we de organisatie die de component heeft ontwikkeld. We vragen of zij de component tijdens een Heartbeat willen presenteren. Mocht dit niet mogelijk zijn doen wij dit als kernteam zelf.
+Vanuit het kernteam benaderen we de organisatie die de component heeft ontwikkeld. We vragen of zij de component tijdens een Heartbeat willen presenteren. Als dit niet mogelijk is, nemen wij als kernteam deze taak op ons.
 
 Daarnaast plaatsen we een bericht in de nieuwsbrief en op LinkedIn.
 
@@ -286,9 +286,9 @@ Promoties hoeven niet altijd dezelfde vorm aan te houden. Gebruik onderstaande p
 - Beschrijving van de component.
 - URL van de component op nldesignsystem.nl
 - URL van de GitHub Discussion.
-- Credits: persoon/personen van organisatie, eventueel in combinatie met een kort interview.
+- Credits: persoon/personen van organisatie, eventueel gecombineerd met een kort interview.
 
-Promoties kunnen gecombineerd worden als er meerdere componenten van status veranderen.
+Promoties kunnen ook gecombineerd worden wanneer meerdere componenten van status veranderen.
 
 ## 🏁 Finish
 

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -184,8 +184,8 @@ Door deze 'Component stickers' op screenshots te plakken, kunnen we geïnteresse
 
 Doel: iedereen kan zien dat de component nu richting Candidate wil.
 
-- Verander het label 'Community' van het backlog issue naar 'Candidate'.
-- Verander het label 'Community' van de GitHub Discussion naar 'Candidate'.
+- Verander het label 'Help Wanted' van het backlog issue naar 'Community'.
+- Verander het label 'Help Wanted' van de GitHub Discussion naar 'Community'.
 - Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door te zoeken op `{naam-component}`.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
@@ -22,12 +22,12 @@ Als je als organisatie een component wilt bijdragen aan NL Design System kun je 
 
 ## Voeg de component toe aan de componenten bord
 
-Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebruik door andere teams. Door de status van de component en de documentatie beschikbaar te maken kunnen organisaties de component op nldesignsystem.nl vinden. Het kernteam kan de component dan de Community status geven.
+Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebruik door andere teams. Door de status van de component en de bijbehorende documentatie beschikbaar te stellen, kunnen andere organisaties de component vinden op nldesignsystem.nl. Het kernteam kan de component dan de 'Community' status geven.
 
-1. Open het community bord via [Community Componenten bord op GitHub](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+Community+Componenten).
+1. Open het Communitybord via [Community Componenten bord op GitHub](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+Community+Componenten).
 2. Klik op de + icoon links onderaan de pagina om een component toe te voegen.
 3. Kies `Add item from repository`.
-4. Selecteer `backlog` en zoek op de component naam.
+4. Selecteer `backlog` en zoek op de naam van de component.
 5. Selecteer de component.
 6. Kies rechts onderin `Add selected items`.
 
@@ -45,7 +45,7 @@ Vul de prefix van de organisatie in, bijvoorbeeld `utrecht-` of `ams-`.
 
 Doel: Bij implementaties van de component op nldesignsystem.nl/componenten willen we de naam van de component in de component bibliotheek laten zien zodat developers en designers hem makkelijk kunnen vinden.
 
-Vul de naam van het css component in, bijvoorbeeld `{prefix-organisatie}-{naam-component}`.
+Vul de naam van het CSS component in, bijvoorbeeld `{prefix-organisatie}-{naam-component}`.
 
 **🚩 Checkpoint**: Naam
 
@@ -57,9 +57,9 @@ Door met [design tokens](/handboek/design-tokens/) te werken zorgen we ervoor da
 
 Zorg ervoor dat de component gebruik maakt van de minimale design tokens.
 
-**Tip!** Om te controleren of er design tokens zijn toegepast kun je gebruik maken van de 'Inspect' functionaliteit van je browser. Wanneer je in de CSS verwijzingen ziet naar CSS variabelen zoals bijvoorbeeld `--{prefix-organisatie}-button-primary-action-background-color` of `--{prefix-organisatie}-button-font-family` kun je er vanuit gaan dat er design tokens zijn gebruikt.
+**Tip!** Om te controleren of er design tokens zijn toegepast, kun je  de 'Inspect' functie in je browser gebruiken. Wanneer je in de CSS verwijzingen ziet naar CSS-variabelen zoals bijvoorbeeld `--{prefix-organisatie}-button-primary-action-background-color` of `--{prefix-organisatie}-button-font-family` kun je ervan uitgaan dat er design tokens zijn gebruikt.
 
-**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan een design tokens voor font-family bij de componenten Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
+**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan design tokens voor font-family bij componenten zoals Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
 
 **🚩 Checkpoint**: Minimale design tokens
 
@@ -69,7 +69,7 @@ Doel: Een voorspelbare naamgeving van design tokens.
 
 Voor NL Design System zijn er afspraken gemaakt voor duidelijke en voorspelbare namen. De beschikbare design tokens van een component moeten voldoen aan [de naamgeving conventie van NL Design System](https://www.nldesignsystem.nl/handboek/design-tokens/#naamgeving). Zo is een component herbruikbaar voor alle verschillende thema's.
 
-Zorg ervoor dat de design tokens voldoen aan de naamgeving conventie.
+Zorg ervoor dat de design tokens voldoen aan de naamgevingsconventie.
 
 **🚩 Checkpoint**: Naamgeving design tokens
 
@@ -104,7 +104,7 @@ Zorg ervoor dat de organisatie de CC0 licentie benoemt in het README.md bestand 
 
 Doel: Designers van andere organisaties kunnen de component overnemen en gaan gebruiken. De URL wordt zichtbaar op nldesignsystem.nl bij de documentatie van de component.
 
-Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page).
+Kopieer de URL van de componentpagina door in Figma met de rechtermuisknop op de component in de sidebar te klikken en 'Copy link to page' te selecteren.
 
 **🚩 Checkpoint**: Figma URL
 
@@ -134,9 +134,9 @@ Doel: Organisaties die de component gebruiken kunnen zien of de huisstijl uit ee
 
 1. Clone de http://github.com/nl-design-system/themes repository.
 2. Zorg dat je [pnpm](https://pnpm.io) hebt geinstalleerd.
-3. Installeer de dependencies van de repository met `pnpm install`.
-4. Zorg dat de design tokens beschikbaar zijn voor Storybook met `pnpm run build`.
-5. Draai Storybook met `pnpm run storybook`.
+3. Installeer de dependencies van de repository met het commando: `pnpm install`.
+4. Maak de design tokens beschikbaar voor Storybook door `pnpm run build` uit te voeren.
+5. Draai Storybook met: `pnpm run storybook`.
 
 ### Voeg de story toe aan de `Components` sectie in Storybook
 
@@ -146,7 +146,7 @@ Doel: makkelijk maken voor developers om de component te vinden in de themes Sto
 
 1. Ga naar `packages/storybook/voorbeeld-design-tokens`.
 2. Maak een mapje aan voor de component met de naam zoals beschreven bij NL Design System, of open het bestaande mapje om een component van een extra organisatie toe te voegen.
-3. Maak een nieuw bestand `{prefix-organisatie}-{naam-component}.stories.tsx`.
+3. Maak een nieuw bestand aan met de naam  `{prefix-organisatie}-{naam-component}.stories.tsx`.
 
 #### Voeg de component toe aan de story
 
@@ -189,7 +189,7 @@ Doel: makkelijk maken voor organisaties die de component hergebruiken om huissti
 #### Voeg organisatie toe aan de theme-toolkit
 
 **Tip!**
-Is er al een bestand `packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx`? Ga dan door naar de volgende sectie "Voeg een component toe".
+Is er al een bestand genaamd `packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx` aanwezig? Ga in dat geval direct verder met de volgende sectie: "Voeg een component toe".
 
 ```tsx
 // packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx
@@ -263,7 +263,7 @@ Doel: alle teams kunnen nu zien dat de component beschikbaar is voor hergebruik 
 
 Zet checkpoint 'Status' op 'Available'.
 
-Breng de community en het kernteam op de hoogte via Slack. De component kan dan door het kernteam of op een volgende Estafettemodeldag Candidate worden gemaakt.
+Breng de community en het kernteam op de hoogte via Slack. De component kan daarna door het kernteam of tijdens een volgende Estafettemodeldag 'Candidate' worden gemaakt.
 
 ```md
 ## 🎉 {naam-component} is nu beschikbaar bij {organisatie} 🎉

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
@@ -253,7 +253,7 @@ Zorg dat de component beschikbaar komt met een Pull Request op GitHub en vraag h
 Doel: Developers kunnen de code zien en suggesties doen voor verbeteringen. Dit helpt het samenwerken aan toegankelijke en gebruiksvriendelijke componenten die voor iedereen bruikbaar zijn.
 
 - Ga in GitHub naar de CSS van de component toe en kopieer de URL.
-- Vul deze URL in.
+- Plak deze URL in het juiste veld.
 
 **🚩 Checkpoint**: GitHub URL (CSS)
 

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
@@ -22,14 +22,14 @@ Als je als organisatie een component wilt bijdragen aan NL Design System kun je 
 
 ## Voeg de component toe aan de componenten bord
 
-Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebruik door andere teams. Door de status van de component en de documentatie beschikbaar te maken kunnen organisaties de component op nldesignsystem.nl vinden en kan het kernteam de component de Community status geven.
+Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebruik door andere teams. Door de status van de component en de documentatie beschikbaar te maken kunnen organisaties de component op nldesignsystem.nl vinden. Het kernteam kan de component dan de Community status geven.
 
-1. Open het community bord via [Community Componenten bord op GitHub](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+Community+Componenten)
-2. Klik op de + icoon links onderaan de pagina om een component toe te voegen
-3. Kies `Add item from repository`
-4. Selecteer `backlog` en zoek op de component naam
-5. Selecteer de component
-6. Kies rechts onderin `Add selected items`
+1. Open het community bord via [Community Componenten bord op GitHub](https://github.com/orgs/nl-design-system/projects?query=is%3Aopen+Community+Componenten).
+2. Klik op de + icoon links onderaan de pagina om een component toe te voegen.
+3. Kies `Add item from repository`.
+4. Selecteer `backlog` en zoek op de component naam.
+5. Selecteer de component.
+6. Kies rechts onderin `Add selected items`.
 
 **🚩 Checkpoint**: Title
 
@@ -37,7 +37,7 @@ Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebru
 
 Doel: Om een component de status Community te geven is het belangrijk dat API's zoals design tokens de prefix van de verantwoordelijke organisatie hebben. Deze kolom is dus voor iedere component van de organisatie hetzelfde.
 
-Vul de prefix van de organisatie in
+Vul de prefix van de organisatie in, bijvoorbeeld `utrecht-` of `ams-`.
 
 **🚩 Checkpoint**: Organisatie prefix
 
@@ -45,7 +45,7 @@ Vul de prefix van de organisatie in
 
 Doel: Bij implementaties van de component op nldesignsystem.nl/componenten willen we de naam van de component in de component bibliotheek laten zien zodat developers en designers hem makkelijk kunnen vinden.
 
-Vul de naam van het css component in, dus bijvoorbeeld `{organisatie-prefix}-{component-naam}`
+Vul de naam van het css component in, bijvoorbeeld `{prefix-organisatie}-{naam-component}`.
 
 **🚩 Checkpoint**: Naam
 
@@ -55,9 +55,11 @@ Doel: Meerdere organisaties kunnen de component naar hun huisstijl omzetten.
 
 Door met [design tokens](/handboek/design-tokens/) te werken zorgen we ervoor dat meerdere organisaties de component van een eigen huisstijl kunnen voorzien. Minimaal zouden er design tokens beschikbaar moeten zijn om kleur en typografie beslissingen door te voeren.
 
-Zorg ervoor dat de component van jouw organisatie gebruik maakt van design tokens. Of controleer de implementaties van organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Zorg ervoor dat de component gebruik maakt van de minimale design tokens.
 
-**Tip!** Om te controleren of er design tokens zijn toegepast kun je gebruik maken van de 'Inspect' functionaliteit van je browser. Wanneer je in de CSS verwijzingen ziet naar CSS variabelen zoals bijvoorbeeld `--{organisatie-prefix}-button-primary-action-background-color` of `--{organisatie-prefix}-button-font-family` kun je er vanuit gaan dat er design tokens zijn gebruikt.
+**Tip!** Om te controleren of er design tokens zijn toegepast kun je gebruik maken van de 'Inspect' functionaliteit van je browser. Wanneer je in de CSS verwijzingen ziet naar CSS variabelen zoals bijvoorbeeld `--{prefix-organisatie}-button-primary-action-background-color` of `--{prefix-organisatie}-button-font-family` kun je er vanuit gaan dat er design tokens zijn gebruikt.
+
+**Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan een design tokens voor font-family bij de componenten Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
 
 **🚩 Checkpoint**: Minimale design tokens
 
@@ -67,7 +69,7 @@ Doel: Een voorspelbare naamgeving van design tokens.
 
 Voor NL Design System zijn er afspraken gemaakt voor duidelijke en voorspelbare namen. De beschikbare design tokens van een component moeten voldoen aan [de naamgeving conventie van NL Design System](https://www.nldesignsystem.nl/handboek/design-tokens/#naamgeving). Zo is een component herbruikbaar voor alle verschillende thema's.
 
-Zorg ervoor dat de design tokens van de component van jouw organisatie voldoen aan de naamgeving conventie. Of controleer de implementaties van organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Zorg ervoor dat de design tokens voldoen aan de naamgeving conventie.
 
 **🚩 Checkpoint**: Naamgeving design tokens
 
@@ -77,7 +79,7 @@ Doel: De component mag door andere organisaties gebruikt worden. Producten die e
 
 Binnen het NL Design System werken we voor componenten met de [Openbare Licentie van de Europese Unie (EUPL-1.2)](https://nldesignsystem.nl/open-source/eupl/).
 
-Zorg ervoor dat de organisatie naar de EUPL-1.2 licentie verwijst op de onderstaande posities. Of controleer de organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Zorg ervoor dat de organisatie naar de EUPL-1.2 licentie verwijst op de onderstaande posities:
 
 - **GitHub repository**: Als één van de repository details onder 'About' in de sidebar.
 - **Package in npm**: Onder 'License' in de sidebar.
@@ -92,7 +94,7 @@ Doel: De documentatie van een component mag door andere organisaties hergebruikt
 
 Binnen het NL Design System werken we voor de documentatie met de [Creative Commons 0 licentie (CC0)](https://nldesignsystem.nl/open-source/cc0).
 
-Zorg ervoor dat de organisatie de CC0 licentie benoemt in het README.md bestand van de component in GitHub. Of controleer de organisaties die aan de GitHub Discussion van de component zijn toegevoegd.
+Zorg ervoor dat de organisatie de CC0 licentie benoemt in het README.md bestand van de component in GitHub.
 
 **Tip!** Door de 'Code' of 'Raw' weergave van het README.md bestand te bekijken zou je bovenaan `<!-- @license CC0-1.0 -->` moeten zien staan.
 
@@ -102,7 +104,7 @@ Zorg ervoor dat de organisatie de CC0 licentie benoemt in het README.md bestand 
 
 Doel: Designers van andere organisaties kunnen de component overnemen en gaan gebruiken. De URL wordt zichtbaar op nldesignsystem.nl bij de documentatie van de component.
 
-Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page). Kun je dat niet doen, vraag dan iemand met edit rechten om de URL.
+Kopieer de URL van de component pagina door in Figma met rechtermuisknop op de component in de sidebar te klikken (Copy link to page).
 
 **🚩 Checkpoint**: Figma URL
 
@@ -112,7 +114,7 @@ Doel: Developers kunnen de component installeren. De URL wordt zichtbaar op nlde
 
 Vul de https://www.npmjs.com URL van het css component in. Is er geen losse package voor de component en is deze onderdeel van een css bibliotheek? Vul dan de url van de bibliotheek in.
 
-Note: Is de component alleen beschikbaar in React? Dan kan deze stap helaas niet worden gechecked.
+**Let op!** Is de component alleen beschikbaar in React? Dan kan deze stap helaas niet worden gechecked.
 
 **🚩 Checkpoint**: NPM URL (CSS)
 
@@ -130,11 +132,11 @@ Is er alleen een React Storybook? Zorg dan dat een codevoorbeeld van CSS beschik
 
 Doel: Organisaties die de component gebruiken kunnen zien of de huisstijl uit een eigen thema goed wordt toegepast. Nu, maar ook bij nieuwe versies van de component bibliotheek.
 
-1. Clone de http://github.com/nl-design-system/themes repository
-2. Zorg dat je [pnpm](https://pnpm.io) hebt geinstalleerd
-3. Installeer de dependencies van de repository met `pnpm install`
-4. Zorg dat de design tokens beschikbaar zijn voor Storybook met `pnpm run build`
-5. Draai Storybook met `pnpm run storybook`
+1. Clone de http://github.com/nl-design-system/themes repository.
+2. Zorg dat je [pnpm](https://pnpm.io) hebt geinstalleerd.
+3. Installeer de dependencies van de repository met `pnpm install`.
+4. Zorg dat de design tokens beschikbaar zijn voor Storybook met `pnpm run build`.
+5. Draai Storybook met `pnpm run storybook`.
 
 ### Voeg de story toe aan de `Components` sectie in Storybook
 
@@ -142,19 +144,19 @@ Doel: makkelijk maken voor developers om de component te vinden in de themes Sto
 
 #### Maak een story bestand aan
 
-1. Ga naar `packages/storybook/voorbeeld-design-tokens`
-2. Maak een mapje aan voor de component met de naam zoals beschreven bij NL Design System, of open het bestaande mapje om een component van een extra organisatie toe te voegen
-3. Maak een nieuw bestand `{organisatie-prefix}-{component-naam}.stories.tsx`
+1. Ga naar `packages/storybook/voorbeeld-design-tokens`.
+2. Maak een mapje aan voor de component met de naam zoals beschreven bij NL Design System, of open het bestaande mapje om een component van een extra organisatie toe te voegen.
+3. Maak een nieuw bestand `{prefix-organisatie}-{naam-component}.stories.tsx`.
 
 #### Voeg de component toe aan de story
 
 ```tsx
-// packages/storybook/voorbeeld-design-tokens/{component-naam}/{organisatie-prefix}-{component-naam}.stories.tsx
+// packages/storybook/voorbeeld-design-tokens/{naam-component}/{prefix-organisatie}-{naam-component}.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
 import { ComponentNaam } from "organisatie-package";
 
 const meta = {
-  id: "{organisatie-prefix}-{component-naam}",
+  id: "{prefix-organisatie}-{naam-component}",
   title: "Components/{Component Naam}/{Organisatie Naam}",
   component: ComponentNaam,
   parameters: { actions: { disable: true } },
@@ -176,7 +178,7 @@ export const VoorbeeldTheme: Story = {
 // Een story met het thema van de organisatie die de component bijdraagt
 export const OrganisatieNaamTheme: Story = {
   name: "{Organisatie naam} theme",
-  parameters: { theme: "{organisatie-prefix}-theme" },
+  parameters: { theme: "{prefix-organisatie}-theme" },
 };
 ```
 
@@ -186,18 +188,19 @@ Doel: makkelijk maken voor organisaties die de component hergebruiken om huissti
 
 #### Voeg organisatie toe aan de theme-toolkit
 
-Tip: Is er al een bestand `packages/theme-toolkit/src/component-stories-{organisatie-prefix}.tsx`? Ga dan door naar de volgende sectie "Voeg een component toe"
+**Tip!**
+Is er al een bestand `packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx`? Ga dan door naar de volgende sectie "Voeg een component toe".
 
 ```tsx
-// packages/theme-toolkit/src/component-stories-{organisatie-prefix}.tsx
+// packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx
 import { STORY_GROUPS } from "./component-stories-util";
 import { ComponentName } from "{react-component-library-package}";
 
 export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
   {
     // De id die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
-    storyId: "react-{organisatie-prefix}-{component}--default",
-    component: "{organisatie-prefix}-{component-naam}",
+    storyId: "react-{prefix-organisatie}-{component}--default",
+    component: "{prefix-organisatie}-{naam-component}",
     // Optioneel: Kies een van de opties van STORY_GROUPS
     group: STORY_GROUPS[],
     name: "{Naam van de organisatie} {Naam van de component}",
@@ -212,7 +215,7 @@ export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
 In de array van stories kun je stories toevoegen voor de component. In ieder geval een `default` story, maar mogelijk ook stories voor de diverse states of varianten van de component waar losse design beslissingen over genomen kunnen worden.
 
 ```tsx
-// packages/theme-toolkit/src/component-stories-{organisatie-prefix}.tsx
+// packages/theme-toolkit/src/component-stories-{prefix-organisatie}.tsx
 
 // De lijst van stories voor alle componenten
 export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
@@ -220,7 +223,7 @@ export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
     // De id die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
     storyId:
       "{type component, nu alleen nog react}-{organisatie prefix}-{component naam}--{story naam, bijvoorbeel default, naam-van-de-variant of naam-van-de-state}",
-    component: "{organisatie-prefix}-{component-naam}",
+    component: "{prefix-organisatie}-{naam-component}",
     group: "Optioneel, gebruik hier een van de opties uit STORY_GROUPS",
     name: "{Naam van de organisatie} {Naam van de component}",
     // De render functie om de component als story te renderen met properties en children zoals nodig als voorbeeld.
@@ -231,13 +234,13 @@ export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
 
 #### Voeg de component toe aan een config toe
 
-1. Open de config.json van het thema van de organisatie
-2. Voeg de id van de story of stories toe aan `"stories": []`
+1. Open de config.json van het thema van de organisatie.
+2. Voeg de id van de story of stories toe aan `"stories": []`.
 
 Optioneel: voeg het component ook toe aan het voorbeeld thema
 
-1. Open de config.json van het Voorbeeld thema `packages/voorbeeld-design-tokens/src/config.json`
-2. Voeg de id van de story of stories toe aan `"stories": []`
+1. Open de config.json van het Voorbeeld thema `packages/voorbeeld-design-tokens/src/config.json`.
+2. Voeg de id van de story of stories toe aan `"stories": []`.
 
 ### Maak een Pull Request
 
@@ -249,8 +252,8 @@ Zorg dat de component beschikbaar komt met een Pull Request op GitHub en vraag h
 
 Doel: Developers kunnen de code zien en suggesties doen voor verbeteringen. Dit helpt het samenwerken aan toegankelijke en gebruiksvriendelijke componenten die voor iedereen bruikbaar zijn.
 
-Ga in GitHub naar de CSS van de component toe en kopieer de URL.
-Vul deze URL in.
+- Ga in GitHub naar de CSS van de component toe en kopieer de URL.
+- Vul deze URL in.
 
 **🚩 Checkpoint**: GitHub URL (CSS)
 
@@ -258,15 +261,25 @@ Vul deze URL in.
 
 Doel: alle teams kunnen nu zien dat de component beschikbaar is voor hergebruik door andere organsaties.
 
-Is de component nog geen Candidate? Breng de community en het kernteam dan op de hoogte via Slack. De component kan dan door het kernteam of op een volgende Estafettemodeldag Candidate worden gemaakt.
+Zet checkpoint 'Status' op 'Available'.
+
+Breng de community en het kernteam op de hoogte via Slack. De component kan dan door het kernteam of op een volgende Estafettemodeldag Candidate worden gemaakt.
 
 ```md
-## 🎉 {Component naam} is nu beschikbaar bij {Naam Organisatie} 🎉
+## 🎉 {naam-component} is nu beschikbaar bij {organisatie} 🎉
 
 📣 Kernteam: Helpen jullie mee de component Community te maken?
 ```
 
-**🚩 Checkpoint**: Status naar Available
+Heeft de component al de status 'Community'? Plaats dan het volgende bericht:
+
+```md
+## 🎉 {naam-component} is nu beschikbaar bij {organisatie} 🎉
+
+Wat is er nieuw? {beschrijf hier wat er anders is aan deze implementatie ten opzichte van andere community componenten}
+```
+
+**🚩 Checkpoint**: Status
 
 ## Heb je een vraag?
 

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
@@ -37,7 +37,7 @@ Doel: als organisatie wil je dit component graag beschikbaar maken voor hergebru
 
 Doel: Om een component de status Community te geven is het belangrijk dat API's zoals design tokens de prefix van de verantwoordelijke organisatie hebben. Deze kolom is dus voor iedere component van de organisatie hetzelfde.
 
-Vul de prefix van de organisatie in, bijvoorbeeld `utrecht-` of `ams-`.
+Vul de prefix van de organisatie in, bijvoorbeeld `utrecht` of `ams`.
 
 **🚩 Checkpoint**: Organisatie prefix
 

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-organisaties.mdx
@@ -57,7 +57,7 @@ Door met [design tokens](/handboek/design-tokens/) te werken zorgen we ervoor da
 
 Zorg ervoor dat de component gebruik maakt van de minimale design tokens.
 
-**Tip!** Om te controleren of er design tokens zijn toegepast, kun je  de 'Inspect' functie in je browser gebruiken. Wanneer je in de CSS verwijzingen ziet naar CSS-variabelen zoals bijvoorbeeld `--{prefix-organisatie}-button-primary-action-background-color` of `--{prefix-organisatie}-button-font-family` kun je ervan uitgaan dat er design tokens zijn gebruikt.
+**Tip!** Om te controleren of er design tokens zijn toegepast, kun je de 'Inspect' functie in je browser gebruiken. Wanneer je in de CSS verwijzingen ziet naar CSS-variabelen zoals bijvoorbeeld `--{prefix-organisatie}-button-primary-action-background-color` of `--{prefix-organisatie}-button-font-family` kun je ervan uitgaan dat er design tokens zijn gebruikt.
 
 **Tip!** Soms heeft een component geen specifieke design tokens nodig. Denk bijvoorbeeld aan design tokens voor font-family bij componenten zoals Mark of Icon. Gebruik in dit soort gevallen je gezonde verstand.
 
@@ -146,7 +146,7 @@ Doel: makkelijk maken voor developers om de component te vinden in de themes Sto
 
 1. Ga naar `packages/storybook/voorbeeld-design-tokens`.
 2. Maak een mapje aan voor de component met de naam zoals beschreven bij NL Design System, of open het bestaande mapje om een component van een extra organisatie toe te voegen.
-3. Maak een nieuw bestand aan met de naam  `{prefix-organisatie}-{naam-component}.stories.tsx`.
+3. Maak een nieuw bestand aan met de naam `{prefix-organisatie}-{naam-component}.stories.tsx`.
 
 #### Voeg de component toe aan de story
 
@@ -198,7 +198,7 @@ import { ComponentName } from "{react-component-library-package}";
 
 export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
   {
-    // De id die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
+    // De ID die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
     storyId: "react-{prefix-organisatie}-{component}--default",
     component: "{prefix-organisatie}-{naam-component}",
     // Optioneel: Kies een van de opties van STORY_GROUPS
@@ -220,7 +220,7 @@ In de array van stories kun je stories toevoegen voor de component. In ieder gev
 // De lijst van stories voor alle componenten
 export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
   ...{
-    // De id die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
+    // De ID die gebruikt wordt in de config.json van organisaties die de component willen gebruiken
     storyId:
       "{type component, nu alleen nog react}-{organisatie prefix}-{component naam}--{story naam, bijvoorbeel default, naam-van-de-variant of naam-van-de-state}",
     component: "{prefix-organisatie}-{naam-component}",
@@ -235,12 +235,12 @@ export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
 #### Voeg de component toe aan een config toe
 
 1. Open de config.json van het thema van de organisatie.
-2. Voeg de id van de story of stories toe aan `"stories": []`.
+2. Voeg de ID van de story of stories toe aan `"stories": []`.
 
 Optioneel: voeg het component ook toe aan het voorbeeld thema
 
 1. Open de config.json van het Voorbeeld thema `packages/voorbeeld-design-tokens/src/config.json`.
-2. Voeg de id van de story of stories toe aan `"stories": []`.
+2. Voeg de ID van de story of stories toe aan `"stories": []`.
 
 ### Maak een Pull Request
 

--- a/docs/handboek/component-bijdragen/definition-of-done.mdx
+++ b/docs/handboek/component-bijdragen/definition-of-done.mdx
@@ -75,12 +75,12 @@ Dit component bestaat in de community, op één of meer plekken. Om bij NL Desig
 - Beschikbaar in de [Storybook met alle NL Design System thema's](https://nl-design-system.github.io/themes/).
 - Visuele regressietests zijn beschikbaar in de Thema Storybook.
 - Beschikbaar in de NL Design System Figma bibliotheek.
-- Informatie van de component beschikbaar op nldesignsystem.nl.
 - Beschikbaar in de NL Design System Component assessment (Figma).
 
 #### 3. Kernteam zet component op Community
 
 - Status bijgewerkt naar Community.
+- Informatie van de component bijgewerkt op nldesignsystem.nl
 - Gebruik van component uit de community gepromoot.
 
 Bekijk de status op [het projectbord voor de Community componenten](https://github.com/orgs/nl-design-system/projects/29).


### PR DESCRIPTION
**Community Stappenplan voor kernteam**
- Opzet van schrijfwijze gelijk getrokken omdat dit het Community stappenplan voor het kernteam zelf betreft.
- Checkpoint 'nldesignsystem' gelijk getrokken met Help Wanted stappenplan.
- Checkpoint 'promotie' opgesplitst in verband met component progress.
- Fout in 'Status bijwerken' eruit.
- Dubbeling van component progress er uit.
- Tip over minimale tokens toegevoegd.
- Hier en daar kleine tweaks die mooi meegenomen waren.

**Definition of done**
- Heading uit Stappenplan gelijk getrokken met item in opsomming.
- Positie aangepast.

**Community Stappenplan voor community**
- Opzet van schrijfwijze gelijk getrokken omdat dit het Community stappenplan voor de community zelf betreft.
- Tip over minimale tokens toegevoegd.
- Hier en daar kleine tweaks die mooi meegenomen waren.