### PR TITLE
fix: align multiline items w/ item text not marker

### DIFF
--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -1,29 +1,34 @@
 .nlds-anatomy-list {
-  padding-inline: 0;
+  column-gap: 2rem;
+  counter-reset: count 0;
   display: flex;
   flex-direction: column;
-  column-gap: 2rem;
+  padding-inline: 0;
   row-gap: 0.5rem;
-  counter-reset: count 0;
 }
 
 .nlds-anatomy-list__item {
   list-style: none;
+  padding-inline-start: calc(
+    var(--nl-anatomy-marker-min-inline-size, 2rem) + (4 * var(--nl-anatomy-marker-padding-inline, 0.125rem))
+  );
+  position: relative;
 }
 
 .nlds-anatomy-marker,
 .nlds-anatomy-list__item::before {
-  counter-increment: count 1;
-
   border-width: var(--nl-number-badge-border-width, 1px);
   box-sizing: border-box;
   color: var(--nl-number-badge-color);
+  counter-increment: count 1;
   display: inline-flex;
   font-family: var(--nl-number-badge-font-family);
   font-size: max(var(--nl-number-badge-font-size), 1rem);
   font-style: normal;
   font-variant-numeric: lining-nums tabular-nums;
   font-weight: var(--nl-number-badge-font-weight, bold);
+  inset-block-start: calc(-1 * var(--nl-anatomy-marker-padding-inline, 0.125rem));
+  inset-inline-start: 0;
   justify-content: center;
   max-block-size: max-content;
   max-inline-size: max-content;
@@ -31,17 +36,18 @@
   min-inline-size: var(--nl-anatomy-marker-min-inline-size, 2rem);
   padding-block: var(--nl-anatomy-marker-padding-block, 0.125rem);
   padding-inline: var(--nl-anatomy-marker-padding-inline, 0.125rem);
+  position: absolute;
 }
 
 .nlds-anatomy-list__item::before {
-  content: counter(count);
   background-color: #de00a4;
-  color: white;
   border-radius: 100%;
-  min-inline-size: 32px;
-  min-block-size: 32px;
-  vertical-align: middle;
+  color: white;
+  content: counter(count);
   margin-inline-end: 1ch;
+  min-block-size: 32px;
+  min-inline-size: 32px;
+  vertical-align: middle;
 }
 
 @media screen and (forced-colors: active) {

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -45,8 +45,8 @@
   border-radius: 100%;
   color: white;
   content: counter(count);
-  min-block-size: 32px;
-  min-inline-size: 32px;
+  min-block-size: var(--nlds-anatomy-marker-min-block-size, 32px);
+  min-inline-size: var(--nlds-anatomy-marker-min-inline-size, 32px);
 }
 
 @media screen and (forced-colors: active) {

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -10,7 +10,7 @@
 .nlds-anatomy-list__item {
   list-style: none;
   padding-inline-start: calc(
-    var(--nlds-anatomy-marker-min-inline-size, 2rem) + (2 * var(--nlds-anatomy-marker-padding-inline, 0.125rem)) +
+    var(--nlds-anatomy-marker-min-size, 2rem) + (2 * var(--nlds-anatomy-marker-padding-inline, 0.125rem)) +
       var(--nlds-anatomy-marker-gap, 0.5ch)
   );
   position: relative;
@@ -33,20 +33,20 @@
   justify-content: center;
   max-block-size: max-content;
   max-inline-size: max-content;
-  min-block-size: var(--nlds-anatomy-marker-min-block-size, 2rem);
-  min-inline-size: var(--nlds-anatomy-marker-min-inline-size, 2rem);
+  min-block-size: var(--nlds-anatomy-marker-min-size, 2rem);
+  min-inline-size: var(--nlds-anatomy-marker-min-size, 2rem);
   padding-block: var(--nlds-anatomy-marker-padding-block, 0.125rem);
   padding-inline: var(--nlds-anatomy-marker-padding-inline, 0.125rem);
   position: absolute;
 }
 
 .nlds-anatomy-list__item::before {
+  align-items: center;
   background-color: #de00a4;
   border-radius: 100%;
   color: white;
   content: counter(count);
-  min-block-size: var(--nlds-anatomy-marker-min-block-size, 32px);
-  min-inline-size: var(--nlds-anatomy-marker-min-inline-size, 32px);
+  display: flex;
 }
 
 @media screen and (forced-colors: active) {

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -27,15 +27,15 @@
   font-style: normal;
   font-variant-numeric: lining-nums tabular-nums;
   font-weight: var(--nl-number-badge-font-weight, bold);
-  inset-block-start: calc(-1 * var(--nl-anatomy-marker-padding-inline, 0.125rem));
+  inset-block-start: calc(-1 * var(--nlds-anatomy-marker-padding-inline, 0.125rem));
   inset-inline-start: 0;
   justify-content: center;
   max-block-size: max-content;
   max-inline-size: max-content;
-  min-block-size: var(--nl-anatomy-marker-min-block-size, 2rem);
-  min-inline-size: var(--nl-anatomy-marker-min-inline-size, 2rem);
-  padding-block: var(--nl-anatomy-marker-padding-block, 0.125rem);
-  padding-inline: var(--nl-anatomy-marker-padding-inline, 0.125rem);
+  min-block-size: var(--nlds-anatomy-marker-min-block-size, 2rem);
+  min-inline-size: var(--nlds-anatomy-marker-min-inline-size, 2rem);
+  padding-block: var(--nlds-anatomy-marker-padding-block, 0.125rem);
+  padding-inline: var(--nlds-anatomy-marker-padding-inline, 0.125rem);
   position: absolute;
 }
 

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -47,7 +47,6 @@
   content: counter(count);
   min-block-size: 32px;
   min-inline-size: 32px;
-  vertical-align: middle;
 }
 
 @media screen and (forced-colors: active) {

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -10,7 +10,8 @@
 .nlds-anatomy-list__item {
   list-style: none;
   padding-inline-start: calc(
-    var(--nl-anatomy-marker-min-inline-size, 2rem) + (4 * var(--nl-anatomy-marker-padding-inline, 0.125rem))
+    var(--nlds-anatomy-marker-min-inline-size, 2rem) + (2 * var(--nlds-anatomy-marker-padding-inline, 0.125rem)) +
+      var(--nlds-anatomy-marker-gap, 0.5ch)
   );
   position: relative;
 }
@@ -44,7 +45,6 @@
   border-radius: 100%;
   color: white;
   content: counter(count);
-  margin-inline-end: 1ch;
   min-block-size: 32px;
   min-inline-size: 32px;
   vertical-align: middle;

--- a/src/components/AnatomyList.css
+++ b/src/components/AnatomyList.css
@@ -28,7 +28,7 @@
   font-style: normal;
   font-variant-numeric: lining-nums tabular-nums;
   font-weight: var(--nl-number-badge-font-weight, bold);
-  inset-block-start: calc(-1 * var(--nlds-anatomy-marker-padding-inline, 0.125rem));
+  inset-block-start: calc(-1 * var(--nlds-anatomy-marker-padding-block, 0.125rem));
   inset-inline-start: 0;
   justify-content: center;
   max-block-size: max-content;


### PR DESCRIPTION
voor: 

<img width="626" alt="omschrijving code blok met daarvoor het cijfer 1 in een bolletje. de omschrijving loopt vanaf regel 2 onder het bolletje door" src="https://github.com/user-attachments/assets/fdac379a-9e17-4924-885a-9ffcde4f2d71" />

na:

<img width="616" alt="zoals hierboven, maar de omschrijving staat als geheel naast het bolletje en lijn dus als geheel aan de linkerkant uit" src="https://github.com/user-attachments/assets/08c772de-81ab-4907-bd3d-a5c28c6eb881" />
