### PR TITLE
docs: suspend Level AAA focus-indicator requirement until 2025Q1

### DIFF
--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -19,7 +19,6 @@ import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_w
 import Wcag143 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.3.md";
 import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
 import Wcag211 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.1.1-link.md";
-import Wcag2413 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.13.md";
 import Wcag247 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.4.7.md";
 import Wcag252 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.2.md";
 import Wcag253 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-2.5.3-link.md";
@@ -117,12 +116,15 @@ export const component = componentProgress.find((item) => item.number === issueN
       status: "",
       component: <Wcag1411 />,
     },
+    /* Suspended until we have a common implementation of focus-indicator in 2025Q1 */
+    /*
     {
       title: "De Link heeft een goed zichtbare focusindicator",
       sc: "2.4.13",
       status: "",
       component: <Wcag2413 />,
     },
+    */
     {
       title: "De Link heeft een aanklikbaar gedeelte van ten minste 44 bij 44 pixels",
       sc: "2.5.5",


### PR DESCRIPTION
We gaan in 2025 Q1 de consistente focus-indicator code aanpakken wanneer we voldoende focusable componenten hebben
