### PR TITLE
feat: add overview page for publishing new versions

### DIFF
--- a/docs/handboek/designer/nieuwe-versie-publiceren/README.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/README.md
@@ -25,16 +25,16 @@ Onder deze pagina vind je drie soorten documentatie.
 
 We gebruiken semantic versioning, ofwel semver, om aan te geven wat voor soort wijziging er is doorgevoerd: een patch, minor of major. Deze pagina legt uit wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
 
-[Lees meer over versiebeheer van design tokens]()
+[Lees meer over versiebeheer van design tokens](https://nldesignsystem.nl/)
 
 ## Werken met changelog voor Figma
 
 Voor designers die werken met een duplicaat van onze Figma bibliotheken, beschrijven we hoe de changelog werkt: wat je erin kunt vinden, hoe je het leest en wat je ermee kunt doen.
 
-[Bekijk hoe de changelog werkt]()
+[Bekijk hoe de changelog werkt](https://nldesignsystem.nl/)
 
 ## Changelog Figma
 
 Het overzicht van alle wijzigingen in de Figma bibliotheken.
 
-[Ga naar het overzicht met wijzigingen]()
+[Ga naar het overzicht met wijzigingen](https://nldesignsystem.nl/)

--- a/docs/handboek/designer/nieuwe-versie-publiceren/README.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/README.md
@@ -22,16 +22,19 @@ De Figma bibliotheken en het JSON bestand met de design tokens zijn voortdurend 
 Onder deze pagina vind je drie soorten documentatie.
 
 ## Versiebeheer van design tokens
+
 We gebruiken semantic versioning, ofwel semver, om aan te geven wat voor soort wijziging er is doorgevoerd: een patch, minor of major. Deze pagina legt uit wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
 
 [Lees meer over versiebeheer van design tokens]()
 
 ## Werken met changelog voor Figma
-Voor designers die werken met een duplicaat van onze Figma bibliotheken, beschrijven we hoe de changelog werkt: wat je erin kunt vinden, hoe je het leest en wat je ermee kunt doen. 
+
+Voor designers die werken met een duplicaat van onze Figma bibliotheken, beschrijven we hoe de changelog werkt: wat je erin kunt vinden, hoe je het leest en wat je ermee kunt doen.
 
 [Bekijk hoe de changelog werkt]()
 
 ## Changelog Figma
+
 Het overzicht van alle wijzigingen in de Figma bibliotheken.
 
 [Ga naar het overzicht met wijzigingen]()

--- a/docs/handboek/designer/nieuwe-versie-publiceren/README.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/README.md
@@ -1,0 +1,37 @@
+---
+title: Nieuwe versie publiceren · Designer · Handboek
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Nieuwe versie publiceren
+sidebar_position: 3
+pagination_label: Nieuwe versie publiceren
+description: Informatie over het bijhouden van wijzigingen in design tokens en Figma bibliotheken voor designers.
+keywords:
+  - versiebeheer
+  - changelog
+  - semantic versioning
+  - major
+  - minor
+  - patch
+---
+
+# Nieuwe versie publiceren
+
+De Figma bibliotheken en het JSON bestand met de design tokens zijn voortdurend in ontwikkeling. Nieuwe tokens worden toegevoegd, bestaande tokens worden aangepast en ook Figma bibliotheken veranderen mee. Om deze wijzigingen helder te documenteren en goed te communiceren, houden we op verschillende manieren bij wat er verandert, wanneer dat gebeurt en wat dat betekent voor jou als designer.
+
+Onder deze pagina vind je drie soorten documentatie.
+
+## Versiebeheer van design tokens
+We gebruiken semantic versioning, ofwel semver, om aan te geven wat voor soort wijziging er is doorgevoerd: een patch, minor of major. Deze pagina legt uit wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
+
+[Lees meer over versiebeheer van design tokens]()
+
+## Werken met changelog voor Figma
+Voor designers die werken met een duplicaat van onze Figma bibliotheken, beschrijven we hoe de changelog werkt: wat je erin kunt vinden, hoe je het leest en wat je ermee kunt doen. 
+
+[Bekijk hoe de changelog werkt]()
+
+## Changelog Figma
+Het overzicht van alle wijzigingen in de Figma bibliotheken.
+
+[Ga naar het overzicht met wijzigingen]()

--- a/docs/handboek/designer/nieuwe-versie-publiceren/index.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/index.md
@@ -25,16 +25,22 @@ Onder deze pagina vind je drie soorten documentatie.
 
 We gebruiken semantic versioning, ofwel semver, om aan te geven wat voor soort wijziging er is doorgevoerd: een patch, minor of major. Deze pagina legt uit wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
 
+<!--
 [Lees meer over versiebeheer van design tokens](https://nldesignsystem.nl/)
+-->
 
 ## Werken met changelog voor Figma
 
 Voor designers die werken met een duplicaat van onze Figma bibliotheken, beschrijven we hoe de changelog werkt: wat je erin kunt vinden, hoe je het leest en wat je ermee kunt doen.
 
+<!--
 [Bekijk hoe de changelog werkt](https://nldesignsystem.nl/)
+-->
 
 ## Changelog Figma
 
 Het overzicht van alle wijzigingen in de Figma bibliotheken.
 
+<!--
 [Ga naar het overzicht met wijzigingen](https://nldesignsystem.nl/)
+-->

--- a/docs/handboek/designer/nieuwe-versie-publiceren/index.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/index.md
@@ -3,7 +3,7 @@ title: Nieuwe versie publiceren · Designer · Handboek
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Nieuwe versie publiceren
-sidebar_position: 3
+sidebar_position: 7
 pagination_label: Nieuwe versie publiceren
 description: Informatie over het bijhouden van wijzigingen in design tokens en Figma bibliotheken voor designers.
 keywords:

--- a/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
@@ -1,5 +1,18 @@
 ---
 title: Versiebeheer voor design tokens
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Versiebeheer voor design tokens
+sidebar_position: 1
+pagination_label: Versiebeheer voor design tokens
+description: Informatie over wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
+keywords:
+  - versiebeheer
+  - changelog
+  - semantic versioning
+  - major
+  - minor
+  - patch
 ---
 
 Design tokens komen uiteindelijk terecht in een package. Een package is een pakketje van code dat gebruikt kan worden door ontwikkelaars. Denk daarbij aan CSS variabelen.

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -14,6 +14,7 @@ Redirect 301 "/handboek/community-stappenplan" "/handboek/component-bijdragen/co
 Redirect 301 "/handboek/candidate-stappenplan" "/handboek/component-bijdragen/candidate-stappenplan"
 Redirect 301 "/handboek/hall-of-fame-stappenplan" "/handboek/component-bijdragen/hall-of-fame-stappenplan"
 Redirect 301 "/handboek/component-bijdragen/community-stappenplan-voor-organisaties" "/handboek/component-bijdragen/community-stappenplan/voor-organisaties"
+Redirect 301 "/handboek/designer/breaking-changes" "/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens"
 Redirect 301 "/button-group" "/action-group"
 Redirect 301 "/breadcrumb" "/breadcrumb-navigation"
 Redirect 301 "/definition-list" "/description-list"


### PR DESCRIPTION
This commit adds a new overview page under the documentation section, explaining how version updates are handled for design tokens and Figma libraries. The page links to subpages about semantic versioning, working with the Figma changelog, and the changelog overview itself.

The goal is to help designers understand how to track changes, what kind of updates to expect, and how those are communicated.