### PR TITLE
docs: global design system links

### DIFF
--- a/docs/project/global-design-system.mdx
+++ b/docs/project/global-design-system.mdx
@@ -1,0 +1,64 @@
+---
+title: Global design systems for governments
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Global design systems
+pagination_label: Global design systems
+description: Links to global design systems for governments.
+keywords:
+  - design system
+  - design systems
+  - government
+  - global design system
+  - internationaal
+  - international
+  - links
+---
+
+<div lang="en">
+
+# Global design systems for governments
+
+Europe:
+
+{/* alphabetical order */}
+
+- Belgium: [Vlaanderen](https://overheid.vlaanderen.be/webuniversum/alle-webcomponenten)
+- Czech Republic: [<span lang="en">Czech Design System</span>](https://designsystem.gov.cz/)
+- Denmark: [<span lang="en">Denmark Design System</span>](https://designsystem.dk)
+- Estonia: [<span lang="en">Estland Design System</span>](https://brand.estonia.ee/)
+- Europe: [<span lang="en">Europa Component Library</span>](https://ec.europa.eu/component-library/)
+- France: [<span lang="fr">Système de Design de l'État</span>](https://www.systeme-de-design.gouv.fr) ([Storybook](https://www.systeme-de-design.gouv.fr))
+- Germany: [<span lang="en">Angie Design System</span>](https://digitalservicebund.github.io/angie/) ([Angie Design System op GitHub](https://github.com/digitalservicebund/angie))
+- Greece: [GOV.GR Design System](https://guide.services.gov.gr)
+- Iceland: [<span lang="en">Iceland Design System</span>](https://island.is/en/o/digital-iceland/design-system) ([Figma](https://www.figma.com/@islandis))
+- Ireland: [<span lang="en">Ireland Design System</span>](https://ogcio.github.io/ogcio-ds-website/)
+- Italy: [Designers Italia: The Design System for the Italian Public Administration](https://designers.italia.it)
+- Portugal: [Ágora Design System](https://mosaico.gov.pt/ferramentas/agora-design-system), [Ágora Design System on ZeroHeight](https://zeroheight.com/1be481dc2/p/97181d-agora-design-system), [Storybook for Ágora Design System](https://react.agora.gov.pt/?path=/docs/documentation-welcome--documentation)
+- United Kingdom:
+  - [GOV.UK Design System](http://design-system.service.gov.uk/)
+  - Scotland: [<span lang="en">Scottish Government Design System</span>](https://designsystem.gov.scot)
+
+European cities and regions:
+
+- Finland — [Helsinki](https://hel.fi): [<span lang="en">Helsinki Design System</span>](https://hds.hel.fi/)
+
+Outside Europe:
+
+{/* alphabetical order */}
+
+- Canada: [<span lang="en">Canada Design System</span>](https://www.canada.ca/en/government/about/design-system.html)
+- Japan: [<span lang="en">Japan Design System</span>](https://www.digital.go.jp/policies/servicedesign/designsystem/) ([Japan Design System in Figma](https://www.figma.com/community/file/1172530831489802410))
+- New-Zealand: [<span lang="en">New Zealand Design System</span>](https://design-system-alpha.digital.govt.nz/)
+- Singapore: [<span lang="en">Singapore Design System</span>](https://www.designsystem.tech.gov.sg)
+- United States of America: [<span lang="en">U.S. Web Design System</span>](https://designsystem.digital.gov)
+
+## Contribute
+
+Should your government design system be part of this list? Let us know, for example by [creating a GitHub Issue](https://github.com/nl-design-system/documentatie/issues). You can create an issue in English!
+
+## Collaborate
+
+You can find some of these design systems on Slack. [Join us on Slack](http://praatmee.codefor.nl), you can find us in the [Slack channel #global-design-system](https://codefornl.slack.com/archives/C08N9AJFAG0).
+
+</div>

--- a/docs/project/links.mdx
+++ b/docs/project/links.mdx
@@ -92,6 +92,7 @@ Europa:
 - IJsland: [<span lang="en">Iceland Design System</span>](https://island.is/en/o/digital-iceland/design-system) ([Figma](https://www.figma.com/@islandis))
 - Italië: [Designers Italia: The Design System for the Italian Public Administration](https://designers.italia.it)
 - Frankrijk: [<span lang="fr">Système de Design de l'État</span>](https://www.systeme-de-design.gouv.fr) ([Storybook](https://www.systeme-de-design.gouv.fr))
+- Portugal: [Ágora Design System](https://mosaico.gov.pt/ferramentas/agora-design-system), [Ágora Design System op ZeroHeight](https://zeroheight.com/1be481dc2/p/97181d-agora-design-system), [Storybook voor Ágora Design System](https://react.agora.gov.pt/?path=/docs/documentation-welcome--documentation)
 - Verenigd Koninkrijk:
   - [GOV.UK Design System](http://design-system.service.gov.uk/)
   - Schotland: [<span lang="en">Scottish Government Design System</span>](https://designsystem.gov.scot)

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -326,6 +326,7 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'project/kernteam' },
         { type: 'doc', id: 'project/blijf-op-de-hoogte' },
         { type: 'doc', id: 'project/links' },
+        { type: 'doc', id: 'project/global-design-system' },
       ],
     },
   ],


### PR DESCRIPTION
> BTW could we have a list of our Design Systems somewhere here? (or more than just ours). Maybe pinned or in channel description or somewhere? Ours is Helsinki Design System (HDS) at hds.hel.fi

Naar aanleiding van [de vraag in Slack](https://codefornl.slack.com/archives/C08N9AJFAG0/p1745482148614329), heb ik de pagina in het Engels beschikbaar gemaakt: [Global design systems for governments](https://documentatie-git-docs-international-nl-design-system.vercel.app/project/global-design-system)
