### PR TITLE
feat: add component overview links to estafettemodel

### DIFF
--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -42,7 +42,7 @@ Bestaat nog niet, maar de rationale is duidelijk, elke organisatie die hem nodig
 - Bewijs verzamelen dat een onderdeel door meerdere organisaties en producten gebruikt kan worden.
 - Zeker stellen dat een onderdeel aan de toegankelijkheidseisen kan voldoen en gebruiksvriendelijk kan zijn. Anders zal het als "Discouraged" aangemerkt worden.
 
-[Bekijk alle Help Wanted componenten](/componenten/?filter=community&filter=candidate&filter=todo)
+[Bekijk alle Help Wanted componenten](/componenten/?filter=community&filter=candidate&filter=todo&filter=hallOfFame)
 
 ## Community
 
@@ -59,7 +59,7 @@ Bestaat in de community, op één of meer plekken en voldoet aan de checklist to
 - Teams kunnen op elkaars onderdeel doorontwikkelen zodat de overlap duidelijk wordt voor doorontwikkeling naar "Candidate".
 - Innovatie op bestaande NL Design System "Candidate" of "Hall of Fame" mogelijk door "Community" uitbreiding op het bestaande onderdeel.
 
-[Bekijk alle Community componenten](/componenten/?filter=candidate&filter=todo&filter=helpWanted)
+[Bekijk alle Community componenten](/componenten/?filter=candidate&filter=todo&filter=helpWanted&filter=hallOfFame)
 
 ## Candidate
 
@@ -81,7 +81,7 @@ Voldoet aan de checklist tot en met "Candidate". Het kernteam verwacht dat het u
 - Best effort op toegankelijkheid. Specialisten uit het kernteam hebben het onderdeel gevalideerd en eventuele documentatie en verbeteringen zijn toegevoegd.
 - Voor componenten: Samenwerking tussen developers en designers is mogelijk gemaakt.
 
-[Bekijk alle Candidate componenten](/componenten/?filter=todo&filter=helpWanted&filter=community)
+[Bekijk alle Candidate componenten](/componenten/?filter=todo&filter=helpWanted&filter=community&filter=hallOfFame)
 
 ## Hall of Fame
 
@@ -101,6 +101,8 @@ Is bewezen door gebruik in productie bij ten minste twee verschillende organisat
 - Garantie op bruikbaarheid.
 - Voor componenten zijn automatische tests beschikbaar om regressies te voorkomen.
 - Richtlijnen zijn onderbouwd met referenties naar gebruikersonderzoek en toegankelijkheidsaudits.
+
+[Bekijk alle Hall of Fame componenten](/componenten/?filter=todo&filter=helpWanted&filter=community&filter=candidate)
 
 ## Discouraged
 

--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -42,6 +42,8 @@ Bestaat nog niet, maar de rationale is duidelijk, elke organisatie die hem nodig
 - Bewijs verzamelen dat een onderdeel door meerdere organisaties en producten gebruikt kan worden.
 - Zeker stellen dat een onderdeel aan de toegankelijkheidseisen kan voldoen en gebruiksvriendelijk kan zijn. Anders zal het als "Discouraged" aangemerkt worden.
 
+[Bekijk alle Help Wanted componenten](/componenten/?filter=community&filter=candidate&filter=todo)
+
 ## Community
 
 Door de community gebouwd volgens NL Design System richtlijnen.
@@ -56,6 +58,8 @@ Bestaat in de community, op één of meer plekken en voldoet aan de checklist to
 - Validatie dat een onderdeel door meerdere organisaties en producten gebruikt wordt.
 - Teams kunnen op elkaars onderdeel doorontwikkelen zodat de overlap duidelijk wordt voor doorontwikkeling naar "Candidate".
 - Innovatie op bestaande NL Design System "Candidate" of "Hall of Fame" mogelijk door "Community" uitbreiding op het bestaande onderdeel.
+
+[Bekijk alle Community componenten](/componenten/?filter=candidate&filter=todo&filter=helpWanted)
 
 ## Candidate
 
@@ -76,6 +80,8 @@ Voldoet aan de checklist tot en met "Candidate". Het kernteam verwacht dat het u
 - Onderdeel is behoorlijk stabiel en we verwachten dat er vanaf nu nog weinig veranderingen nodig zijn.
 - Best effort op toegankelijkheid. Specialisten uit het kernteam hebben het onderdeel gevalideerd en eventuele documentatie en verbeteringen zijn toegevoegd.
 - Voor componenten: Samenwerking tussen developers en designers is mogelijk gemaakt.
+
+[Bekijk alle Candidate componenten](/componenten/?filter=todo&filter=helpWanted&filter=community)
 
 ## Hall of Fame
 

--- a/src/components/ComponentOverview.tsx
+++ b/src/components/ComponentOverview.tsx
@@ -3,14 +3,20 @@ import { useHistory } from '@docusaurus/router';
 import { useCurrentSidebarCategory } from '@docusaurus/theme-common';
 import { useDocById } from '@docusaurus/theme-common/internal';
 import componentProgress from '@nl-design-system/component-progress/dist/index.json';
-import { AccordionProvider, Fieldset, FormToggle, Paragraph } from '@utrecht/component-library-react';
+import {
+  AccordionProvider,
+  Fieldset,
+  FormToggle,
+  Paragraph,
+  PrimaryActionButton,
+} from '@utrecht/component-library-react';
 import { Checkbox, FormField, FormLabel } from '@utrecht/component-library-react/dist/css-module';
 import { useEffect, useState } from 'react';
+import { COMPONENT_STATES, normalizeName, relayProjectIds } from '../utils';
 import { CardGroup } from './CardGroup';
 import { ComponentCard } from './ComponentCard';
-import { EstafetteBadge } from './EstafetteBadge';
-import { COMPONENT_STATES, normalizeName, relayProjectIds } from '../utils';
 import './ComponentOverview.css';
+import { EstafetteBadge } from './EstafetteBadge';
 
 export const ComponentOverview = () => {
   const SEARCH_PARAM = 'filter';
@@ -51,6 +57,11 @@ export const ComponentOverview = () => {
   const [showOnlyImplemented, setshowOnlyImplemented] = useState(
     params.has(SEARCH_PARAM, SEARCH_VALUES.ONLY_IMPLEMENTED),
   );
+
+  const showAllComponents = () => {
+    // Reset the filter and reload the page to show all components
+    window.location.search = '';
+  };
 
   useEffect(() => {
     setFilteredComponents(() =>
@@ -108,11 +119,6 @@ export const ComponentOverview = () => {
     replace({ ...location, search: params.toString() });
   }, [showTodo, showHelpWanted, showCommunity, showCandidate, showHallOfFame, showOnlyImplemented]);
 
-  const todo = components.filter((c) => c.relayStep === 'UNKNOWN');
-  const helpWanted = components.filter((c) => c.relayStep === 'HELP_WANTED');
-  const community = components.filter((c) => c.relayStep === 'COMMUNITY');
-  const candidate = components.filter((c) => c.relayStep === 'CANDIDATE');
-  const hallOfFame = components.filter((c) => c.relayStep === 'HALL_OF_FAME');
   const onlyImplemented = components.filter((c) =>
     c.projects?.filter((p) => {
       const results = !relayProjectIds.includes(p.id);
@@ -135,66 +141,52 @@ export const ComponentOverview = () => {
             body: (
               <>
                 <Fieldset aria-describedby="filter-results" aria-labelledby="filter-results-label">
-                  {!!todo.length && (
-                    <FormField type="checkbox">
-                      <Checkbox
-                        defaultChecked={showTodo}
-                        id="TODO"
-                        onChange={() => setShowTodo((checked) => !checked)}
-                      />
-                      <FormLabel htmlFor="TODO">
-                        <EstafetteBadge state="Todo" />
-                      </FormLabel>
-                    </FormField>
-                  )}
-                  {!!helpWanted.length && (
-                    <FormField type="checkbox">
-                      <Checkbox
-                        defaultChecked={showHelpWanted}
-                        id="HELP_WANTED"
-                        onChange={() => setShowHelpWanted((checked) => !checked)}
-                      />
-                      <FormLabel htmlFor="HELP_WANTED">
-                        <EstafetteBadge state="Help Wanted" />
-                      </FormLabel>
-                    </FormField>
-                  )}
-                  {!!community.length && (
-                    <FormField type="checkbox">
-                      <Checkbox
-                        defaultChecked={showCommunity}
-                        id="COMMUNITY"
-                        onChange={() => setShowCommunity((checked) => !checked)}
-                      />
-                      <FormLabel htmlFor="COMMUNITY">
-                        <EstafetteBadge state="Community" />
-                      </FormLabel>
-                    </FormField>
-                  )}
-                  {!!candidate.length && (
-                    <FormField type="checkbox">
-                      <Checkbox
-                        defaultChecked={showCandidate}
-                        id="CANDIDATE"
-                        onChange={() => setShowCandidate((checked) => !checked)}
-                      />
-                      <FormLabel htmlFor="CANDIDATE">
-                        <EstafetteBadge state="Candidate" />
-                      </FormLabel>
-                    </FormField>
-                  )}
-                  {!!hallOfFame.length && (
-                    <FormField type="checkbox">
-                      <Checkbox
-                        defaultChecked={showHallOfFame}
-                        id="HALL_OF_FAME"
-                        onChange={() => setShowHallOfFame((checked) => !checked)}
-                      />
-                      <FormLabel htmlFor="HALL_OF_FAME">
-                        <EstafetteBadge state="Hall of Fame" />
-                      </FormLabel>
-                    </FormField>
-                  )}
+                  <FormField type="checkbox">
+                    <Checkbox defaultChecked={showTodo} id="TODO" onChange={() => setShowTodo((checked) => !checked)} />
+                    <FormLabel htmlFor="TODO">
+                      <EstafetteBadge state="Todo" />
+                    </FormLabel>
+                  </FormField>
+                  <FormField type="checkbox">
+                    <Checkbox
+                      defaultChecked={showHelpWanted}
+                      id="HELP_WANTED"
+                      onChange={() => setShowHelpWanted((checked) => !checked)}
+                    />
+                    <FormLabel htmlFor="HELP_WANTED">
+                      <EstafetteBadge state="Help Wanted" />
+                    </FormLabel>
+                  </FormField>
+                  <FormField type="checkbox">
+                    <Checkbox
+                      defaultChecked={showCommunity}
+                      id="COMMUNITY"
+                      onChange={() => setShowCommunity((checked) => !checked)}
+                    />
+                    <FormLabel htmlFor="COMMUNITY">
+                      <EstafetteBadge state="Community" />
+                    </FormLabel>
+                  </FormField>
+                  <FormField type="checkbox">
+                    <Checkbox
+                      defaultChecked={showCandidate}
+                      id="CANDIDATE"
+                      onChange={() => setShowCandidate((checked) => !checked)}
+                    />
+                    <FormLabel htmlFor="CANDIDATE">
+                      <EstafetteBadge state="Candidate" />
+                    </FormLabel>
+                  </FormField>
+                  <FormField type="checkbox">
+                    <Checkbox
+                      defaultChecked={showHallOfFame}
+                      id="HALL_OF_FAME"
+                      onChange={() => setShowHallOfFame((checked) => !checked)}
+                    />
+                    <FormLabel htmlFor="HALL_OF_FAME">
+                      <EstafetteBadge state="Hall of Fame" />
+                    </FormLabel>
+                  </FormField>
                   <Paragraph style={{ '--utrecht-paragraph-margin-block-end': '1rem' }}>
                     <b>Tip</b>: Zien welke componenten je nu al kunt gebruiken? Kies dan onderstaande optie om alleen
                     beschikbare componenten te tonen.
@@ -220,6 +212,13 @@ export const ComponentOverview = () => {
       <Paragraph role="status" id="filter-results">
         {filteredComponents.length} van {components.length} componenten zichtbaar
       </Paragraph>
+
+      {filteredComponents.length === 0 && (
+        <Paragraph>
+          <PrimaryActionButton onClick={() => showAllComponents()}>Toon alle componenten</PrimaryActionButton>
+        </Paragraph>
+      )}
+
       <CardGroup appearance="large">
         {filteredComponents.map(({ title, id, href, description }) => {
           const component = componentProgress.find((item) => {


### PR DESCRIPTION
- Add links for each component status from Estafettemodel page to component overview page
- Add "Toon alle componenten" button to component overview page when no component matches the filter