### PR TITLE
Docs/rechttrekken fout voorbeeld

### DIFF
--- a/docs/componenten/ac/_wcag-1.3.1-code-block.md
+++ b/docs/componenten/ac/_wcag-1.3.1-code-block.md
@@ -6,7 +6,7 @@ in combinatie met `pre`.
 Dus niet zo:
 
 ```html
-<!-- dit niet doen -->
+<!-- Foute code, niet gebruiken -->
 <pre>
   <div class="code-block">
     @use "./mixin";

--- a/docs/componenten/ac/_wcag-1.3.1-code.md
+++ b/docs/componenten/ac/_wcag-1.3.1-code.md
@@ -5,7 +5,7 @@ Gebruik voor tekst gemarkeerd als code semantische HTML. In het geval van de com
 Dus niet zo:
 
 ```html
-<!-- dit niet doen -->
+<!-- Foute code, niet gebruiken -->
 Een zin over het element <span class="code">button</span> met een achtergrondkleur in CSS.
 ```
 

--- a/docs/componenten/ac/_wcag-1.3.1-mark.md
+++ b/docs/componenten/ac/_wcag-1.3.1-mark.md
@@ -7,7 +7,7 @@ In het geval van de component Mark is dat het HTML-element `mark`.
 Dus niet zo:
 
 ```html
-<!-- dit niet doen -->
+<!-- Foute code, niet gebruiken -->
 Een zin met <span class="mark">een stuk gemarkeerde tekst</span> met een achtergrondkleur in CSS
 ```
 

--- a/docs/componenten/ac/_wcag-2.5.3-link.md
+++ b/docs/componenten/ac/_wcag-2.5.3-link.md
@@ -9,7 +9,7 @@ Pas op met het gebruik van `aria-label` om een naam te geven aan een link. Een `
 Dus niet:
 
 ```html
-<!-- Dit is een fout voorbeeld, niet kopiëren -->
+<!-- Foute code, niet gebruiken -->
 <a href="login-url" aria-label="Klik hier om in te loggen">Log in met DigiD</a>
 ```
 

--- a/docs/componenten/ac/_wcag-4.1.1-heading.md
+++ b/docs/componenten/ac/_wcag-4.1.1-heading.md
@@ -11,7 +11,7 @@ Een voorbeeld is een button met een heading erin:
 ```
 
 ```html
-<!-- dit niet doen -->
+<!-- Foute code, niet gebruiken -->
 <button>
   <h2>heading in button, niet toegestaan</h2>
 </button>


### PR DESCRIPTION
Zie #1601

comment foute code gelijktrekken. Nu komt voor: `<!-- dit niet doen -->` of  '' of `<!--  Niet gebruiken is foute code -->`