### PR TITLE
Fix: kop van h2 naar h1

### DIFF
--- a/.changeset/audiodescription-headingache.md
+++ b/.changeset/audiodescription-headingache.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": patch
+---
+
+Kop Audiodescriptie aangepast van h2 naar h1.

--- a/docs/richtlijnen/content/video/audiodescriptie.md
+++ b/docs/richtlijnen/content/video/audiodescriptie.md
@@ -24,7 +24,7 @@ import { Canvas } from "@site/src/components/Canvas/Canvas";
 import { Guideline } from "@site/src/components/Guideline";
 import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/\_footer_info.md";
 
-## Audiodescriptie bij video
+# Audiodescriptie bij video
 
 Audiodescriptie bij een video is een hoorbare, gesproken beschrijving van belangrijke informatie die je ziet in een video, maar niet hoort. Voorbeelden hiervan zijn:
 


### PR DESCRIPTION
In richtlijnen Audiodescriptie de eerste kop aangepast van h2 naar h1