### PR TITLE
docs: wcag 1.4.10 full page

### DIFF
--- a/.changeset/wcag-1.4.10-full-page.md
+++ b/.changeset/wcag-1.4.10-full-page.md
@@ -1,5 +1,5 @@
 ---
-"@nl-design-system-unstable/documentation": patch
+"@nl-design-system-unstable/documentation": minor
 ---
 
 Tekst [WCAG-pagina 1.4.10](/wcag/1.4.10) volledig afgemaakt.

--- a/.changeset/wcag-1.4.10-full-page.md
+++ b/.changeset/wcag-1.4.10-full-page.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": patch
+---
+
+Tekst [WCAG-pagina 1.4.10](/wcag/1.4.10) volledig afgemaakt.

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.10 Reflow
 pagination_label: WCAG-succescriterium 1.4.10 Reflow
-description: De gebruiker moet de webpagina tot 400% kunnen vergroten in de browser zonder verlies van inhoud of functionaliteit.
+description: De gebruiker moet de webpagina tot 400% kunnen vergroten in de browser. De content en werking moeten dan nog hetzelfde zijn.
 slug: 1.4.10
 keywords:
   - WCAG
@@ -32,8 +32,8 @@ import Summary from "./summaries/_1.4.10-summary.md";
 
 Er zijn minimaal 2 manieren om tot 400% te vergroten en dit criterium te testen.
 
-1. Stel de schermbreedte van de browser op 1280px breedte. Dit kan vaak via de developer tools. Zoom vervolgens in in de browser naar een percentage van 400%.
-2. Stel de schermbreedte van de browser in op 320px breedte. Dit komt overeen met 1280px en 4 maal vergroten.
+1. Stel de schermbreedte van de browser op 1280 pixels breedte. Dit kan vaak via de developer tools. Zoom vervolgens in in de browser naar een percentage van 400%.
+2. Stel de schermbreedte van de browser in op 320 pixels breedte. Dit komt overeen met 1280 pixels en 4 maal vergroten.
 
 Als de browser op 1 van deze 2 manieren ingesteld is, controleer dan het volgende:
 

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.10 Reflow
 pagination_label: WCAG-succescriterium 1.4.10 Reflow
-description: De gebruiker moet de webpagina 400% kunnen vergroten in de browser en inhoud nog steeds kunnen lezen en de website goed kunnen gebruiken.
+description: De gebruiker moet de webpagina tot 400% kunnen vergroten in de browser zonder verlies van inhoud of functionaliteit.
 slug: 1.4.10
 keywords:
   - WCAG
@@ -28,9 +28,18 @@ import Summary from "./summaries/_1.4.10-summary.md";
 
 <Summary />
 
-## Opgelet
+## Hoe te testen
 
-Deze inhoud wordt binnenkort aangevuld met uitgebreidere uitleg, bronnen en informatie over hoe te testen.
+Er zijn minimaal 2 manieren om tot 400% te vergroten en dit criterium te testen.
+
+1. Stel de schermbreedte van de browser op 1280px breedte. Dit kan vaak via de developer tools. Zoom vervolgens in in de browser naar een percentage van 400%.
+2. Stel de schermbreedte van de browser in op 320px breedte. Dit komt overeen met 1280px en 4 maal vergroten.
+
+Als de browser op 1 van deze 2 manieren ingesteld is, controleer dan het volgende:
+
+- Zijn er horizontale scrollbars aanwezig?
+- Is alle content nog bereikbaar en te lezen? Het hoeft niet meteen zichtbaar te zijn. Een ingeklapt menu is een voldoende alternatief voor een zichtbaar menu.
+- Is alle functionaliteit nog bereikbaar en bruikbaar?
 
 ## Gebruikersonderzoek
 

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -37,9 +37,11 @@ Er zijn minimaal 2 manieren om tot 400% te vergroten en dit criterium te testen.
 
 Als de browser op 1 van deze 2 manieren ingesteld is, controleer dan het volgende:
 
-- Zijn er horizontale scrollbars aanwezig?
-- Is alle content nog bereikbaar en te lezen? Het hoeft niet meteen zichtbaar te zijn. Een ingeklapt menu is een voldoende alternatief voor een zichtbaar menu.
-- Is alle functionaliteit nog bereikbaar en bruikbaar?
+- Er mogen geen horizontale scrollbars
+- Alle content moet bereikbaar en leesbaar zijn. Het hoeft niet meteen zichtbaar te zijn. Dit mag ook in accordions of andere uitklapbare delen zijn.
+- Alle functionaliteit moet ook bereikbaar en bruikbaar zijn. Een ingeklapt menu is een voldoende alternatief voor een zichtbaar menu.
+
+Er is een uitzondering voor content die voor het gebruik of de betekenis een tweedimensionale lay-out vereist. Denk hierbij aan bepaalde tabellen, kaarten en datavisualizaties die niet gesplitst en gescheiden kunnen worden. In die gevallen kunnen er lokaal scrollbars aanwezig zijn.
 
 ## Gebruikersonderzoek
 

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -4,7 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1.4.10 Reflow
 pagination_label: WCAG-succescriterium 1.4.10 Reflow
-description: De gebruiker moet de webpagina tot 400% kunnen vergroten in de browser. De content en werking moeten dan nog hetzelfde zijn.
+description: De gebruiker moet de webpagina tot 400% kunnen vergroten in de browser. Dezelfde inhoud moet aanwezig zijn, en alles moet nog op eenzelfde manier werken.
 slug: 1.4.10
 keywords:
   - WCAG

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -37,7 +37,7 @@ Er zijn minimaal 2 manieren om tot 400% te vergroten en dit criterium te testen.
 
 Als de browser op 1 van deze 2 manieren ingesteld is, controleer dan het volgende:
 
-- Er mogen geen horizontale scrollbars
+- Er mogen geen horizontale scrollbars zijn.
 - Alle content moet bereikbaar en leesbaar zijn. Het hoeft niet meteen zichtbaar te zijn. Dit mag ook in accordions of andere uitklapbare delen zijn.
 - Alle functionaliteit moet ook bereikbaar en bruikbaar zijn. Een ingeklapt menu is een voldoende alternatief voor een zichtbaar menu.
 

--- a/docs/wcag/summaries/_1.4.10-summary.md
+++ b/docs/wcag/summaries/_1.4.10-summary.md
@@ -4,8 +4,8 @@ De gebruiker moet de webpagina 400% kunnen vergroten in de browser. Het gaat hie
 
 Alle functies, zoals het menu, moeten werken en zichtbaar zijn. Alle tekst moet leesbaar zijn.
 
-Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of gedeeltelijk verborgen worden door andere inhoud wanneer de gebruiker 400% inzoomt of op een buitengewoon klein scherm werkt (320 bij 256 CSS).
+Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of gedeeltelijk verborgen worden door andere inhoud wanneer de gebruiker 400% inzoomt of op een buitengewoon klein scherm werkt (320 bij 256 CSS pixels).
 
-Zorg ervoor dat er geen horizontale scrollbar nodig is. Uitzonderingen zijn voor onderdelen die in essentie twee-dimensionaal zijn, zoals bijvoorbeeld: tabellen, grafieken, video's en landkaarten.
+Zorg ervoor dat er geen horizontale scrollbar nodig is. Uitzonderingen zijn voor onderdelen die in essentie twee-dimensionaal zijn, zoals tabellen, grafieken, video's en landkaarten.
 
-Definieer in de CSS een wijze om lange woorden af te breken en te laten doorlopen op de volgende regel. Zodat er geen horizontale scrollbar ontstaat of tekst onleesbaar wordt.
+Definieer in de CSS een wijze om lange woorden af te breken en door te laten lopen op de volgende regel. Voorkom zo een horizontale scrollbar en onleesbare tekst.

--- a/docs/wcag/summaries/_1.4.10-summary.md
+++ b/docs/wcag/summaries/_1.4.10-summary.md
@@ -4,7 +4,7 @@ De gebruiker moet de webpagina 400% kunnen vergroten in de browser. Het gaat hie
 
 Alle functies, zoals het menu, moeten werken en zichtbaar zijn. Alle tekst moet leesbaar zijn.
 
-Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of gedeeltelijk verborgen worden door andere inhoud wanneer de gebruiker 400% inzoomt of op een buitengewoon klein scherm werkt (320 bij 256 CSS pixels).
+Er mag geen inhoud buiten beeld vallen, onbereikbaar of verborgen zijn of gedeeltelijk verborgen worden door andere inhoud wanneer de gebruiker 400% inzoomt of op een buitengewoon klein scherm werkt (320 bij 256 pixels).
 
 Zorg ervoor dat er geen horizontale scrollbar nodig is. Uitzonderingen zijn voor onderdelen die in essentie twee-dimensionaal zijn, zoals tabellen, grafieken, video's en landkaarten.
 


### PR DESCRIPTION
2 punten van twijfel:
- Moet ik termen verder uitleggen of duiden? Sommige termen zijn vooral in het Engels goed vindbaar (zoals viewport) en dan is het gebruik van het Nederlandse "schermbreedte" misschien een drempel om meer informatie te vinden.
- Moet ik verder uitleggen hoe je iets in een browser moet doen? Het voelt nu wel vrij minimaal, maar het lijkt me ook niet de bedoeling om browser-documentatie te schrijven.