### PR TITLE
docs: update heartbeat planning for 2025

### DIFF
--- a/docs/community/events/heartbeat/heartbeat.mdx
+++ b/docs/community/events/heartbeat/heartbeat.mdx
@@ -46,6 +46,7 @@ De Heartbeat vindt om de week plaats op dinsdag. Dit zijn de data voor 2025:
 - 10 juni
 - 24 juni
 - 8 juli
+- 19 augustus
 - 2 september
 - 16 september
 - 30 september

--- a/docs/community/events/heartbeat/heartbeat.mdx
+++ b/docs/community/events/heartbeat/heartbeat.mdx
@@ -31,30 +31,29 @@ Deze sessies zijn publiek toegankelijk.
 
 ## Planning
 
-De Heartbeat vindt om de week plaats op dinsdag. Dit zijn de data voor 2024:
+De Heartbeat vindt om de week plaats op dinsdag. Dit zijn de data voor 2025:
 
-- 9 januari
-- 23 januari
-- 6 februari
-- 20 februari
-- 5 maart
-- 19 maart
-- 2 april
-- 16 april
-- 30 april
-- 14 mei
-- 28 mei
-- 11 juni
-- 25 juni
-- 9 juli
-- 3 september
-- 17 september
-- 1 oktober
-- 15 oktober
-- 29 oktober
-- 12 november
-- 26 november
-- 10 december
+- 7 januari
+- 4 februari
+- 18 februari
+- 4 maart
+- 18 maart
+- 1 april
+- 15 april
+- 29 april
+- 13 mei
+- 27 mei
+- 10 juni
+- 24 juni
+- 8 juli
+- 2 september
+- 16 september
+- 30 september
+- 14 oktober
+- 28 oktober
+- 11 november
+- 25 november
+- 9 december
 
 [Voeg Heartbeats aan je kalender (.ics)](/heartbeat/heartbeat.ics)
 


### PR DESCRIPTION
Based on this year:
- second session in january skipped

Based on overlapping summer holiday from https://www.rijksoverheid.nl/onderwerpen/schoolvakanties/zomervakantie/zomervakantie-2025 which is 19 juli to 17 august.

Based on last year: only one in december