### PR TITLE
Update acceptatiecriteria accordion

### DIFF
--- a/docs/componenten/ac/_wcag-2.5.2-accordion.md
+++ b/docs/componenten/ac/_wcag-2.5.2-accordion.md
@@ -4,4 +4,4 @@ Zorg ervoor dat, als de gebruiker de accordion aanraakt met een enkele aanwijzer
 
 Dit voorkomt het per ongeluk aanraken en openen van content, wanneer het niet de bedoeling was.
 
-Met een zowel een `button` element als met een `details` en `summary` combinatie gaat dit automatisch goed. Met een div-element waarop `role= "button"` is geplaatst, moet zowel de toetsenbordinteractie als de interactie voor muis en touch nog worden toegevoegd. Gebruik voor dit laatste bij voorkeur het `click`event, omdat dit apparaatonafhankelijk is.
+Met een zowel een `button` element als met een `details` en `summary` combinatie gaat dit automatisch goed. Met een div-element waarop `role= "button"` is geplaatst, moet zowel de toetsenbordinteractie als de interactie voor muis en touch nog worden toegevoegd. Gebruik voor dit laatste bij voorkeur het `click` event, omdat dit apparaatonafhankelijk is.

--- a/docs/componenten/ac/_wcag-4.1.2-accordion.md
+++ b/docs/componenten/ac/_wcag-4.1.2-accordion.md
@@ -5,7 +5,6 @@ Het onderdeel van de userinterface waarmee een bezoeker de accordion opent, heef
 Opties:
 
 - Wanneer een details en summary combinatie gebruikt wordt, heeft het summary element voor hulpsoftware automatisch de juiste rol.
-
 - Een HTML `button` heeft ook automatisch de juiste rol. Het is mogelijk om met ARIA een `role=button` toe te voegen aan een ander element dan een `button`, maar dit is niet aan te raden. Heb je het absoluut nodig, zorg er dan voor dat het gekozen element ook voldoet aan de verwachte toetsenbordinteractie, focusstijl, etc.
 
 De staat van de accordion (open of dicht) moet ook beschikbaar zijn voor hulpsoftware.
@@ -13,10 +12,7 @@ De staat van de accordion (open of dicht) moet ook beschikbaar zijn voor hulpsof
 Opties:
 
 - Wanneer een details en summary combinatie gebruikt wordt, gaat dit automatisch goed.
-
 - Bij een knop moet de staat worden aangegeven met het aria-expanded attribuut.
-
-Let erop dat je hiervoor JavaScript nodig hebt en zorg ervoor dat `aria-expanded` de waarde `false` krijgt wanneer het menu weer is ingeklapt.
 
 ```html
 <button aria-expanded="true">Menu</button>

--- a/docs/componenten/ac/_wcag-4.1.2-accordion.md
+++ b/docs/componenten/ac/_wcag-4.1.2-accordion.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-Het onderdeel van de userinterface waarmee een bezoeker de accordion opent, heeft de rol `button`.
+Het onderdeel van de gebruikersinterface waarmee een bezoeker de accordion opent, heeft de rol `button`.
 
 Opties:
 


### PR DESCRIPTION
- Dubbeling in tekst
- Opsomming zonder witregel.
- 'gebruikersinterface' in plaats van 'userinterface'.
- Extra spatie na `click` en voor event.