### PR TITLE
docs: spotlight voor melding werkzaamheden

### DIFF
--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -13,10 +13,14 @@ keywords:
   - token studio
 ---
 
+import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+
 # Figma structuur
 
 <SpotlightSection>
-**Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
+  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande
+  documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en
+  [neem contact op met het kernteam](../../project/kernteam.mdx).
 </SpotlightSection>
 
 ## Figma

--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -15,6 +15,10 @@ keywords:
 
 # Figma structuur
 
+<SpotlightSection>
+  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
+</SpotlightSection>
+
 ## Figma
 
 Het kernteam, en reeds aangesloten organisaties hebben een voorkeur voor Figma.

--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -16,7 +16,7 @@ keywords:
 # Figma structuur
 
 <SpotlightSection>
-  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
+**Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
 </SpotlightSection>
 
 ## Figma

--- a/docs/handboek/designer/stappenplan.mdx
+++ b/docs/handboek/designer/stappenplan.mdx
@@ -16,6 +16,10 @@ keywords:
 
 # Stappenplan
 
+<SpotlightSection>
+  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
+</SpotlightSection>
+
 Aan de hand van dit stappenplan leggen we je graag uit hoe je gebruik kunt maken van de [NL Design System bibliotheek](figma-structuur.mdx) en de [Token Studio plugin](figma-structuur.mdx).
 
 Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).

--- a/docs/handboek/designer/stappenplan.mdx
+++ b/docs/handboek/designer/stappenplan.mdx
@@ -14,10 +14,14 @@ keywords:
   - figma
 ---
 
+import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+
 # Stappenplan
 
 <SpotlightSection>
-  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).  
+  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande
+  documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en
+  [neem contact op met het kernteam](../../project/kernteam.mdx).
 </SpotlightSection>
 
 Aan de hand van dit stappenplan leggen we je graag uit hoe je gebruik kunt maken van de [NL Design System bibliotheek](figma-structuur.mdx) en de [Token Studio plugin](figma-structuur.mdx).


### PR DESCRIPTION
Om bezoekers van nldesignsystem.nl te attenderen dat er werkzaamheden plaatsvinden rondom de Figma bibliotheken en documentatie plaatsen we een melding.