### PR TITLE
feat: toevoegen rijkshuisstijl community open hour pagina

### DIFF
--- a/.changeset/cold-cycles-smell.md
+++ b/.changeset/cold-cycles-smell.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+De Rijkshuisstijl Community Open Hour pagina toegevoegd.

--- a/docs/community/community-sprints/rijkshuisstijl-community.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community.mdx
@@ -72,7 +72,7 @@ Daarnaast organiseren we elke oneven week op dinsdag om 16:00 uur een [Rijkshuis
 
 ### Zelf iets aandragen of checken?
 
-Bekijk het [GitHub sprintbord](https://github.com/orgs/nl-design-system/projects/59), dien een [GitHub issue](https://github.com/nl-design-system/rijkshuisstijl-community/issues) in of breng het onderwep in op de [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
+Bekijk het [GitHub sprintbord](https://github.com/orgs/nl-design-system/projects/59), dien een [GitHub issue](https://github.com/nl-design-system/rijkshuisstijl-community/issues) in, of breng je onderwerp in tijdens de [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
 
 ### Vragen of ideeën
 

--- a/docs/community/community-sprints/rijkshuisstijl-community.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community.mdx
@@ -68,7 +68,7 @@ Je kunt ons ook vinden op Slack. Meld je aan bij onze [Slackgroep ‘NL Design S
 
 Ook kan je gedurende elke sprint de Rijkshuisstijl Community volgen en deelnemen aan de slowchat in het [#rijkshuisstijl-community](https://codefornl.slack.com/archives/C05AQK9R41G)-kanaal.
 
-Daarnaast organiseren we elke oneven week op dinsdag om 14:00 uur een [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
+Daarnaast organiseren we elke oneven week op dinsdag om 16:00 uur een [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
 
 ### Zelf iets aandragen of checken?
 

--- a/docs/community/community-sprints/rijkshuisstijl-community.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community.mdx
@@ -66,11 +66,13 @@ Deze sprint is bedoeld voor iedereen die werkt aan Rijksoverheidswebsites, en in
 
 Je kunt ons ook vinden op Slack. Meld je aan bij onze [Slackgroep ‘NL Design System (praatmee.codefor.nl)’](https://praatmee.codefor.nl/) en sluit aan bij #nl-design-system.
 
-Ook kan je gedurende elke sprint de Rijkshuisstijl Community volgen en deelnemen aan de slowchat in het #nl-design-system-developer kanaal.
+Ook kan je gedurende elke sprint de Rijkshuisstijl Community volgen en deelnemen aan de slowchat in het [#rijkshuisstijl-community](https://codefornl.slack.com/archives/C05AQK9R41G)-kanaal.
+
+Daarnaast organiseren we elke oneven week op dinsdag om 14:00 uur een [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
 
 ### Zelf iets aandragen of checken?
 
-Bekijk het [GitHub sprintbord](https://github.com/orgs/nl-design-system/projects/59) of dien een [GitHub issue](https://github.com/nl-design-system/rijkshuisstijl-community/issues) in.
+Bekijk het [GitHub sprintbord](https://github.com/orgs/nl-design-system/projects/59), dien een [GitHub issue](https://github.com/nl-design-system/rijkshuisstijl-community/issues) in of breng het onderwep in op de [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour#over-de-rijkshuisstijl-community).
 
 ### Vragen of ideeën
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
@@ -18,7 +18,7 @@ Tijdens de Rijkshuisstijl Community Open Hour wisselen verschillende organisatie
 
 ## Over de Rijkshuisstijl Community Open Hour
 
-Voor iedereen die interesse heeft in de Rijkshuisstijl is er op de oneven weken, iedere dinsdag om 14:00 uur, een Rijkshuisstijl Community Open Hour. Dit is een moment om kennis te delen en samen vraagstukken rond de Rijkshuisstijl te bespreken. Ook het delen van work-in-progress, tips of inzichten uit gebruikersonderzoek wordt gewaardeerd!
+Voor iedereen die interesse heeft in de Rijkshuisstijl is er op de oneven weken, iedere dinsdag om 16:00 uur, een Rijkshuisstijl Community Open Hour. Dit is een moment om kennis te delen en samen vraagstukken rond de Rijkshuisstijl te bespreken. Ook het delen van work-in-progress, tips of inzichten uit gebruikersonderzoek wordt gewaardeerd!
 
 Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen we samen op aan het begin van de Rijkshuisstijl Community Open Hour. Maar wil je alvast iets inbrengen of je voorbereiden? Bekijk of vul dan de [agenda in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F08UP7ZBR8Q) aan.
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
@@ -14,7 +14,7 @@ import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dis
 
 # Rijkshuisstijl Community Open Hour
 
-Tijdens de Rijkshuisstijl Community Open Hour wisselen verschillende organisaties informatie, inzichten en tips uit over de Rijkshuisstijl. Lees hier wat de Open Hour inhoud, hoe je mee kunt doen en wanneer het plaatsvindt.
+Tijdens de Rijkshuisstijl Community Open Hour delen verschillende organisaties hun kennis, inzichten en ervaringen rond de Rijkshuisstijl. Op deze pagina lees je wat het Open Hour inhoudt, hoe je kunt meedoen en wanneer het plaatsvindt.
 
 ## Over de Rijkshuisstijl Community Open Hour
 
@@ -24,7 +24,7 @@ Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen 
 
 Soms staat de Open Hour in het teken van één specifiek onderwerp. Denk bijvoorbeeld aan het ophalen van feedback over bepaalde stylingkeuzes. Dit is altijd erg waardevol, maar vraagt soms iets meer voorbereiding.
 
-Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Rijkshuisstijl Community Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
+Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Rijkshuisstijl Community Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen. Dus terugkijken met een bak popcorn zit er niet in.
 
 ## Ben je erbij?
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour.mdx
@@ -1,0 +1,65 @@
+---
+title: Rijkshuisstijl Community Open Hour · Bijeenkomsten
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Rijkshuisstijl Community Open Hour
+pagination_label: Tijdens de Rijkshuisstijl Community Open Hour wisselen verschillende organisaties informatie, inzichten en tips uit over de Rijkshuisstijl.
+description: Tijdens de Rijkshuisstijl Community Open Hour wisselen verschillende organisaties informatie, inzichten en tips uit over de Rijkshuisstijl. Lees hier hoe je mee kunt doen en wanneer het plaatsvindt.
+slug: /events/rijkshuisstijl-community-open-hour
+---
+
+import { ButtonLink } from "@site/src/components/ButtonLink";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+
+# Rijkshuisstijl Community Open Hour
+
+Tijdens de Rijkshuisstijl Community Open Hour wisselen verschillende organisaties informatie, inzichten en tips uit over de Rijkshuisstijl. Lees hier wat de Open Hour inhoud, hoe je mee kunt doen en wanneer het plaatsvindt.
+
+## Over de Rijkshuisstijl Community Open Hour
+
+Voor iedereen die interesse heeft in de Rijkshuisstijl is er op de oneven weken, iedere dinsdag om 14:00 uur, een Rijkshuisstijl Community Open Hour. Dit is een moment om kennis te delen en samen vraagstukken rond de Rijkshuisstijl te bespreken. Ook het delen van work-in-progress, tips of inzichten uit gebruikersonderzoek wordt gewaardeerd!
+
+Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen we samen op aan het begin van de Rijkshuisstijl Community Open Hour. Maar wil je alvast iets inbrengen of je voorbereiden? Bekijk of vul dan de [agenda in Slack](https://codefornl.slack.com/docs/T68FXPFQV/F08UP7ZBR8Q) aan.
+
+Soms staat de Open Hour in het teken van één specifiek onderwerp. Denk bijvoorbeeld aan het ophalen van feedback over bepaalde stylingkeuzes. Dit is altijd erg waardevol, maar vraagt soms iets meer voorbereiding.
+
+Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Rijkshuisstijl Community Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
+
+## Ben je erbij?
+
+Iedereen kan aansluiten! Wekelijks, of incidenteel, wanneer je vragen hebt of iets wilt bespreken.
+
+De Rijkshuisstijl Community Open Hour vindt plaats in het [#rijkshuisstijl-community](https://codefornl.slack.com/archives/C05AQK9R41G)-kanaal op de Slack van Code for NL. We gebruiken de Huddle-functie van dat kanaal om elkaar te spreken. In dat kanaal vind je ook de threads van eerdere sessies.
+
+{/* TODO: Binnenkort maken we een aanmeldpagina Door je aan te melden kunnen wij je op de hoogte houden van Rijkshuisstijl Community Open Hours. Je ontvangt dan ook direct een kalenderbestandje, zodat je de Rijkshuisstijl Community Open Hour makkelijk aan je agenda kan toevoegen. */}
+
+<ActionGroup>
+  {/* TODO: Binnenkort maken we een aanmeldpagina <ButtonLink href="/events/rijkshuisstijl-community-open-hour/aanmelden" appearance="primary-action">
+    {"Meld je aan"}
+    <IconChevronRight />
+  </ButtonLink> */}
+  <ButtonLink href="https://praatmee.codefor.nl/" appearance="secondary-action">
+    {"Doe mee op Slack"}
+    <IconChevronRight />
+  </ButtonLink>
+</ActionGroup>
+
+## Over de Rijkshuisstijl Community
+
+De Rijkshuisstijl Community Open Hour is een onderdeel van de Rijkshuisstijl Community. De Rijkshuisstijl Community Sprint maakt deel uit van een samenwerkingsverband om NL Design System-componenten te ontwikkelen voor projecten die moeten voldoen aan de Rijkshuisstijl. Organisaties van de centrale overheid van Nederland (bijvoorbeeld: Belastingdienst, DUO, Logius, SVB) en degenen die door hen zijn ingehuurd voor het ontwikkelen van websites en apps, kunnen via dit project samenwerken.
+
+<ActionGroup>
+  {/* TODO: Binnenkort maken we een aanmeldpagina <ButtonLink href="/events/rijkshuisstijl-community-open-hour/aanmelden" appearance="primary-action">
+    {"Meld je aan"}
+    <IconChevronRight />
+  </ButtonLink> */}
+  <ButtonLink href="/community/community-sprints/rijkshuisstijl-community" appearance="primary-action">
+    {"Lees meer over de Rijkshuisstijl Community"}
+    <IconChevronRight />
+  </ButtonLink>
+</ActionGroup>
+
+## Vragen of ideeën?
+
+Heb je vragen of ideeën voor de Rijkshuisstijl Community Open Hour? Stuur ons dan een mailtje via <a href="mailto:info@nldesignsystem.nl">info@nldesignsystem.nl</a>.

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -307,6 +307,24 @@ const sidebars: SidebarsConfig = {
             },
             {
               type: 'category',
+              label: 'Rijkshuisstijl Community Open Hour',
+              description:
+                'Tijdens de (online) Rijkshuisstijl Community Open Hour delen designers en developers van verschillende organisaties kennis.',
+              link: {
+                type: 'generated-index',
+                title: 'Rijkshuisstijl Community Open Hour',
+                slug: '/events/rijkshuisstijl-community-open-hour/overzicht',
+              },
+              items: [
+                {
+                  type: 'doc',
+                  id: 'community/events/rijkshuisstijl-community-open-hour/rijkshuisstijl-community-open-hour',
+                },
+                // { type: 'doc', id: 'community/events/rijkshuisstijl-community-open-hour/aanmelden' }, // TODO: Binnenkort maken we een aanmeldpagina
+              ],
+            },
+            {
+              type: 'category',
               label: 'Developer Open Hour',
               description:
                 'Tijdens het (online) Developer Open Hour delen developers van verschillende organisaties kennis.',


### PR DESCRIPTION
Met commented code waar we refereren naar de aanmeld pagina, welke in een latere iteratie word toegevoegd.

[RHC Open Hour preview.
](https://documentatie-git-feat-toevoegen-rijkshu-6ffbdf-nl-design-system.vercel.app/events/rijkshuisstijl-community-open-hour)
[RHC Community Sprint preview.](https://documentatie-git-feat-toevoegen-rijkshu-6ffbdf-nl-design-system.vercel.app/community/community-sprints/rijkshuisstijl-community)