### PR TITLE
docs: Richtlijnen: Voorbeeld toevoegen voortgang meerstappenformulier opnemen in het kopje en visueel scheiden via CSS

### DIFF
--- a/.changeset/richtlijnen-voortgang.md
+++ b/.changeset/richtlijnen-voortgang.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+Richtlijnen voor het aangeven van de voortgang gelijkgetrokken met hoe ze in meerstappenformulieren gebruikt gaan worden.

--- a/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
+++ b/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
@@ -50,7 +50,7 @@ import { Guideline } from "@site/src/components/Guideline";
     {() => (
       <>
         <hgroup>
-          <h1>Uw gegevens</h1>
+          <h2>Uw gegevens</h2>
           <p>Stap 2 van 3</p>
         </hgroup>
       </>
@@ -63,12 +63,12 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <h1>
+        <h2>
           <span class="progress-indicator">
             Stap 2 van 3
           </span>
           Titel van de stap
-        </h1>
+        </h2>
       </>
     )}
 
@@ -79,9 +79,8 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-<p>Stap 2 van 3</p>
-<h2>Uw gegevens</h2>
-
+        <p>Stap 2 van 3</p>
+        <h2>Uw gegevens</h2>
       </>
     )}
 

--- a/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
+++ b/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
@@ -40,10 +40,8 @@ import { Guideline } from "@site/src/components/Guideline";
       <>
         <h2>Uw gegevens</h2>
         <p>Stap 2 van 3</p>
-
       </>
     )}
-
   </Canvas>
 </Guideline>
 
@@ -55,14 +53,29 @@ import { Guideline } from "@site/src/components/Guideline";
           <h1>Uw gegevens</h1>
           <p>Stap 2 van 3</p>
         </hgroup>
-
       </>
     )}
 
   </Canvas>
 </Guideline>
 
-<Guideline appearance="dont" title="Stap boven het kopje van het formulier.">
+<Guideline appearance="do" title="De tekst van de stap opnemen in het kopje." description="En deze visueel op een andere regel plaatsen.">
+  <Canvas language="html">
+    {() => (
+      <>
+        <h1>
+          <span class="progress-indicator">
+            Stap 2 van 3
+          </span>
+          Titel van de stap
+        </h1>
+      </>
+    )}
+
+  </Canvas>
+</Guideline>
+
+<Guideline appearance="dont" title="In de HTML-code de stap boven het kopje van het formulier plaatsen.">
   <Canvas language="html">
     {() => (
       <>

--- a/docs/richtlijnen/formulieren/multistep/1-step-count/_guideline.md
+++ b/docs/richtlijnen/formulieren/multistep/1-step-count/_guideline.md
@@ -17,7 +17,9 @@ Aanpassen van de `<title>` in de `<head>` geldt voor WCAG ook voor dynamisch geg
 document.title = "Stap 3 van 6: Adresgegevens";
 ```
 
-De stappen kort uitschrijven als tekst heeft de voorkeur boven een visuele weergave zoals in een progressbar. Tekst schaalt beter mee bij vergroting of op mobiele weergave. Bovendien is het sneller te lezen en wordt het beter gevonden. Lees hierover [Using progress indicators](https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators) op [gov.uk](http://gov.uk/).
+De stappen kort uitschrijven als tekst heeft de voorkeur boven een visuele weergave zoals in een progressbar. Tekst schaalt beter mee bij vergroting of op mobiele weergave. Bovendien is het sneller te lezen en wordt het beter gevonden.
+
+Lees hierover [<span lang="en">Using progress indicators</span>](https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators) en [<span lang="en">Do less</span>](https://designnotes.blog.gov.uk/2014/07/07/do-less-problems-as-shared-spaces/) op GOV.UK.
 
 Het duidelijk aangeven van het aantal stappen en de huidige locatie binnen de stappen is nodig om te voldoen de WCAG-succescriteria:
 

--- a/docs/richtlijnen/formulieren/multistep/2-location/_code.mdx
+++ b/docs/richtlijnen/formulieren/multistep/2-location/_code.mdx
@@ -25,7 +25,7 @@ import { Guideline } from "@site/src/components/Guideline";
       <>
         <h2>
           <span class="progress-indicator">Stap 2 van 3</span>
-          Titel van de stap
+          Uw gegevens
         </h2>
         <form>[... inhoud formulier …]</form>
       </>

--- a/docs/richtlijnen/formulieren/multistep/2-location/_code.mdx
+++ b/docs/richtlijnen/formulieren/multistep/2-location/_code.mdx
@@ -15,6 +15,24 @@ import { Guideline } from "@site/src/components/Guideline";
   </Canvas>
 </Guideline>
 
+<Guideline
+  appearance="do"
+  title="De tekst van de stap opnemen in het kopje, boven het formulier."
+  description="En deze tekst visueel op een andere regel plaatsen. "
+>
+  <Canvas language="html">
+    {() => (
+      <>
+        <h2>
+          <span class="progress-indicator">Stap 2 van 3</span>
+          Titel van de stap
+        </h2>
+        <form>[... inhoud formulier …]</form>
+      </>
+    )}
+  </Canvas>
+</Guideline>
+
 <Guideline appearance="dont" title="Info binnen het formulier.">
   <Canvas language="html">
     {() => (

--- a/src/components/Guideline.css
+++ b/src/components/Guideline.css
@@ -54,6 +54,12 @@ p + .nlds-guideline {
   margin-block-end: 16px;
 }
 
+.nlds-guideline span.progress-indicator {
+  display: block;
+  font-size: 1rem;
+  font-weight: normal;
+}
+
 .nlds-guideline__badge--dont {
   --utrecht-paragraph-color: var(--nlds-invalid-color);
 }


### PR DESCRIPTION
Naar aanleiding van discussie https://github.com/nl-design-system/documentatie/issues/1895
Optie toevoegen op de stappenvoortgang op te nemen in het kopje en visueel via CSS op een andere regel te plaatsen.
Besloten door @jeffreylauwers en @rianrietveld


Twee voorbeelden toegevoegd, preview:
- https://documentatie-git-docs-voortgang-nl-design-system.vercel.app/richtlijnen/formulieren/meerdere-stappen/voortgang-tonen
- https://documentatie-git-docs-voortgang-nl-design-system.vercel.app/richtlijnen/formulieren/meerdere-stappen/plaatsing-voortgang

Keuze vastgelegd in GitHub Discussion voor een Meerstappenformulier:
https://github.com/orgs/nl-design-system/discussions/364#discussioncomment-11840898