### PR TITLE
Zorg dat img role op svgs gezet door svgr

### DIFF
--- a/src/components/ComponentAnatomy.tsx
+++ b/src/components/ComponentAnatomy.tsx
@@ -9,7 +9,6 @@ import { AnatomyList, AnatomyListItem } from './AnatomyList';
 interface IllustrationProps {
   className?: string;
   height?: boolean;
-  role?: string;
 }
 
 interface ComponentAnatomyProps {
@@ -33,7 +32,7 @@ export const ComponentAnatomy = ({
     <Suspense fallback={null}>
       <figure className={clsx('component-anatomy')}>
         {AnatomyIllustration && (
-          <AnatomyIllustration role="img" height={null} className={clsx('component-anatomy__illustration')} />
+          <AnatomyIllustration height={null} className={clsx('component-anatomy__illustration')} />
         )}
         {AnatomyIllustration && AnatomyLegend && (
           <figcaption>

--- a/svgr.config.js
+++ b/svgr.config.js
@@ -1,0 +1,4 @@
+// .svgrrc.js
+module.exports = {
+  svgProps: { role: 'img' },
+};


### PR DESCRIPTION
Ik had de hoop bijna opgegeven, na svgr config te proberen te zetten via Docusaurus settings en plugins, tot @matijs op het idee kwam dat svgr de settings uit een los settinggbestandje misschien wel gewoon oppikt. En dat doet ie. Zo hoeven we niet meer de extra role toe te voegen.