### PR TITLE
Fix 404 op foutieve link in button acceptatiecriteria

### DIFF
--- a/docs/componenten/ac/_wcag-2.4.6-button.md
+++ b/docs/componenten/ac/_wcag-2.4.6-button.md
@@ -7,5 +7,5 @@ NL Design System richtlijnen:
 - [Duidelijke buttontekst die beschrijft wat de button doet](/richtlijnen/formulieren/buttons/duidelijk-buttontekst/)
 - [Respecteer conventies](/richtlijnen/stijl/iconen/respecteer-conventies)
 - [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/respecteer-conventies)
-- [Zorg voor een consistente navigatie en benaming van links en buttons](/formulieren/meerdere-stappen/consistente-benaming/)
+- [Zorg voor een consistente navigatie en benaming van links en buttons](richtlijnen/formulieren/meerdere-stappen/consistente-benaming/)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam/)

--- a/docs/componenten/ac/_wcag-2.4.6-button.md
+++ b/docs/componenten/ac/_wcag-2.4.6-button.md
@@ -7,5 +7,5 @@ NL Design System richtlijnen:
 - [Duidelijke buttontekst die beschrijft wat de button doet](/richtlijnen/formulieren/buttons/duidelijk-buttontekst/)
 - [Respecteer conventies](/richtlijnen/stijl/iconen/respecteer-conventies)
 - [Gebruik SVG voor iconen en geen font](/richtlijnen/stijl/iconen/respecteer-conventies)
-- [Zorg voor een consistente navigatie en benaming van links en buttons](richtlijnen/formulieren/meerdere-stappen/consistente-benaming/)
+- [Zorg voor een consistente navigatie en benaming van links en buttons](/richtlijnen/formulieren/meerdere-stappen/consistente-benaming/)
 - [De toegankelijke naam van een button](/richtlijnen/formulieren/buttons/toegankelijke-naam/)


### PR DESCRIPTION
Op pagina https://nldesignsystem.nl/button stond onder Toegankelijkheid algemeen, 2.4.6 een link naar: https://nldesignsystem.nl/formulieren/meerdere-stappen/consistente-benaming/

Dit werkt niet, het moet zijn: 
https://nldesignsystem.nl/richtlijnen/formulieren/meerdere-stappen/consistente-benaming/