### PR TITLE
docs: add slug for handboek pages

### DIFF
--- a/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/candidate-stappenplan.mdx
@@ -6,6 +6,7 @@ sidebar_label: Candidate
 sidebar_position: 5
 pagination_label: Candidate
 description: Stappen voor de Candidate fase van Definition of Done
+slug: /candidate-stappenplan
 keywords:
   - componenten
   - design system

--- a/docs/handboek/component-bijdragen/definition-of-done.mdx
+++ b/docs/handboek/component-bijdragen/definition-of-done.mdx
@@ -6,6 +6,7 @@ sidebar_label: Definition of Done
 sidebar_position: 1
 pagination_label: Definition of Done
 description: Definition of Done voor componenten
+slug: /definition-of-done
 keywords:
   - componenten
   - design system

--- a/docs/handboek/component-bijdragen/hall-of-fame-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/hall-of-fame-stappenplan.mdx
@@ -6,6 +6,7 @@ sidebar_label: Hall of Fame
 sidebar_position: 6
 pagination_label: Hall of Fame
 description: Stappen voor de Hall of Fame fase van Definition of Done
+slug: /hall-of-fame-stappenplan
 keywords:
   - componenten
   - design system

--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -6,6 +6,7 @@ sidebar_label: Help Wanted
 sidebar_position: 2
 pagination_label: Help Wanted
 description: Stappen voor de Help Wanted fase van Definition of Done
+slug: /help-wanted-stappenplan
 keywords:
   - componenten
   - design system

--- a/docs/handboek/design-tokens/README.mdx
+++ b/docs/handboek/design-tokens/README.mdx
@@ -6,6 +6,7 @@ sidebar_label: Design Tokens
 sidebar_position: 2
 pagination_label: Design Tokens - Introductie
 description: NL Design System introductie
+slug: /design-tokens
 keywords:
   - design token
   - design tokens

--- a/docs/handboek/designer/README.md
+++ b/docs/handboek/designer/README.md
@@ -6,6 +6,7 @@ sidebar_label: Introductie
 sidebar_position: 1
 pagination_label: Index
 description: Het startpunt voor designers die willen meedoen met het NL Design System.
+slug: /designer
 keywords:
   - index
   - designer

--- a/docs/handboek/designer/community.md
+++ b/docs/handboek/designer/community.md
@@ -6,6 +6,7 @@ sidebar_label: Community
 sidebar_position: 6
 pagination_label: Voorbeeld thema
 description: Lees over de community van designers en hoe je hier onderdeel van kan worden.
+slug: /designer/community
 keywords:
   - index
   - designer

--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -6,7 +6,7 @@ sidebar_label: Figma structuur
 sidebar_position: 2
 pagination_label: Figma structuur
 description: Handboek over de Figma structuur en hoe je hier gebruik van kunt maken.
-slug: /figma-structuur
+slug: /designer/figma-structuur
 keywords:
   - designer
   - meedoen

--- a/docs/handboek/designer/figma-structuur.mdx
+++ b/docs/handboek/designer/figma-structuur.mdx
@@ -6,6 +6,7 @@ sidebar_label: Figma structuur
 sidebar_position: 2
 pagination_label: Figma structuur
 description: Handboek over de Figma structuur en hoe je hier gebruik van kunt maken.
+slug: /figma-structuur
 keywords:
   - designer
   - meedoen

--- a/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
@@ -6,7 +6,7 @@ sidebar_label: Changelog Figma
 sidebar_position: 3
 pagination_label: Changelog Figma
 description: Overzicht van de wijzigingen in de Figma bibliotheken.
-slug: /changelog-figma
+slug: /designer/changelog-figma
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/_changelog-figma.md
@@ -6,6 +6,7 @@ sidebar_label: Changelog Figma
 sidebar_position: 3
 pagination_label: Changelog Figma
 description: Overzicht van de wijzigingen in de Figma bibliotheken.
+slug: /changelog-figma
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/index.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/index.md
@@ -6,6 +6,7 @@ sidebar_label: Nieuwe versie publiceren
 sidebar_position: 7
 pagination_label: Nieuwe versie publiceren
 description: Informatie over het bijhouden van wijzigingen in design tokens en Figma bibliotheken voor designers.
+slug: /designer/nieuwe-versie-publiceren
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
@@ -6,6 +6,7 @@ sidebar_label: Versiebeheer voor design tokens
 sidebar_position: 1
 pagination_label: Versiebeheer voor design tokens
 description: Informatie over wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
+slug: /versiebeheer-voor-design-tokens
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens.md
@@ -6,7 +6,7 @@ sidebar_label: Versiebeheer voor design tokens
 sidebar_position: 1
 pagination_label: Versiebeheer voor design tokens
 description: Informatie over wat semver inhoudt en hoe we het toepassen op de packages met design tokens.
-slug: /versiebeheer-voor-design-tokens
+slug: /designer/versiebeheer-voor-design-tokens
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
@@ -6,6 +6,7 @@ sidebar_label: Werken met changelog voor Figma
 sidebar_position: 2
 pagination_label: Werken met changelog voor Figma
 description: Informatie over het gebruik van de changelog voor designers die werken met een duplicaat van de Figma bibliotheek.
+slug: /werken-met-changelog-voor-figma
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
+++ b/docs/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma.md
@@ -6,7 +6,7 @@ sidebar_label: Werken met changelog voor Figma
 sidebar_position: 2
 pagination_label: Werken met changelog voor Figma
 description: Informatie over het gebruik van de changelog voor designers die werken met een duplicaat van de Figma bibliotheek.
-slug: /werken-met-changelog-voor-figma
+slug: /designer/werken-met-changelog-voor-figma
 keywords:
   - versiebeheer
   - changelog

--- a/docs/handboek/designer/stappenplan.mdx
+++ b/docs/handboek/designer/stappenplan.mdx
@@ -6,6 +6,7 @@ sidebar_label: Figma stappenplan
 sidebar_position: 3
 pagination_label: Figma stappenplan
 description: Een stappenplan dat je kan volgen om met de Figma bibliotheken van NL Design System te werken. Vervolgens kun je gebruik maken van het Start thema, of een eigen thema doorvoeren.
+slug: /figma-stappenplan
 keywords:
   - index
   - designer

--- a/docs/handboek/designer/stappenplan.mdx
+++ b/docs/handboek/designer/stappenplan.mdx
@@ -6,7 +6,7 @@ sidebar_label: Figma stappenplan
 sidebar_position: 3
 pagination_label: Figma stappenplan
 description: Een stappenplan dat je kan volgen om met de Figma bibliotheken van NL Design System te werken. Vervolgens kun je gebruik maken van het Start thema, of een eigen thema doorvoeren.
-slug: /figma-stappenplan
+slug: /designer/figma-stappenplan
 keywords:
   - index
   - designer

--- a/docs/handboek/designer/voorbeeld-thema.md
+++ b/docs/handboek/designer/voorbeeld-thema.md
@@ -6,6 +6,7 @@ sidebar_label: Voorbeeld thema
 sidebar_position: 5
 pagination_label: Voorbeeld thema
 description: Toelichting op design keuzes voor het Voorbeeld thema.
+slug: /voorbeeld-thema
 keywords:
   - index
   - designer

--- a/docs/handboek/designer/zelf-componenten-maken.mdx
+++ b/docs/handboek/designer/zelf-componenten-maken.mdx
@@ -6,6 +6,7 @@ sidebar_label: Zelf componenten maken
 sidebar_position: 4
 pagination_label: Zelf componenten maken
 description: Handboek hoe je zelf componenten kan maken in Figma met design tokens.
+slug: /designer/zelf-componenten-maken
 keywords:
   - index
   - designer

--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -6,6 +6,7 @@ sidebar_label: Estafettemodel
 sidebar_position: 2
 pagination_label: Estafettemodel
 description: Het estafettemodel van NL Design System is een aanpak om samen de beste en meest bruikbare componenten, richtlijnen en patronen te maken.
+slug: /estafettemodel
 keywords:
   - design token
   - design tokens


### PR DESCRIPTION
Slug als metadata toegevoegd aan pagina's binnen het Handboek.