### PR TITLE
chore: reference correct package in changesets

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,7 +4,7 @@ Kopieer en plak het onderstaande sjabloon. Je kunt hiervoor de kopieer knop link
 
 ```markdown
 ---
-"@nl-design-system-unstable/nlds-design-tokens": major
+"@nl-design-system-unstable/documentation": major
 ---
 
 Beschrijving
@@ -15,9 +15,9 @@ dubbele aanhalingstekens op een nieuwe regel.
 
 Gebruik:
 
-- `"@nl-design-system-unstable/nlds-design-tokens": major` voor breaking changes
-- `"@nl-design-system-unstable/nlds-design-tokens": minor` voor nieuwe features
-- `"@nl-design-system-unstable/nlds-design-tokens": patch` voor bug fixes
+- `"@nl-design-system-unstable/documentation": major` voor breaking changes
+- `"@nl-design-system-unstable/documentation": minor` voor nieuwe features
+- `"@nl-design-system-unstable/documentation": patch` voor bug fixes
 
 Beschrijf na de tweede set `---` welke veranderingen je hebt doorgevoerd.
 

--- a/.changeset/ac-accordion.md
+++ b/.changeset/ac-accordion.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria aangepast voor component Accordion.

--- a/.changeset/ac-code-block.md
+++ b/.changeset/ac-code-block.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor component Code Block.

--- a/.changeset/ac-code.md
+++ b/.changeset/ac-code.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor component Code.

--- a/.changeset/ac-color-sample.md
+++ b/.changeset/ac-color-sample.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor component Color Sample.

--- a/.changeset/ac-keybordtrap.md
+++ b/.changeset/ac-keybordtrap.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 WCAG 2.1.2 Geen toetsenbordval toegevoegd aan de acceptatiecriteria voor de componenten Button, Login Link en Link.

--- a/.changeset/ac-login-link.md
+++ b/.changeset/ac-login-link.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor component Login Link.

--- a/.changeset/ac-mark.md
+++ b/.changeset/ac-mark.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor component Mark.

--- a/.changeset/ac-word-break.md
+++ b/.changeset/ac-word-break.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Voegt optie voor word-break to aan de relevante acceptatiecriteria.

--- a/.changeset/baseline.md
+++ b/.changeset/baseline.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Baseline toegankelijkheidsondersteuning toegevoegd.

--- a/.changeset/docs-button-text.md
+++ b/.changeset/docs-button-text.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Richtlijnen voor buttonteksten gelijkgetrokken met hoe ze in meerstappenformulieren gebruikt gaan worden.

--- a/.changeset/docs-tekst-verplicht-veld.md
+++ b/.changeset/docs-tekst-verplicht-veld.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Richtlijnen voor teksten om verplichte velden aan te geven vereenvoudigd.

--- a/.changeset/remove-wcag-2.4.13-for-now.md
+++ b/.changeset/remove-wcag-2.4.13-for-now.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Acceptatiecriteria voor WCAG 2.1.3 Focus Weergave worden voor nu verwijderd voor de Candidate componenten. In het eerste kwartaal zat dit succescriterium weer worden toegevoegd na meer onderzoek over de exacte implementatie.

--- a/.changeset/richtlijnen-rich-text-kopjes.md
+++ b/.changeset/richtlijnen-rich-text-kopjes.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Richtlijnen voor rich text en headings in een formulier toegevoegd.

--- a/.changeset/richtlijnen-voortgang.md
+++ b/.changeset/richtlijnen-voortgang.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Richtlijnen voor het aangeven van de voortgang gelijkgetrokken met hoe ze in meerstappenformulieren gebruikt gaan worden.

--- a/.changeset/scheidingsteken.md
+++ b/.changeset/scheidingsteken.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Verandering in het title element in de head. De trailing delimiter en het scheidingsteken tussen items zijn veranderd van | naar ·

--- a/.changeset/wcag-1.3.3-full-page.md
+++ b/.changeset/wcag-1.3.3-full-page.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Tekst [WCAG-pagina 1.3.3](/wcag/1.3.3) volledig afgemaakt.

--- a/.changeset/wcag-1.4.1-full-page.md
+++ b/.changeset/wcag-1.4.1-full-page.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/nlds-design-tokens": minor
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Tekst [WCAG-pagina 1.4.1](/wcag/1.4.1) volledig afgemaakt.


### PR DESCRIPTION
All these changes are for documentation repo, not nlds-design-tokens. The default is also documentation repo, which is why we updated the README.md in the .changeset folder.

Found when reviewing a PR with Renate.

Next step is to merge the publication PR, which was created in oct 2024: https://github.com/nl-design-system/documentatie/pull/1540.