### PR TITLE
docs: pixel tekst verwijderd

### DIFF
--- a/.changeset/pixels-are-rem.md
+++ b/.changeset/pixels-are-rem.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Tekst over pixels in tokens verwijderd omdat we via Tokens Studio rem kunnen gebruiken.

--- a/docs/richtlijnen/stijl/typography/1-fontsize/_guideline.md
+++ b/docs/richtlijnen/stijl/typography/1-fontsize/_guideline.md
@@ -5,5 +5,3 @@ Gebruik een lettergrootte ofwel `font-size` die groot genoeg is voor de [`body t
 Hoewel we `16px` aangeven als minimale `font-size` is het beter om géén gebruik te maken van ‘fixed-size units’ zoals `px`. Gebruik liever een relatieve waarde als `em` of `rem`.
 
 Waarom? Browsers bieden de mogelijkheid om de standaard `font-size` aan te passen. Handig voor iemand die slechtziend is. Wanneer je relatieve waardes gebruikt schaalt alles netjes mee. Maar een pixel blijft een pixel en zodoende verandert er niks.
-
-Vanuit het NL Design System zelf kiezen we momenteel wél voor pixels. Dit komt omdat wij dezelfde design token waarde willen gebruiken in Figma en in code. Wij willen de CSS nog aanpassen om px automatisch om te zetten naar rem.


### PR DESCRIPTION
Doordat we via Tokens Studio rem kunnen gebruiken haal ik deze tekst liever weg om verwarring te voorkomen.