### PR TITLE
fix: update github image links to raw.githubusercontent.com

### DIFF
--- a/blog/2024/20240305-meerdere-manieren-contact.md
+++ b/blog/2024/20240305-meerdere-manieren-contact.md
@@ -6,7 +6,7 @@ authors:
     title: Toegankelijkheidsspecialist NL Design System
     url: https://www.linkedin.com/in/rianrietveld/
 tags: [toegankelijkheid, NL Design System]
-image: https://github.com/nl-design-system/documentatie/blob/assets/meerdere-manieren.png?raw=true
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/refs/heads/assets/meerdere-manieren.png
 hide_table_of_contents: false
 date: 2024-03-05
 ---

--- a/blog/2024/20240311-gebruikerstest-ondernemers.md
+++ b/blog/2024/20240311-gebruikerstest-ondernemers.md
@@ -6,7 +6,7 @@ authors:
     title: Communicatieadviseur NL Design System
     url: https://www.linkedin.com/in/renate-bruinenberg-886019163/
 tags: [meta, NL Design System]
-image: https://github.com/nl-design-system/documentatie/blob/assets/lessen-gebruikerstest.png?raw=true
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/refs/heads/assets/lessen-gebruikerstest.png
 hide_table_of_contents: false
 date: 2024-03-11
 ---

--- a/blog/2024/20240322-design-open-dag.md
+++ b/blog/2024/20240322-design-open-dag.md
@@ -6,7 +6,7 @@ authors:
     title: Public relations lead & Toegankelijkheidsspecialist NL Design System
     url: https://www.linkedin.com/in/hiddedevries/
 tags: [meta, estafettemodel, designers, NL Design System]
-image: https://github.com/nl-design-system/documentatie/blob/assets/samen-aan-de-slag.png?raw=true
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/refs/heads/assets/samen-aan-de-slag.png
 hide_table_of_contents: false
 date: 2024-03-22
 ---

--- a/blog/2024/20240522-community-blocks.md
+++ b/blog/2024/20240522-community-blocks.md
@@ -7,7 +7,7 @@ authors:
     url: https://www.linkedin.com/in/renate-bruinenberg-886019163/
 tags: [WordPress, developers, NL Design System]
 hide_table_of_contents: false
-image: https://github.com/nl-design-system/documentatie/blob/assets/community-blocks.png?raw=true
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/refs/heads/assets/community-blocks.png
 date: 2024-05-22
 ---
 

--- a/blog/2025/20250125-stappen-a-status-website.md
+++ b/blog/2025/20250125-stappen-a-status-website.md
@@ -6,7 +6,7 @@ authors:
     title: Specialist webtoegankelijkheid
     url: https://www.linkedin.com/in/rianrietveld/
 tags: [A status, toegankelijkheid, toegankelijkheidsverklaring]
-image: https://github.com/nl-design-system/documentatie/blob/assets/blog-9-stappen.png
+image: https://raw.githubusercontent.com/nl-design-system/documentatie/refs/heads/assets/blog-9-stappen.png
 hide_table_of_contents: false
 date: 2025-02-10
 ---


### PR DESCRIPTION
Update all front matter images (page thumbnails) for blogposts to use raw.githubusercontent.com