### PR TITLE
docs: richtlijnen: tekst foutmeldingen eenvoudiger

### DIFF
--- a/.changeset/docs-tekst-verplicht-veld.md
+++ b/.changeset/docs-tekst-verplicht-veld.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+Richtlijnen voor teksten om verplichte velden aan te geven vereenvoudigd.

--- a/blog/2024/20240624-toegankelijke-foutmeldingen.md
+++ b/blog/2024/20240624-toegankelijke-foutmeldingen.md
@@ -96,7 +96,7 @@ Een keuze kan zijn: zijn de meeste velden verplicht, markeer dan de niet-verplic
 
 Wat je ook kiest, wees consequent binnen het formulier en ook binnen alle formulieren van de website en laat de gebruiker altijd boven het formulier weten hoe al dan niet verplichte velden zijn aangemerkt.
 
-Bijvoorbeeld met de tekst 'Vul alle velden in. Als een veld niet verplicht is, staat dit erbij.'
+Bijvoorbeeld met de tekst 'Vul alles in. Als iets niet verplicht is, staat dat erbij.'
 
 Lees hierover de richtlijn [Vermeld duidelijk of een veld wel of niet verplicht is
 ](/richtlijnen/formulieren/voorkom-fouten#vermeld-duidelijk-of-een-veld-verplicht-is).

--- a/docs/richtlijnen/formulieren/help/1-show-required/_mark-optional-fields-code.mdx
+++ b/docs/richtlijnen/formulieren/help/1-show-required/_mark-optional-fields-code.mdx
@@ -7,7 +7,7 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <p>Vul alle velden in. Als een veld niet verplicht is, staat dit erbij.</p>
+        <p>Vul alles in. Als iets niet verplicht is, staat dat erbij.</p>
         <form>
           <label htmlFor="kleur1">Wat is je lievelingskleur</label>
           <input type="text" id="kleur1" name="lievelingskleur" aria-required="true" aria-invalid="false" />

--- a/docs/richtlijnen/formulieren/help/1-show-required/_mark-required-fields-code.mdx
+++ b/docs/richtlijnen/formulieren/help/1-show-required/_mark-required-fields-code.mdx
@@ -7,7 +7,7 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <p>Als een veld verplicht is, staat dit erbij.</p>
+        <p>Als iets verplicht is, staat dit erbij.</p>
         <form>
           <label htmlFor="kleur3">Wat is je lievelingskleur (verplicht)</label>
           <input type="text" id="kleur3" name="lievelingskleur" aria-required="true" aria-invalid="false" />
@@ -27,7 +27,7 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas language="html">
     {() => (
       <>
-        <p>Als een veld verplicht is, staat er een * bij.</p>
+        <p>Als iets verplicht is, staat er een * bij.</p>
         <form>
           <label htmlFor="kleur4">Wat is je lievelingskleur *</label>
           <input type="text" id="kleur24" name="lievelingskleur" aria-required="true" aria-invalid="false" />


### PR DESCRIPTION
Naar aanleiding van discussie https://github.com/nl-design-system/documentatie/issues/1896
Tekst aangeven verplichte velden vereenvoudigd.
Besloten door @jeffreylauwers en @rianrietveld

Preview:
https://documentatie-git-docs-tekst-verplichte-velden-nl-design-system.vercel.app/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/

Ook de tekst van de blogpost Toegankelijke foutmeldingen in formulieren is aangepast.
Preview:
https://documentatie-git-docs-tekst-verplichte-velden-nl-design-system.vercel.app/blog/toegankelijke-foutmeldingen-formulieren