### PR TITLE
Fix focus issue in component filter

### DIFF
--- a/src/components/ComponentOverview.tsx
+++ b/src/components/ComponentOverview.tsx
@@ -24,7 +24,7 @@ export const ComponentOverview = () => {
   };
 
   const category = useCurrentSidebarCategory();
-  const { location, push } = useHistory();
+  const { location, replace } = useHistory();
 
   const params = new URLSearchParams(location.search);
 
@@ -105,7 +105,7 @@ export const ComponentOverview = () => {
       params.append(SEARCH_PARAM, SEARCH_VALUES.ONLY_IMPLEMENTED);
     }
 
-    push({ ...location, search: params.toString() });
+    replace({ ...location, search: params.toString() });
   }, [showTodo, showHelpWanted, showCommunity, showCandidate, showHallOfFame, showOnlyImplemented]);
 
   const todo = components.filter((c) => c.relayStep === 'UNKNOWN');

--- a/src/components/ComponentOverview.tsx
+++ b/src/components/ComponentOverview.tsx
@@ -127,7 +127,7 @@ export const ComponentOverview = () => {
           {
             className: 'utrecht-accordion--nlds-subtle',
             headingLevel: 2,
-            expanded: false,
+            expanded: params.size > 0,
 
             // TODO: Make Pull Request for Utrecht Accordion to allow `ReactNode`
             // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
(turns out… losing focus is default behavour of history.push() in React Router, but not of history.replace(); this seems coincidental, this change also means that there is no history kept of the different filter settings, I think that's ok)

--- 

Dit fixt twee dingen: 

- focus werd bij veranderen filter terugverplaatst naar body, dat gebeurt nu niet meer
- filters gaan nu automatisch open als je in de URL filters had staan (bv als iemand het met je deelde)