### PR TITLE
Fix ruimte onder ul's 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -957,6 +957,6 @@ pre {
   font-size: 0.9em;
   line-height: 1;
 }
-.docs-doc-page ul {
+.DocSearch ul {
   margin: auto 0;
 }


### PR DESCRIPTION
(fixes https://github.com/nl-design-system/documentatie/issues/1729)

Door een te breed gescopete CSS-regel plakten `p`'s vast aan de `ul`'s erboven, zoals hier:

<img width="296" alt="screenshot nlds site; p staat tegen ul aan" src="https://github.com/user-attachments/assets/da88f17b-ce32-49fc-802c-23c697babec8" />

Dit PR maakt een einde aan deze praktijk: 

<img width="299" alt="zelfde screenshot, nu met ruimte tussen ul en p" src="https://github.com/user-attachments/assets/88da2f50-5f63-4902-a651-adf7910e23d9" />

de `margin: 0 auto` was specifiek om in de search modal de juiste uitlijning te bewerkstelligen, maar gescoped op alle ul's in docpagina's. 
