### PR TITLE
docs: update planning design open dag

### DIFF
--- a/docs/community/events/design-open-dag.mdx
+++ b/docs/community/events/design-open-dag.mdx
@@ -41,14 +41,6 @@ Aline Nap, designer bij Logius.
 
 ## Planning
 
-### 2024
-
-- vrijdag 25 oktober (Utrecht)
-- vrijdag 22 november (Utrecht)
-- vrijdag 20 december (Utrecht)
-
-### 2025
-
 - vrijdag 31 januari (Utrecht)
 - vrijdag 28 februari
 - vrijdag 28 maart


### PR DESCRIPTION
Deze PR haalt de data uit 2024 weg en toont enkel nog de aanstaande data voor de komende 5 maanden in 2025.