### PR TITLE
Categorie en advies wijziging succescriterium 2.5.2 aanwijzerannulering

### DIFF
--- a/.changeset/docs-ac-2.5.2-changes
+++ b/.changeset/docs-ac-2.5.2-changes
@@ -1,0 +1,7 @@
+---
+"@nl-design-system-unstable/nlds-design-tokens": minor
+---
+
+Advies voor WCAG 2.5.2 aangepast.
+In acceptatiecriteria waar WCAG 2.5.2 voorkomt, het criterium verplaatst van categorie Toetsenbord naar Algemeen.
+Enkele grammaticafoutjes opgelost.

--- a/docs/componenten/ac/_wcag-2.5.2-accordion.md
+++ b/docs/componenten/ac/_wcag-2.5.2-accordion.md
@@ -4,4 +4,4 @@ Zorg ervoor dat, als de gebruiker de accordion aanraakt met een enkele aanwijzer
 
 Dit voorkomt het per ongeluk aanraken en openen van content, wanneer het niet de bedoeling was.
 
-Met een zowel een `button` element als met een `details` en `summary` combinatie gaat dit automatisch goed. Met een div-element waarop `role= "button"` is geplaatst, moet zowel de toetsenbordinteractie als de interactie voor muis en touch nog worden toegevoegd. Gebruik voor dit laatste bij voorkeur het `click` event, omdat dit apparaatonafhankelijk is.
+Met een zowel een `button` element als met een `details` en `summary` combinatie gaat dit automatisch goed. Met een div-element waarop `role= "button"` is geplaatst, moet zowel de toetsenbordinteractie als de interactie voor muis en touch nog worden toegevoegd. Gebruik voor dit laatste bij voorkeur het `click`-event, omdat dit apparaatonafhankelijk is.

--- a/docs/componenten/ac/_wcag-2.5.2.md
+++ b/docs/componenten/ac/_wcag-2.5.2.md
@@ -2,8 +2,4 @@
 
 Als de gebruiker een interactief element indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid om de actie te voorkomen of ongedaan te maken.
 
-Dat kan op meerdere manieren:
-
-- De actie gebeurt pas bij het `up`-event, en de gebruiker kan nog de aanwijzer verplaatsen naar buiten het element om het `up`-event te voorkomen.
-- De actie gebeurt bij het `down`-event, maar bij het `up`-event wordt het effect weer ongedaan gemaakt.
-- Je kunt het effect achteraf weer ongedaan maken.
+Een manier om dit in te stellen, is dat de actie niet activeert als de bezoeker de aanwijzer indrukt, maar pas als de bezoeker de aanwijzer weer loslaat. Zo kan de bezoeker de aanwijzer nog verplaatsen naar buiten het element om de actie weer ongedaan te maken. Gebruik hiervoor bij voorkeur het `click`-event, omdat dit apparaatonafhankelijk is.

--- a/docs/componenten/accordion/index.mdx
+++ b/docs/componenten/accordion/index.mdx
@@ -102,6 +102,12 @@ export const component = componentProgress.find((item) => item.number === issueN
       component: <Wcag246 />,
     },
     {
+      title: "De bezoeker kan het openen van de accordion of een interactief element in de accordion annuleren",
+      sc: "2.5.2",
+      status: "",
+      component: <Wcag252 />,
+    },
+    {
       title: "De visuele naam van de accordion komt voor in de toegankelijke naam van de accordion",
       sc: "2.5.3",
       status: "",
@@ -237,12 +243,6 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.4.11",
       status: "",
       component: <Wcag2411 />,
-    },
-    {
-      title: "De bezoeker kan het openen van de accordion of een interactief element in de accordion annuleren",
-      sc: "2.5.2",
-      status: "",
-      component: <Wcag252 />,
     },
   ]}
 />

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -105,6 +105,13 @@ export const component = componentProgress.find((item) => item.number === issueN
       component: <Wcag246 />,
     },
     {
+      title:
+        "Als de gebruiker een button indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid om de actie te voorkomen of ongedaan te maken",
+      sc: "2.5.2",
+      status: "",
+      component: <Wcag252 />,
+    },
+    {
       title: "De zichtbare naam van de button is gelijk aan de toegankelijke naam",
       sc: "2.5.3",
       status: "",
@@ -200,13 +207,6 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.1.2",
       status: "",
       component: <Wcag212 />,
-    },
-    {
-      title:
-        "Als de gebruiker een button indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid is om actie te voorkomen of ongedaan te maken",
-      sc: "2.5.2",
-      status: "",
-      component: <Wcag252 />,
     },
     {
       title: "Als de Button de toetsenbordfocus krijgt, is het element niet volledig bedekt door andere inhoud",

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -92,6 +92,13 @@ export const component = componentProgress.find((item) => item.number === issueN
       component: <Wcag244 />,
     },
     {
+      title:
+        "Als de gebruiker de Link indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid om de actie te voorkomen of ongedaan te maken",
+      sc: "2.5.2",
+      status: "",
+      component: <Wcag252 />,
+    },
+    {
       title: "De zichtbare naam van de Link komt voor in de toegankelijke naam",
       sc: "2.5.3",
       status: "",
@@ -194,13 +201,6 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.4.11",
       status: "",
       component: <Wcag2411 />,
-    },
-    {
-      title:
-        "Als de gebruiker de Link indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid is om actie te voorkomen of ongedaan te maken",
-      sc: "2.5.2",
-      status: "",
-      component: <Wcag252 />,
     },
   ]}
 />

--- a/docs/componenten/login-link/index.mdx
+++ b/docs/componenten/login-link/index.mdx
@@ -81,6 +81,13 @@ export const component = componentProgress.find((item) => item.number === issueN
       component: <Wcag244 />,
     },
     {
+      title:
+        "Als de gebruiker de Login Link indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid om de actie te voorkomen of ongedaan te maken",
+      sc: "2.5.2",
+      status: "",
+      component: <Wcag252 />,
+    },
+    {
       title: "De zichtbare naam van de Login Link komt voor in de toegankelijke naam",
       sc: "2.5.3",
       status: "",
@@ -183,13 +190,6 @@ export const component = componentProgress.find((item) => item.number === issueN
       sc: "2.4.11",
       status: "",
       component: <Wcag2411 />,
-    },
-    {
-      title:
-        "Als de gebruiker de Login Link indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid is om actie te voorkomen of ongedaan te maken",
-      sc: "2.5.2",
-      status: "",
-      component: <Wcag252 />,
     },
   ]}
 />

--- a/docs/wcag/summaries/_2.5.2-summary.md
+++ b/docs/wcag/summaries/_2.5.2-summary.md
@@ -1,12 +1,12 @@
 <!-- @license CC0-1.0 -->
 
-Zorg ervoor dat, als de gebruiker bijvoorbeeld een link of button indrukt met een aanwijzer zoals een muis of vinger, er de mogelijkheid is om actie te voorkomen of ongedaan te maken.
+Zorg ervoor dat, als de gebruiker bijvoorbeeld een link of button indrukt met een aanwijzer zoals een muis of vinger, er de mogelijkheid is om de actie te voorkomen of ongedaan te maken.
 
 Dit voorkomt het per ongeluk aanraken en activeren van functies, waarvan het niet de bedoeling was.
 
 Dat kan op meerdere manieren:
 
-- De actie gebeurt pas bij het `up`-event, en de gebruiker kan nog de aanwijzer verplaatsen naar buiten het element om het up-event te voorkomen.
+- De gebruiker kan de aanwijzer nog verplaatsen naar buiten het element om het activeren van de actie te voorkomen. Gebruik hier bij voorkeur het `click`-event voor, omdat dit apparaatonafhankelijk is.
 - De actie gebeurt bij het `down`-event, maar bij het `up`-event wordt het effect weer ongedaan gemaakt.
 - Je kunt het effect achteraf weer ongedaan maken.
 


### PR DESCRIPTION
closes #2119 
closes #2145 

Succescriterium 2.5.2 aanwijzerannulering verplaatst van Toetsenbord naar Algemeen bij Accordion, Button, Link en Login link.

Snippets voor 2.5.2 aanwijzerannulering aangepast, waarin nu staat dat het click-event de voorkeur heeft.