### PR TITLE
Fix/richtlijnen content frontmatter

### DIFF
--- a/.changeset/the-front-row.md
+++ b/.changeset/the-front-row.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": patch
+---
+
+Frontmatter in de content richtlijnen gelijkgetrokken.

--- a/docs/richtlijnen/content/tekstopmaak/colour-contrast.md
+++ b/docs/richtlijnen/content/tekstopmaak/colour-contrast.md
@@ -1,5 +1,5 @@
 ---
-title: Kleurgebruik in tekst · Content · Richtlijnen
+title: Kleurgebruik in tekst · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Kleurgebruik in tekst

--- a/docs/richtlijnen/content/tekstopmaak/emphasize-text.md
+++ b/docs/richtlijnen/content/tekstopmaak/emphasize-text.md
@@ -1,5 +1,5 @@
 ---
-title: Tekst benadrukken · Content · Richtlijnen
+title: Tekst benadrukken · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Tekst benadrukken

--- a/docs/richtlijnen/content/tekstopmaak/headings.md
+++ b/docs/richtlijnen/content/tekstopmaak/headings.md
@@ -1,5 +1,5 @@
 ---
-title: Koppen · Content · Richtlijnen
+title: Koppen · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Koppen

--- a/docs/richtlijnen/content/tekstopmaak/language.md
+++ b/docs/richtlijnen/content/tekstopmaak/language.md
@@ -1,5 +1,5 @@
 ---
-title: Taal instellen · Content · Richtlijnen
+title: Taal instellen · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: De juiste taal instellen

--- a/docs/richtlijnen/content/tekstopmaak/link-text.md
+++ b/docs/richtlijnen/content/tekstopmaak/link-text.md
@@ -1,5 +1,5 @@
 ---
-title: Toegankelijke linkteksten · Content · Richtlijnen
+title: Toegankelijke linkteksten · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Toegankelijke linkteksten

--- a/docs/richtlijnen/content/tekstopmaak/quotes.md
+++ b/docs/richtlijnen/content/tekstopmaak/quotes.md
@@ -1,5 +1,5 @@
 ---
-title: Citaten · Code · Richtlijnen
+title: Citaten · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Citaten

--- a/docs/richtlijnen/content/tekstopmaak/summaries.md
+++ b/docs/richtlijnen/content/tekstopmaak/summaries.md
@@ -1,5 +1,5 @@
 ---
-title: Opsommingen · Content · Richtlijnen
+title: Opsommingen · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Opsommingen

--- a/docs/richtlijnen/content/tekstopmaak/tables.md
+++ b/docs/richtlijnen/content/tekstopmaak/tables.md
@@ -1,5 +1,5 @@
 ---
-title: Tabellen · Content · Richtlijnen
+title: Tabellen · Tekstopmaak · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Tabellen

--- a/docs/richtlijnen/content/video/audiodescriptie.md
+++ b/docs/richtlijnen/content/video/audiodescriptie.md
@@ -1,5 +1,5 @@
 ---
-title: Audiodescriptie · Content · Richtlijnen
+title: Audiodescriptie · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Audiodescriptie

--- a/docs/richtlijnen/content/video/beschrijving.md
+++ b/docs/richtlijnen/content/video/beschrijving.md
@@ -1,5 +1,5 @@
 ---
-title: Beschrijving voor video · Content · Richtlijnen
+title: Beschrijving voor video · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Video beschrijving

--- a/docs/richtlijnen/content/video/flitsen.md
+++ b/docs/richtlijnen/content/video/flitsen.md
@@ -1,5 +1,5 @@
 ---
-title: Flitsen in video · Content · Richtlijnen
+title: Flitsen in video · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Flitsen

--- a/docs/richtlijnen/content/video/gebarentaal.md
+++ b/docs/richtlijnen/content/video/gebarentaal.md
@@ -1,5 +1,5 @@
 ---
-title: Gebarentaal · Content · Richtlijnen
+title: Gebarentaal · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Gebarentaal

--- a/docs/richtlijnen/content/video/ondertiteling.md
+++ b/docs/richtlijnen/content/video/ondertiteling.md
@@ -1,5 +1,5 @@
 ---
-title: Ondertiteling · Content · Richtlijnen
+title: Ondertiteling · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Ondertiteling

--- a/docs/richtlijnen/content/video/transcript.md
+++ b/docs/richtlijnen/content/video/transcript.md
@@ -1,5 +1,5 @@
 ---
-title: Transcript · Content · Richtlijnen
+title: Transcript · Video · Content · Richtlijnen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Transcript


### PR DESCRIPTION
closes #2499 

preview (niet dat je daar wat kunt zien): https://documentatie-git-fix-richtlijnen-conten-c6152e-nl-design-system.vercel.app/richtlijnen

Frontmatter in de content richtlijnen gelijkgetrokken