### PR TITLE
chore: trigger a11y-reviews via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/docs/wcag/ @nl-design-system/kernteam-a11y


### PR DESCRIPTION
By popular demand: trigger code reviews in certain documents