### PR TITLE
docs: sidebar positie van design tokens documentatie

### DIFF
--- a/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
@@ -3,7 +3,7 @@ title: Design tokens · Huisstijl vastleggen · Handboek
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design tokens
-sidebar_position: 2
+sidebar_position: 1
 pagination_label: Design tokens - Introductie
 description: Design tokens introductie
 slug: /handboek/huisstijl/design-tokens


### PR DESCRIPTION
Positie van de Design token documentatie aangepast waardoor deze pagina qua volgorde boven de Thema documentatie te staat.