### PR TITLE
docs: Voegt WCAG-succescriterium 1.4.1 Gebruik van kleur toe aan acceptatiecrieria van Color Sample

### DIFF
--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -21,6 +21,7 @@ import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac
 import Wcag111 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.1.1-color-sample.md";
 import Wcag131 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.1-color-sample.md";
 import Wcag132 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.3.2-color-sample.md";
+import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
 import Wcag1411 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.11-color-sample.md";
 import Wcag1412 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.12.md";
 import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wcag-1.4.4.md";
@@ -80,6 +81,12 @@ export const component = componentProgress.find((item) => item.number === issueN
   headingLevel={4}
   testCategory="Toegankelijkheid visueel ontwerp"
   items={[
+    {
+      title: "Kleur is niet de enige manier waarop de informatie over de Color Sample beschikbaar is",
+      sc: "1.4.1",
+      status: "",
+      component: <Wcag141 />,
+    },
     {
       title: "Het kleurcontrast van de tekst van de eigenschappen van de Color Sample is voldoende",
       sc: "1.4.3",


### PR DESCRIPTION
Voegt WCAG-succescriterium 1.4.1 Gebruik van kleur toe aan acceptatiecrieria van Color Sample. Deze ontbrak nog.