### PR TITLE
Tekst over koppen in content-checklist aangepast

### DIFF
--- a/.changeset/checklist-headings-text-change.md
+++ b/.changeset/checklist-headings-text-change.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": patch
+---
+
+Tekst over headings in content checklist aangepast

--- a/docs/richtlijnen/content/README.mdx
+++ b/docs/richtlijnen/content/README.mdx
@@ -32,8 +32,8 @@ Koppen zorgen voor structuur. Ze helpen gebruikers om snel de opbouw van de pagi
 
 **Controleer of:**
 
-- [de juiste kopniveaus zijn gebruikt (bijv. geen sprongen van h2 naar h4)](/richtlijnen/content/tekstopmaak/koppen/#opmaak-van-koppen);
-- [de volgorde van de koppen klopt](/richtlijnen/content/tekstopmaak/koppen#kopniveaus);
+- [de juiste opmaak is gebruikt](/richtlijnen/content/tekstopmaak/koppen/#opmaak-van-koppen);
+- [de volgorde van de koppen klopt (bijv. geen sprongen van h2 naar h4)](/richtlijnen/content/tekstopmaak/koppen#kopniveaus);
 - [de koppen beschrijvend en relevant zijn](/richtlijnen/content/tekstopmaak/koppen#inhoud-van-koppen);
 - [er geen lege koppen zijn](/richtlijnen/content/tekstopmaak/koppen#voor-wie-zijn-toegankelijke-koppen-belangrijk).
 


### PR DESCRIPTION
De twee items leken qua tekst teveel op elkaar. Tekst aangepast zodat het duidelijkers is wat het onderscheid is en wat er moet gebeuren.