### PR TITLE
fix: add redirect for old reference to handboek design tokens

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -46,6 +46,7 @@ Redirect 301 "/textarea" "/text-area"
 Redirect 301 "/text-input-group" "/input-group"
 Redirect 301 "/videos/design-system-week-2022" "/events/design-systems-week-2022"
 Redirect 301 "/wcag/introduction" "/wcag"
+Redirect 301 "/handboek/design-tokens" "/handboek/huisstijl/design-tokens"
 
 # Permanent redirects because the directory structure changed
 RedirectMatch 301 "^/events/?$" "/community/events/overzicht"


### PR DESCRIPTION
No changeset needed, belongs with https://github.com/nl-design-system/documentatie/pull/2563