### PR TITLE
chore: remove open gemeenten from colofon.

### DIFF
--- a/docs/footer/colofon.mdx
+++ b/docs/footer/colofon.mdx
@@ -14,10 +14,6 @@ slug: /colofon
 
 De website wordt gemaakt en onderhouden door het kernteam en is nog volop in ontwikkeling. Mocht u vragen of opmerkingen hebben dan kunt u contact met ons opnemen op ons centrale e-mailadres: <a href="mailto:kernteam@nldesignsystem.nl">kernteam@nldesignsystem.nl</a>.
 
-## Iconen
-
-De toptaak iconen op onze homepage zijn gemaakt door <a href="https://www.opengemeenten.nl/producten/iconenset" target="_top">OpenGemeenten</a>. Deze iconenset is vrij te gebruiken en valt onder de CC BY-SA 4.0-licentie.
-
 ## Open source
 
 De belangrijkste onderdelen van NL Design System zijn open source. We gebruiken voor twee open source licenties:


### PR DESCRIPTION
Ben contacted us that the icon license has changed to CC0, which means no mention of OpenGemeenten is required anymore 🥳