### PR TITLE
Description Box Model correct aangepast

### DIFF
--- a/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
+++ b/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
@@ -3,7 +3,7 @@ title: Werk en denk vanuit het box model · Ruimte · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Box model
-pagination_label: MWerk en denk vanuit het box model
+pagination_label: Werk en denk vanuit het box model
 description: De spacing concepten van het NL Design System zijn gebouwd rond het fundamentele layout-principe van CSS, ook wel bekend als het ‘box model’.
 slug: /richtlijnen/stijl/ruimte/box-model
 keywords:

--- a/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
+++ b/docs/richtlijnen/stijl/space/2-boxing-model/README.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Box model
 pagination_label: MWerk en denk vanuit het box model
-description: Om ruimte consistent toe te passen is het verstandig om te werken met een vaste set aan waardes die oplopen in grootte. Een zogenoemde spacing scale.
+description: De spacing concepten van het NL Design System zijn gebouwd rond het fundamentele layout-principe van CSS, ook wel bekend als het ‘box model’.
 slug: /richtlijnen/stijl/ruimte/box-model
 keywords:
   - kleurcontrast


### PR DESCRIPTION
De description van Box Model had dezelfde tekst als Spacing Scale. Aangepast zodat het bij de inhoud klopt.