### PR TITLE
docs: figma migratie-stappenplan

### DIFF
--- a/docs/handboek/designer/figma-migratie-stappenplan.mdx
+++ b/docs/handboek/designer/figma-migratie-stappenplan.mdx
@@ -636,7 +636,7 @@ Heb je prototypes gemaakt dan heb je dat gedaan op basis van de 'oude' Figma bib
 
 Daarbij kun je gebruik maken van de [Figma's Swap Library functionaliteit](https://help.figma.com/hc/en-us/articles/4404856784663-Swap-style-and-component-libraries).
 
-🎥 [Video: Design tokens van lokale componenten overzetten](https://youtu.be/SoJ9zK_g35g)
+🎥 [Video: Prototype koppelen aan nieuwe bibliotheken](https://youtu.be/zfMcHOA2_3U)
 
 Het kan voorkomen dat eventuele 'overwrites', bijvoorbeeld een tekstaanpassing op een Button, worden teruggezet naar de oorspronkelijke tekst die meekomt uit de bibliotheek. Daarom is het verstandig om 2 dingen te doen.
 


### PR DESCRIPTION
- Figma migratie-stappenplan is een afgeleide van het [algemene stappenplan](https://www.nldesignsystem.nl/handboek/designer/stappenplan).
- We hopen dat deze documentatie designers gaat helpen bij het migreren naar versie 2.
- De pagina is verborgen maar wel bereikbaar omdat dit stappenplan voor niet iedereen van toepassing is.