### PR TITLE
docs: improve description of agenda process for design open hour

### DIFF
--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -20,7 +20,9 @@ import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dis
 
 Wees welkom bij het 2-wekelijkse (online) ‘Design Open Hour’. Een moment om kennis te delen door design gerelateerde vraagstukken met elkaar te bespreken. Maar ook het delen van work-in-progress, tips of interessante inzichten uit gebruikersonderzoek wordt gewaardeerd!
 
-In principe is er vooraf geen agenda. Deze stellen we aan het begin gezamenlijk op (zie de [Canvas in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F07AVE99NU9)). Iedereen kan iets inbrengen. Soms staat de Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
+Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen we samen op aan het begin van de Design Open Hour. Maar wil je alvast iets inbrengen of je voorbereiden? Bekijk of vul dan de [agenda in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F07AVE99NU9) aan.
+
+Soms staat de Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
 
 Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Design Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
 


### PR DESCRIPTION
Clarified that there is no fixed agenda and added a clearer explanation of how participants can view or add topics to the Slack agenda. Improves transparency and helps participants prepare.