### PR TITLE
feat: add figma changelog page

### DIFF
--- a/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
@@ -1,0 +1,35 @@
+---
+title: Changelog Figma · Designer · Handboek
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Changelog Figma
+sidebar_position: 3
+pagination_label: Changelog Figma
+description: Overzicht van de wijzigingen in de Figma bibliotheken.
+keywords:
+  - versiebeheer
+  - changelog
+  - semantic versioning
+  - major
+  - minor
+  - patch
+  - figma bibliotheek
+---
+
+# Changelog Figma bibliotheken
+
+Op deze pagina vind je een overzicht van alle wijzigingen in onze Figma bibliotheken.
+
+Ben je afnemer van de bibliotheken? Dan zie je hier welke updates zijn doorgevoerd, zodat je ze waar nodig ook kunt doorvoeren in de bibliotheek van jouw organisatie. Zo blijf je up-to-date met de laatste versie van de bibliotheek.
+
+Wil je meer weten over hoe je deze changelog gebruikt? Bekijk dan de [uitleg over de changelog voor Figma bibliotheken](https://nldesignsystem.nl/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma). En wil je weten wat de versienummers precies betekenen? Lees dan over [versiebeheer](https://nldesignsystem.nl/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens).
+
+## x.x.x
+
+1 mei 2025
+
+- Korte omschrijving van wijziging 1:
+  - Subitem 1
+  - Subitem 2
+- Korte omschrijving van wijziging 2
+- [Korte omschrijving van wijziging 3](url-figma-bibliotheek)


### PR DESCRIPTION
Add 'Changelog Figma' page. 

This page is currently hidden, as we don’t have a changelog available yet. Once the first version of the changelog is ready, we’ll make this page visible on the website.