### PR TITLE
feat: add werken met changelog voor figma page

### DIFF
--- a/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
@@ -16,7 +16,7 @@ keywords:
   - figma bibliotheek
 ---
 
-# Changelog voor Figma bibliotheken
+# Werken met changelog voor Figma
 
 De changelog is bedoeld voor designers die werken met een eigen duplicaat van de Figma bibliotheken. In de changelog zie je welke onderdelen zijn aangepast, toegevoegd of verbeterd. Zo weet je snel of je iets moet bijwerken in de bibliotheken van jouw organisatie. Op deze manier blijf je up-to-date met de laatste versie van het NL Design System.
 

--- a/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
@@ -1,0 +1,70 @@
+---
+title: Werken met changelog voor Figma · Designer · Handboek
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Werken met changelog voor Figma
+sidebar_position: 2
+pagination_label: Werken met changelog voor Figma
+description: Informatie over het gebruik van de changelog voor designers die werken met een duplicaat van de Figma bibliotheek.
+keywords:
+  - versiebeheer
+  - changelog
+  - semantic versioning
+  - major
+  - minor
+  - patch
+  - figma bibliotheek
+---
+
+# Changelog voor Figma bibliotheken
+
+De changelog is bedoeld voor designers die werken met een eigen duplicaat van de Figma bibliotheken. In de changelog zie je welke onderdelen zijn aangepast, toegevoegd of verbeterd. Zo weet je snel of je iets moet bijwerken in de bibliotheken van jouw organisatie. Op deze manier blijf je up-to-date met de laatste versie van het NL Design System.
+
+<!--
+[Bekijk de changelog](#)
+-->
+
+## Soort wijzigingen
+
+Voor onze Figma bibliotheken gebruiken we semantic versioning. Dit helpt om inzicht te geven in het soort wijziging dat is doorgevoerd: gaat het om iets groots dat impact heeft op je bibliotheek, of om een kleine correctie?
+
+Elke wijziging krijgt een versienummer in het formaat `major.minor.patch` (bijvoorbeeld `1.3.0`). We vermelden dit versienummer ook op de cover van onze Figma bibliotheken. Zo zie je altijd direct met welke versie je werkt.
+
+[Lees meer over versiebeheer](https://nldesignsystem.nl/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens)
+
+### Major
+
+Grote wijzigingen die invloed hebben op het gebruik van componenten, zoals:
+
+- Verwijderde componenten.
+- Design tokens die zijn hernoemd of verwijderd.
+
+**Impact:** Je moet iets aanpassen in de bibliotheek van jouw organisatie.
+
+### Minor
+
+Nieuwe toevoegingen die compatibel zijn, zoals:
+
+- Nieuwe componenten.
+- Extra varianten van een bestaand component.
+- Kleine uitbreidingen binnen een component.
+- Design tokens die zijn toegevoegd.
+
+**Impact:** Je hoeft niet aan te passen, maar je kunt de nieuwe onderdelen gebruiken.
+
+### Patch
+
+Kleine correcties of verfijningen, zoals:
+
+- Tekstuele aanpassingen.
+- Kleine aanpassingen in lay-out of spacing.
+
+**Impact:** Lage impact. Alleen relevant als je de bibliotheek van jouw organisatie volledig up-to-date wilt houden.
+
+## Links naar handige onderdelen
+
+Sommige items in de changelog bevatten een link. Deze verwijzen direct naar het bijbehorende onderdeel in Figma, zodat je snel kunt zien wat er precies is aangepast. Bij complexere wijzigingen linken we soms naar een korte video waarin we de wijziging toelichten of demonstreren in Figma.
+
+## Op de hoogte blijven
+
+Je kunt altijd de changelog pagina blijven bekijken om de bibliotheek up-to-date te houden. Daarnaast sturen wij uiterlijk elk kwartaal een reminder via Slack in het kanaal [#nl-design-system-designers](https://codefornl.slack.com/archives/C01D78C2E4E). Zo ben je altijd op de hoogte van de laatste wijzigingen en hoef je niets te missen.


### PR DESCRIPTION
Add 'Werken met changelog voor Figma' page.

The changelog link has been commented out temporarily. I’ll update it with the correct URL once the changelog page has been created.