### PR TITLE
docs: Bij acceptatiecriteria componenten word-break mogelijkheid vermelden bij reflow en herschalen

### DIFF
--- a/.changeset/ac-word-break.md
+++ b/.changeset/ac-word-break.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+Voegt optie voor word-break to aan de relevante acceptatiecriteria.

--- a/docs/componenten/ac/_wcag-1.4.12.md
+++ b/docs/componenten/ac/_wcag-1.4.12.md
@@ -4,6 +4,8 @@ Als je de tekstafstand vergroot blijft de tekst in zijn geheel zichtbaar. Dit ga
 
 Zorg ervoor dat het element mee kan groeien met de tekst. Geef de breedte en de hoogte dus niet hard op in pixels.
 
+Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.
+
 Je moet de afstand kunnen vergroten naar deze waardes:
 
 - Regelhoogte (regelafstand) naar ten minste 1,5 keer de lettergrootte;

--- a/docs/componenten/ac/_wcag-1.4.4.md
+++ b/docs/componenten/ac/_wcag-1.4.4.md
@@ -4,6 +4,8 @@ Als je de tekst vergroot tot 200% (via browserzoom en via de browserinstellingen
 
 Zorg ervoor dat het element mee kan groeien met de tekst. Geef de breedte en de hoogte dus niet hard op in pixels.
 
+Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.
+
 NL Design System richtlijnen:
 
 - [Let op voorkeursinstellingen voor typografie](/richtlijnen/stijl/typografie/voorkeur)

--- a/docs/wcag/summaries/_1.4.10-summary.md
+++ b/docs/wcag/summaries/_1.4.10-summary.md
@@ -7,3 +7,5 @@ Alle functies, zoals het menu, moeten werken en zichtbaar zijn. Alle tekst moet 
 Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of gedeeltelijk verborgen worden door andere inhoud wanneer de gebruiker 400% inzoomt of op een buitengewoon klein scherm werkt (320 bij 256 CSS).
 
 Zorg ervoor dat er geen horizontale scrollbar nodig is. Uitzonderingen zijn voor onderdelen die in essentie twee-dimensionaal zijn, zoals bijvoorbeeld: tabellen, grafieken, video's en landkaarten.
+
+Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.

--- a/docs/wcag/summaries/_1.4.12-summary.md
+++ b/docs/wcag/summaries/_1.4.12-summary.md
@@ -4,6 +4,8 @@ Tekst kan op een aantal manieren aangepast worden, door mensen voor wie dat pret
 
 Alle tekst moet leesbaar blijven. Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of maar gedeeltelijk zichtbaar zijn.
 
+Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.
+
 Het gaat om:
 
 - De ruimte tussen tekstregels kan relatief groot ingesteld worden, zodat de ruimte tussen tekstregels anderhalf keer groter is dan de hoogte van een tekstregel zelf.

--- a/docs/wcag/summaries/_1.4.4-summary.md
+++ b/docs/wcag/summaries/_1.4.4-summary.md
@@ -5,3 +5,5 @@ De gebruiker moet tekst twee keer (200%) kunnen vergroten. Het gaat hierbij **al
 Alle functies, zoals het menu, moeten werken en zichtbaar zijn. Alle tekst moet leesbaar zijn. Er mag geen inhoud buiten beeld vallen, verborgen zijn of maar gedeeltelijk zichtbaar zijn.
 
 Maak indien nodig een uitzondering voor de tekstgrootte instellen van tekst in afbeeldingen en van ondertitels in video's.
+
+Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.


### PR DESCRIPTION
Voor WCAG-SC [1.4.4 Herschalen van tekst](https://nldesignsystem.nl/wcag/1.4.4/), [1.4.10 Reflow](https://nldesignsystem.nl/wcag/1.4.10/) en [1.4.12 Tekstafstand](https://nldesignsystem.nl/wcag/1.4.12) moet het mogelijk zijn om lange woorden af te breken en te laten doorlopen op de volgende regel. Dit om een horizontale scrollbar te voorkomen.

Voorgestelde tekst:
Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.

Toevoegen bij de acceptatiecriteria van de componenten:

    componenten/ac/_wcag-1.4.4.md
    componenten/ac/_wcag-1.4.12.md

Toevoegen bij de summaries van de WCAG-pagina's:

    wcag/summaries/_1.4.4-summary.md
    wcag/summaries/_1.4.10-summary.md
    wcag/summaries/_1.4.12-summary.md

Gerelateerd issue: https://github.com/nl-design-system/documentatie/issues/1798
