### PR TITLE
refactor: use NL Design System community component

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@nl-design-system-candidate/skip-link-docs": "1.0.1",
     "@tabler/icons-react": "3.30.0",
     "@utrecht/design-tokens": "2.4.0",
+    "@utrecht/youtube-video-react": "1.0.0",
     "clsx": "2.1.1",
     "html-react-parser": "5.2.2",
     "prism-react-renderer": "2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@utrecht/design-tokens':
         specifier: 2.4.0
         version: 2.4.0
+      '@utrecht/youtube-video-react':
+        specifier: 1.0.0
+        version: 1.0.0(@babel/runtime@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -2556,6 +2559,16 @@ packages:
 
   '@utrecht/web-component-library-stencil@3.0.1':
     resolution: {integrity: sha512-LRviT6RAV7ULxbuF3yxpO41XAlgL6UmPnDWL+ltj9lZm6FmKbprQ03u3mt02RN3Zk9Fr/sTwiJ9ydrHn+aagpQ==}
+
+  '@utrecht/youtube-video-css@1.0.0':
+    resolution: {integrity: sha512-zNbXax+t783aHfl47oST5l/jsz18DdQ3nZP6z5wUl5LHyC3IR/29slu4zl2cTps9KdB8BPCpW1xQj+LMQyRhFg==}
+
+  '@utrecht/youtube-video-react@1.0.0':
+    resolution: {integrity: sha512-6YkBBbt8uciUrxa0z6ogWP8TvhmcawL4tLzYyHCfUc3ubOsGtOvMgpai+JIcnvhqad7IUF+4neLD20mBdadM7A==}
+    peerDependencies:
+      '@babel/runtime': ^7.23.6
+      react: '18'
+      react-dom: '18'
 
   '@visx/curve@3.3.0':
     resolution: {integrity: sha512-G1l1rzGWwIs8ka3mBhO/gj8uYK6XdU/3bwRSoiZ+MockMahQFPog0bUkuVgPwwzPSJfsA/E5u53Y/DNesnHQxg==}
@@ -11273,6 +11286,16 @@ snapshots:
   '@utrecht/web-component-library-stencil@3.0.1':
     dependencies:
       '@stencil/core': 4.18.3
+
+  '@utrecht/youtube-video-css@1.0.0': {}
+
+  '@utrecht/youtube-video-react@1.0.0(@babel/runtime@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.7
+      '@utrecht/youtube-video-css': 1.0.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@visx/curve@3.3.0':
     dependencies:

--- a/src/components/VideoPlayer.css
+++ b/src/components/VideoPlayer.css
@@ -1,5 +1,4 @@
-.video-player {
-  aspect-ratio: 16 / 9;
+.utrecht-youtube-video {
   margin-block-end: 32px;
   margin-block-start: 24px;
 }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1,20 +1,14 @@
-import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
-import ReactPlayer, { type ReactPlayerProps } from 'react-player';
+import { YouTubeVideo, type YouTubeVideoProps } from '@utrecht/youtube-video-react/css';
 import './VideoPlayer.css';
 
-export const VideoPlayer = ({
-  videoId,
-  className,
-  ...restProps
-}: PropsWithChildren<ReactPlayerProps & { videoId: string; className?: string }>) => (
-  <ReactPlayer
-    url={`https://youtube.com/watch?v=${videoId}`}
-    className={clsx('video-player', className)}
-    width="100%"
-    height="100%"
-    controls
+export interface VideoPlayerProps extends YouTubeVideoProps {
+  videoId?: string;
+}
+
+export const VideoPlayer = ({ videoId, ...restProps }: PropsWithChildren<VideoPlayerProps>) => (
+  <YouTubeVideo
+    src={`https://youtube.com/embed/${videoId}?enablejsapi=1&origin=http://localhost:3000/`}
     {...restProps}
-    config={{ youtube: { playerVars: { disablekb: 1 } } }}
   />
 );


### PR DESCRIPTION
- [ ] de huidige `react-player` component stelt automatisch de `aria-label` in op basis van de youtube API. Om geen verlies van functionaliteit te hebben, moet ofwel `label` hardcoded ingesteld worden in alle markdown bestanden, of we moeten diezelfde feature maken.
- [ ] de huidige player kan in full screen geopend worden, daarvoor moeten wat extra attributen op de iframe ingesteld worden. Dit zou ingebouwd moeten worden in de Utrecht YouTubeVideo component