### PR TITLE
docs: add slack agenda link to design open dag

### DIFF
--- a/docs/community/events/design-open-dag.mdx
+++ b/docs/community/events/design-open-dag.mdx
@@ -19,7 +19,7 @@ Wees welkom bij de maandelijkse ‘Design Open Dag’. Een uitgebreider en fysie
 
 Delen van work-in-progress, tips of interessante inzichten uit gebruikersonderzoek? Alles is welkom. Daarnaast is het een perfect moment voor een workshop of om feedback op te halen bij andere designers uit de community.
 
-In principe is er vooraf geen agenda. Deze stellen we aan het begin van de dag gezamenlijk op. Iedereen kan iets aandragen.
+Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen we samen op aan het begin van de Design Open Dag. Maar wil je alvast iets inbrengen of je voorbereiden? Bekijk of vul dan de [agenda in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F07K32JGASD) aan.
 
 Tot nu toe vinden de Design Open Dagen plaats in het stadskantoor van gemeente Utrecht. Wil jouw organisatie een ruimte beschikbaar stellen voor een Design Open Dag? Super! Dan horen we dat graag.
 


### PR DESCRIPTION
Added a paragraph explaining the use of the Slack agenda for the Design Open Dag. Encourages participation and better preparation by making the agenda accessible beforehand.