### PR TITLE
docs: Verwijder tijdelijk de 2.4.13 focus indicator uit de acceptatiecriteria voor de Camdidate componenten

### DIFF
--- a/.changeset/remove-wcag-2.4.13-for-now.md
+++ b/.changeset/remove-wcag-2.4.13-for-now.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+Acceptatiecriteria voor WCAG 2.1.3 Focus Weergave worden voor nu verwijderd voor de Candidate componenten. In het eerste kwartaal zat dit succescriterium weer worden toegevoegd na meer onderzoek over de exacte implementatie.

--- a/docs/componenten/ac/_ac_intro.md
+++ b/docs/componenten/ac/_ac_intro.md
@@ -1,3 +1,3 @@
 Gebruik jij één van de implementaties van deze component of heb je je eigen component gemaakt? In beide gevallen geldt: met onderstaande acceptatiecriteria kun je nagaan of jouw gebruik van deze component klopt met NL Design System.
 
-Als je implementatie voldoet aan de acceptatiecriteria voor dit component, kun je er vanuit gaan dat je gebruik van dit component voldoet aan WCAG, niveau A en AA, en voor twee succescriteria aan niveau AAA ([2.4.13 Focusweergave](https://nldesignsystem.nl/wcag/2.4.13) en [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5)).
+Als je implementatie voldoet aan de acceptatiecriteria voor deze component, kun je er vanuit gaan dat je gebruik van deze component voldoet aan WCAG, niveau A en AA, en voor [2.5.5 Grootte van het aanwijsgebied uitgebreid](https://nldesignsystem.nl/wcag/2.5.5)) AAA.

--- a/docs/componenten/ac/_wcag-2.4.7.md
+++ b/docs/componenten/ac/_wcag-2.4.7.md
@@ -2,7 +2,7 @@
 
 Wanneer het element de toetsenbordfocus krijgt is de focus zichtbaar.
 
-Verberg de standaard browserfocusstijl nooit met `outline:none` zonder er een goede focusstijl voor in de plaats te zetten die rekening houdt met goede zichtbaarheid. Maak de focusrand ten minste 2 pixels dik, met een contrast van minimaal 3:1, zie [WCAG-succescriterium 2.4.13 Focusweergave](/wcag/2.4.13).
+Verberg de standaard browserfocusstijl nooit met `outline:none` zonder er een goede focusstijl voor in de plaats te zetten die rekening houdt met goede zichtbaarheid.
 
 NL Design System richtlijnen:
 

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -149,12 +149,15 @@ export const component = componentProgress.find((item) => item.number === issueN
       status: "",
       component: <Wcag247 />,
     },
-    {
-      title: "De button heeft een goed zichtbare focusindicator",
-      sc: "2.4.13",
-      status: "",
-      component: <Wcag2413 />,
-    },
+    /* Suspended until we have a common implementation of focus-indicator in 2025Q1 */
+    /*
+{
+  title: "De button heeft een goed zichtbare focusindicator",
+  sc: "2.4.13",
+  status: "",
+  component: <Wcag2413 />,
+},
+ */
     {
       title: "Buttons met gelijke functies hebben hetzelfde uiterlijk en hetzelfde label",
       sc: "3.2.4",

--- a/docs/componenten/login-link/index.mdx
+++ b/docs/componenten/login-link/index.mdx
@@ -113,12 +113,15 @@ export const component = componentProgress.find((item) => item.number === issueN
       status: "",
       component: <Wcag1411 />,
     },
-    {
-      title: "De Login Link heeft een goed zichtbare focusindicator",
-      sc: "2.4.13",
-      status: "",
-      component: <Wcag2413 />,
-    },
+    /* Suspended until we have a common implementation of focus-indicator in 2025Q1 */
+    /*
+{
+  title: "De Login Link heeft een goed zichtbare focusindicator",
+  sc: "2.4.13",
+  status: "",
+  component: <Wcag2413 />,
+},
+ */
     {
       title: "De Login Link heeft een aanklikbaar gedeelte van ten minste 44 bij 44 pixels",
       sc: "2.5.5",

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -144,12 +144,15 @@ export const component = componentProgress.find((item) => item.number === issueN
       status: "",
       component: <Wcag247 />,
     },
-    {
-      title: "De Skip Link heeft een goed zichtbare focusindicator",
-      sc: "2.4.13",
-      status: "",
-      component: <Wcag2413 />,
-    },
+    /* Suspended until we have a common implementation of focus-indicator in 2025Q1 */
+    /*
+{
+  title: "De Skip Link heeft een goed zichtbare focusindicator",
+  sc: "2.4.13",
+  status: "",
+  component: <Wcag2413 />,
+},
+ */
     {
       title: "De Skip Link heeft een aanklikbaar gedeelte van ten minste 44 bij 44 pixels",
       sc: "2.5.5",

--- a/docs/wcag/2.4.07.mdx
+++ b/docs/wcag/2.4.07.mdx
@@ -29,8 +29,6 @@ import Summary from "./summaries/_2.4.7-summary.md";
 
 <Summary />
 
-**Let op**: voor het NL Design System willen we ook voldoen aan het WCAG-succescriterium [2.4.13 Focusweergave](/wcag/2.4.13) (niveau AAA), dat eisen stelt aan de weergave en het kleurcontrast van de focusring. Dit staat beschreven bij de richtlijn [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren//visueel-ontwerp/#maak-toetsenbord-focus-goed-zichtbaar). Het [intact houden van de browser-outline](https://www.w3.org/WAI/WCAG22/Techniques/general/G149.html) is voldoende voor WCAG-succescriterium 2.4.7 (versie 2.2 niveau AA) maar in de praktijk is die focusring niet voldoende duidelijk in alle situaties.
-
 ## Gerelateerde NL Design System-richtlijn
 
 Formulieren - Visueel Ontwerp: [Maak de toetsenbordfocus goed zichtbaar](/richtlijnen/formulieren/visueel-ontwerp/focus-goed-zichtbaar).


### PR DESCRIPTION
Deze PR verwijderd (naast Link) ook het acceptatiecriterium 2..3.13 voor de componenten 
- Button
- Link
- Skip Link
- Login Link

en verwijzingen in de documentatie.readme

Gerelateerd
Issue: https://github.com/nl-design-system/documentatie/issues/1836
PR van 19 december '24 https://github.com/nl-design-system/documentatie/pull/1835