### PR TITLE
Docs/wcag 1.4.11 full

### DIFF
--- a/.changeset/wcag-1.4.11-full-page.md
+++ b/.changeset/wcag-1.4.11-full-page.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": patch
+---
+
+Tekst [WCAG-pagina 1.4.11](/wcag/1.4.11) volledig afgemaakt.

--- a/docs/wcag/1.4.03.mdx
+++ b/docs/wcag/1.4.03.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.3 Contrast (minimum)
 pagination_label: WCAG-succescriterium 1.4.3 Contrast (minimum)
-description: Het contrast van de tekstkleur ten opzichte van de achtergrondkleur moet hoog genoeg zijn, zodat de tekst in het algemeen goed leesbaar wordt gevonden.
+description: Het contrast van de tekstkleur ten opzichte van de achtergrondkleur moet sterk genoeg zijn, zodat de tekst in het algemeen goed leesbaar wordt gevonden.
 slug: 1.4.3
 keywords:
   - WCAG
@@ -56,7 +56,7 @@ Neem ook afbeeldingen waar tekst in staat mee, als deze tekst onderdeel is van d
 
 _Let op_: Deze eis geldt niet voor tekst op een afbeelding van een logo of van een merknaam, of tekst op een afbeelding die alleen ter decoratie dient en geen deel uitmaakt van de inhoud.
 
-Het NL Design System biedt een makkelijke tool voor het bepalen van kleurcontrast aan. Door het invoeren van de hexadecimale code van de tekstkleur en achtergrondkleur kun je controleren of de tekst voldoet aan WCAG op: [Contrast van kleuren](https://nldesignsystem.nl/contrast/?color=%23999999&background-color=%23f8f5f1).
+Het NL Design System biedt een makkelijke tool voor het bepalen van kleurcontrast aan. Door het invoeren van de hexadecimale code van de tekstkleur en achtergrondkleur kun je controleren of de tekst voldoet aan WCAG op: [Contrast van kleuren](https://nldesignsystem.nl/contrast/).
 
 Voor ontwerpers is er voor Figma een aantal goede tools: [Figma contrast accessibility plugin tools](https://www.figma.com/community/accessibility/contrast).
 

--- a/docs/wcag/1.4.03.mdx
+++ b/docs/wcag/1.4.03.mdx
@@ -73,7 +73,7 @@ Controleer in de volgende situaties of het kleurcontrast van de tekst voldoende 
 - Verschillende gebruikelijke schermgroottes inclusief mobiele weergave.
 - Verschillend oriëntaties: _portrait_ en _landscape_.
 - Vergroot de tekst alleen tot 200%.
-- Zoom in tot 400% vanaf schermbreedte van 1280px (of zet de schermbreedte op 320px).
+- Zoom in tot 400% vanaf schermbreedte van 1280 pixels (of zet de schermbreedte op 320 pixels).
 - Is er een dark mode aanwezig? Test ook hier het kleurcontrast van de tekst.
 - Controleer het kleurcontrast van placeholders.
 - Controleer de verschillende weergave van buttons en de links zoals: met toetsenbordfocus, als je er overheen hovert met de muis, ingedrukt, al eerder bezocht.

--- a/docs/wcag/1.4.03.mdx
+++ b/docs/wcag/1.4.03.mdx
@@ -73,7 +73,7 @@ Controleer in de volgende situaties of het kleurcontrast van de tekst voldoende 
 - Verschillende gebruikelijke schermgroottes inclusief mobiele weergave.
 - Verschillend oriëntaties: _portrait_ en _landscape_.
 - Vergroot de tekst alleen tot 200%.
-- Zoom in tot 400%.
+- Zoom in tot 400% vanaf schermbreedte van 1280px (of zet de schermbreedte op 320px).
 - Is er een dark mode aanwezig? Test ook hier het kleurcontrast van de tekst.
 - Controleer het kleurcontrast van placeholders.
 - Controleer de verschillende weergave van buttons en de links zoals: met toetsenbordfocus, als je er overheen hovert met de muis, ingedrukt, al eerder bezocht.

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.11 Contrast van niet-tekstuele content
 pagination_label: WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content
-description: Zorg voor voldoende kleurcontrast tussen de achtergrondkleur en de kleur van componenten die visueel betekenis hebben.
+description: Het contrast van essentiele onderdelen van componenten  en de directe omgeving moet sterk genoeg zijn, zodat de onderdelen herkenbaar zijn.
 slug: 1.4.11
 keywords:
   - WCAG
@@ -31,20 +31,47 @@ import Summary from "./summaries/_1.4.11-summary.md";
 ## Gerelateerde NL Design System-richtlijnen
 
 - Stijl: [Kleuren](/richtlijnen/stijl/iconen).
-- Formulieren: [Visuel ontwerp](/richtlijnen/formulieren/visueel-ontwerp).
+- Formulieren: [Visueel ontwerp](/richtlijnen/formulieren/visueel-ontwerp).
 
-## Bronnen
+## Bronnen en tools
+
+- Een overzicht van goede bronnen en tools voor kleurcontrast staat bij [Richtlijnen NL Design System voor kleuren](/richtlijnen/stijl/kleuren/).
+- [Figma contrast accessibility plugin tools](https://www.figma.com/community/accessibility/contrast).
+- [axe DevTools browser add-on](https://www.deque.com/axe/browser-extensions/).
+- [WAVE Web Accessibility Evaluation Tools](https://wave.webaim.org/).
+- [Colour Contrast Analyser (CCA)](https://www.tpgi.com/color-contrast-checker/).
+- [Contrast van kleuren - NL Design System](https://nldesignsystem.nl/contrast/).
+
+## Hoe te testen
+
+Naast tekst ([WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3)) moet ook andere essentiele content goed zichtbaar zijn.
+
+Dit kan bijvoorbeeld gaan om grafische objecten (zoals iconen en delen van complexe diagrammen). Het contrast van het (deel van het) icoon dat nodig is voor begrip, moet een contrast van 3.0:1 hebben met de directe omgeving.
+
+Het kan ook gaan om een component van de gebruikersinterface (zoals een link, een knop of een formulier element). Dan moet de visuele informatie die nodig is om het component (of de status ervan) te identificeren een contrast van 3.0:1 hebben met de directe omgeving.
+
+_Let op_: Als een knop een goede "call to action" heeft, dan moet deze tekst ([WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3)) voldoen aan de contrasteisen van tekst, en mag de knop onopvallend zijn. Is er geen "call to action" identificatie? Dan moet de knop zelf contrastrijk genoeg zijn.
+
+_Let op_: Controleer het kleurcontrast altijd in de gegenereerde webpagina in een browser en niet alleen in de code zelf. Linters kunnen helpen om laaghangend fruit te ondervangen, maar de eindtest voor kleurcontrast moet gebeuren op de webpagina zelf als alle componenten worden samengevoegd tot één geheel.
+
+Controleer in de volgende situaties of het kleurcontrast van de componenten voldoende blijft:
+
+- Verschillende gebruikelijke schermgroottes inclusief mobiele weergave.
+- Verschillend oriëntaties: _portrait_ en _landscape_.
+- Vergroot de tekst alleen tot 200%.
+- Zoom in tot 400%.
+- Is er een dark mode aanwezig? Test ook hier het kleurcontrast van de componenten.
+- Controleer de verschillende weergaves en statussen van buttons, menus en de links zoals: met toetsenbordfocus, als je er overheen hovert met de muis, ingedrukt, en al eerder bezocht.
+- Vergeet ook de skiplinks niet.
 
 ## Gebruikersonderzoek
 
 <CTAGebruikersonderzoek />
 
-## Hoe te testen
-
 ## W3C referenties
 
 - Engelse tekst van het WCAG-succescriterium: [<span lang="en">1.4.11 Non-text Contrast</span>](https://www.w3.org/TR/WCAG22/#non-text-contrast).
-- Nederlandse vertaling van het WCAG-succescriterium: [1.4.11 Contrast van niet-tekstuele content](https://www.w3.org/Translations/WCAG22-nl/#contrast-van-niet-tekstuele-content).
+- Nederlandse vertaling van het WCAG-succescriterium: [1.4.11 Contrast van niet-tekstuele content](https://www.w3.org/Translations/WCAG22-nl/#non-text-contrast).
 - Engelstalige informatie op <span lang="en">How to Meet WCAG</span>: [<span lang="en">Quick Reference 1.4.11 Non-text Contrast</span>](https://www.w3.org/WAI/WCAG22/quickref/#non-text-contrast).
 - Engelstalige toelichting: [<span lang="en">Understanding SC 1.4.11 Non-text Contrast</span>](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html).
 

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -28,13 +28,15 @@ import Summary from "./summaries/_1.4.11-summary.md";
 
 <Summary />
 
-## Opgelet
+## Gerelateerde NL Design System-richtlijnen
 
-Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+## Bronnen
 
 ## Gebruikersonderzoek
 
 <CTAGebruikersonderzoek />
+
+## Hoe te testen
 
 ## W3C referenties
 

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.11 Contrast van niet-tekstuele content
 pagination_label: WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content
-description: Het contrast van essentiele onderdelen van componenten  en de directe omgeving moet sterk genoeg zijn, zodat de onderdelen herkenbaar zijn.
+description: Het contrast van essentiele onderdelen van componenten en de directe omgeving moet sterk genoeg zijn, zodat de onderdelen herkenbaar zijn.
 slug: 1.4.11
 keywords:
   - WCAG
@@ -46,11 +46,11 @@ import Summary from "./summaries/_1.4.11-summary.md";
 
 Naast tekst ([WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3)) moet ook andere essentiele content goed zichtbaar zijn.
 
-Dit kan bijvoorbeeld gaan om grafische objecten (zoals iconen en delen van complexe diagrammen). Het contrast van het (deel van het) icoon dat nodig is voor begrip, moet een contrast van 3.0:1 hebben met de directe omgeving.
+Dit kan bijvoorbeeld gaan om grafische objecten, zoals iconen en delen van complexe diagrammen. Het contrast van het (deel van het) icoon dat nodig is voor begrip, moet een contrast van 3.0:1 hebben met de directe omgeving.
 
-Het kan ook gaan om een component van de gebruikersinterface (zoals een link, een knop of een formulier element). Dan moet de visuele informatie die nodig is om het component (of de status ervan) te identificeren een contrast van 3.0:1 hebben met de directe omgeving.
+Het kan ook gaan om een component van de gebruikersinterface, zoals een link, een knop of een formulier element). Dan moet de visuele informatie die nodig is om het component (of de status ervan) te identificeren een contrast van 3.0:1 hebben met de directe omgeving.
 
-_Let op_: Als een knop een goede "call to action" heeft, dan moet deze tekst ([WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3)) voldoen aan de contrasteisen van tekst, en mag de knop onopvallend zijn. Is er geen "call to action" identificatie? Dan moet de knop zelf contrastrijk genoeg zijn.
+_Let op_: Als een component van de gebruikersinterface een tekst bevat, dan moet deze tekst ([WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3)) voldoen aan de contrasteisen van tekst, en mag de knop onopvallend zijn. Als deze een afbeelding bevat, dan is successcriterium 1.4.11 van toepassing op de afbeelding. Bevat het component niks dat het component identificeert? Dan moet het component zelf contrastrijk genoeg zijn.
 
 _Let op_: Controleer het kleurcontrast altijd in de gegenereerde webpagina in een browser en niet alleen in de code zelf. Linters kunnen helpen om laaghangend fruit te ondervangen, maar de eindtest voor kleurcontrast moet gebeuren op de webpagina zelf als alle componenten worden samengevoegd tot één geheel.
 
@@ -59,7 +59,7 @@ Controleer in de volgende situaties of het kleurcontrast van de componenten vold
 - Verschillende gebruikelijke schermgroottes inclusief mobiele weergave.
 - Verschillend oriëntaties: _portrait_ en _landscape_.
 - Vergroot de tekst alleen tot 200%.
-- Zoom in tot 400%.
+- Zoom in tot 400% vanaf schermbreedte van 1280px (of zet de schermbreedte op 320px).
 - Is er een dark mode aanwezig? Test ook hier het kleurcontrast van de componenten.
 - Controleer de verschillende weergaves en statussen van buttons, menus en de links zoals: met toetsenbordfocus, als je er overheen hovert met de muis, ingedrukt, en al eerder bezocht.
 - Vergeet ook de skiplinks niet.

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -30,6 +30,9 @@ import Summary from "./summaries/_1.4.11-summary.md";
 
 ## Gerelateerde NL Design System-richtlijnen
 
+- Stijl: [Kleuren](/richtlijnen/stijl/iconen).
+- Formulieren: [Visuel ontwerp](/richtlijnen/formulieren/visueel-ontwerp).
+
 ## Bronnen
 
 ## Gebruikersonderzoek

--- a/docs/wcag/summaries/_1.4.11-summary.md
+++ b/docs/wcag/summaries/_1.4.11-summary.md
@@ -1,6 +1,7 @@
 <!-- @license CC0-1.0 -->
 
-Zorg voor voldoende kleurcontrast tussen de achtergrondkleur en de kleur van componenten die visueel betekenis hebben.
+Zorg voor voldoende kleurcontrast tussen de kleur van componenten die visueel betekenis hebben.
+en hun directe omgeving.
 
 Bijvoorbeeld:
 
@@ -8,6 +9,4 @@ Bijvoorbeeld:
 - Een icoon dat de status aangeeft van een bericht zoals een oranje driehoek voor een waarschuwing en een groen vinkje voor succes.
 - Een rode rand die aangeeft dat een invoerveld fouten bevat (als aanvulling op de foutmelding in tekst).
 
-Het gemeten kleurcontrast tussen het element en de achtergrond moet minstens 3:1 zijn.
-
-Er is een uitzondering voor inactieve componenten, zoals uitgeschakelde buttons, invoervelden, aankruisvakjes en keuzerondjes. En voor het kleurcontrast voor componenten die door de browser worden bepaald en niet niet kunnen worden veranderd.
+Het gemeten kleurcontrast tussen het element en de omgeving moet minstens 3:1 zijn.

--- a/docs/wcag/summaries/_1.4.11-summary.md
+++ b/docs/wcag/summaries/_1.4.11-summary.md
@@ -1,7 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-Zorg voor voldoende kleurcontrast tussen de kleur van componenten die visueel betekenis hebben.
-en hun directe omgeving.
+Zorg voor voldoende kleurcontrast tussen de kleur van componenten die visueel betekenis hebben en hun directe omgeving.
 
 Bijvoorbeeld:
 


### PR DESCRIPTION
Preview: [WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content](https://documentatie-git-docs-wcag-1411-full-nl-design-system.vercel.app/wcag/1.4.11)