### PR TITLE
feat: add front matter image to blogpost

### DIFF
--- a/blog/2025/20250211-a11y-name-link-logo-header.md
+++ b/blog/2025/20250211-a11y-name-link-logo-header.md
@@ -6,6 +6,7 @@ authors:
     title: Specialist webtoegankelijkheid
     url: https://www.linkedin.com/in/rianrietveld/
 tags: [link, logo, toegankelijke naam]
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/blog-toegankelijke-naam-link-logo.png
 hide_table_of_contents: false
 date: 2025-02-11
 ---


### PR DESCRIPTION
Add front matter image to blog post so LinkedIn, etc show thumbnail when the blog post is linked. Image is already pushed to the assets branch and live.