### PR TITLE
docs: linkjes bijgewerkt

### DIFF
--- a/docs/community/community-sprints/rijkshuisstijl-community/rijkshuisstijl-community.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/rijkshuisstijl-community.mdx
@@ -43,7 +43,7 @@ Bekijk de links en documentatie die horen bij deze Community Sprint:
 - [NL Design System - Rijkshuisstijl Community - Bibliotheek in Figma](https://www.figma.com/design/txFX5MGRf4O904dtIFcGTF/NLDS---Rijkshuisstijl---Bibliotheek?m=auto&node-id=197-664&t=5aHpOpfnIQGAV26F-1)
 - [Local - Rijkshuisstijl Community - Bibliotheek in Figma](https://www.figma.com/design/Nv5EsCW9ioWBUSi9m9JqOa/Local---Rijkshuisstijl---Bibliotheek?node-id=0-1&t=DluVJa2VwO612InV-11)
 - [NL Design System - Rijkshuisstijl Community - Templates in Figma](https://www.figma.com/design/H4hSqpPbvFMLklDZgswwgd/NLDS---Rijkshuisstijl---Templates?node-id=1-3&t=XfVtQMPPVZoIzqLj-1)
-- [Design tokens](https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/proprietary/design-tokens/figma/figma.tokens.json) (in te laden in Token Studio)
+- [Design tokens](https://github.com/nl-design-system/rijkshuisstijl-community/blob/main/proprietary/design-tokens/figma/figma.tokens.json) (in te laden in Tokens Studio)
 - [Rijkshuisstijl Community Storybook met componenten en templates](https://rijkshuisstijl-community.vercel.app/)
 - [Rijkshuisstijl Community Website](https://www.rijkshuisstijl-community.nl/)
 

--- a/docs/community/events/design-open-hour/design-open-hour.mdx
+++ b/docs/community/events/design-open-hour/design-open-hour.mdx
@@ -24,7 +24,7 @@ Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen 
 
 Soms staat de Design Open Hour in het teken van 1 bepaald onderwerp. Zo is er tijdens eerdere edities feedback opgehaald rondom formulier patronen en gehele flows. Dit is altijd super waardevol maar vergt ook iets meer voorbereiding.
 
-Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Design Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
+Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Design Open Hours worden echter, in tegenstelling tot de [Heartbeat](/events/heartbeat), niet opgenomen dus terugkijken met een bak popcorn zit er niet in.
 
 <ActionGroup>
   <ButtonLink href="/events/design-open-hour/aanmelden" appearance="primary-action">

--- a/docs/community/events/design-systems-week-2024/programma.mdx
+++ b/docs/community/events/design-systems-week-2024/programma.mdx
@@ -151,7 +151,7 @@ Internationalisatie is meer dan alleen het vertalen van content op je website in
   verbeteren van de gebruikerservaring voor onze inwoners en ondernemers. Een belangrijk onderdeel van mijn rol is de
   implementatie van het NL Design System. We gebruiken als een van de eerste gemeentes de voorbeeldbibliotheek als basis
   voor ons eigen design system. In mijn presentatie zal ik laten zien hoe wij de bibliotheek gebruiken (met de plugin
-  van token studio) en wat we hiervan hebben geleerd.”
+  van Tokens Studio) en wat we hiervan hebben geleerd.”
 </Paragraph>
 
 <Paragraph>

--- a/docs/community/events/developer-open-hour/developer-open-hour.mdx
+++ b/docs/community/events/developer-open-hour/developer-open-hour.mdx
@@ -25,7 +25,7 @@ Voor developers is er elke donderdag een Developer Open Hour. Op even weken is d
 
 We raden je aan om in het chatkanaal je idee voor de agenda delen, om alvast interesse te wekken!
 
-Anders dan de [Heartbeat](../heartbeat/heartbeat), worden Developer Open Hours niet opgenomen.
+Anders dan de [Heartbeat](/events/heartbeat), worden Developer Open Hours niet opgenomen.
 
 ## Ben je erbij?
 

--- a/docs/community/events/heartbeat/videos.mdx
+++ b/docs/community/events/heartbeat/videos.mdx
@@ -57,7 +57,7 @@ Sabine deelt inzichten uit het onderzoek naar de taalswitch. Bryan laat zien hoe
 
 {/* Heartbeat #99 */}
 
-Francesca en Rozerin vertellen over de Mijn, Mijn, Mijn workshop rondom het samenwerken aan 1 uitstraling voor Mijn omgevingen. Jeffrey laat zien hoe je in Figma design tokens kunt documenteren met Automator en Token Studio. En hoe hij experimenteerde om design tokens uit een JSON bestand te ordenen.
+Francesca en Rozerin vertellen over de Mijn, Mijn, Mijn workshop rondom het samenwerken aan 1 uitstraling voor Mijn omgevingen. Jeffrey laat zien hoe je in Figma design tokens kunt documenteren met Automator en Tokens Studio. En hoe hij experimenteerde om design tokens uit een JSON bestand te ordenen.
 
 <VideoPlayer videoId="JutGVOM2s7I" />
 
@@ -152,7 +152,7 @@ In deze Heartbeat vertelt Wart over de Candidate-stappen en de API-alignement ti
 
 Bryan de Jong van VNG en Frameless: “We maken het makkelijker voor organisaties om aan de slag te gaan met NL Design System door het beschikbaar stellen van templates, documentatie en thema tooling binnen de community. Hiervoor gebruiken we community componenten en bestaande UX onderzoeken en designs.”
 
-Marieke Brouwer van de Gemeente Groningen: “bij de gemeente zijn wij met een klein team actief bezig met het verbeteren van de gebruikerservaring voor onze inwoners en ondernemers. Een belangrijk onderdeel van mijn rol is de implementatie van het NL Design System. We gebruiken als een van de eerste gemeentes de voorbeeldbibliotheek als basis voor ons eigen design system. In mijn presentatie zal ik laten zien hoe wij de bibliotheek gebruiken (met de plugin van token studio) en wat we hiervan hebben geleerd.”
+Marieke Brouwer van de Gemeente Groningen: “bij de gemeente zijn wij met een klein team actief bezig met het verbeteren van de gebruikerservaring voor onze inwoners en ondernemers. Een belangrijk onderdeel van mijn rol is de implementatie van het NL Design System. We gebruiken als een van de eerste gemeentes de voorbeeldbibliotheek als basis voor ons eigen design system. In mijn presentatie zal ik laten zien hoe wij de bibliotheek gebruiken (met de plugin van Tokens Studio) en wat we hiervan hebben geleerd.”
 
 Lars van de Cappelle van Design System Bold: “Bij Bold zijn we van een Single-brand naar Multi-brand Design System uitgebreid waar de Belastingdienst, Toeslagen en Douane gebruik van maakt. Hiervoor zijn we overgestapt op design tokens om ons Design System van deze organisatiethema's te kunnen voorzien. Hierbij hebben we ook Dark Mode meegenomen. Tijdens mijn demo zal ik laten zien hoe we dit hebben aangepakt in Figma en in de code.”
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour.mdx
@@ -24,7 +24,7 @@ Iedereen kan onderwerpen inbrengen. Er is vooraf geen vaste agenda. Die stellen 
 
 Soms staat de Open Hour in het teken van één specifiek onderwerp. Denk bijvoorbeeld aan het ophalen van feedback over bepaalde stylingkeuzes. Dit is altijd erg waardevol, maar vraagt soms iets meer voorbereiding.
 
-Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Rijkshuisstijl Community Open Hours worden echter, in tegenstelling tot de [Heartbeat](../heartbeat/heartbeat), niet opgenomen. Dus terugkijken met een bak popcorn zit er niet in.
+Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij zijn? Geen probleem. Rijkshuisstijl Community Open Hours worden echter, in tegenstelling tot de [Heartbeat](/events/heartbeat), niet opgenomen. Dus terugkijken met een bak popcorn zit er niet in.
 
 ## Ben je erbij?
 

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -23,7 +23,7 @@ Leuk dat je er bent! Of je nu mee wilt helpen aan het NL Design System of simpel
 
 Het NL Design System zit net even anders in elkaar als andere Design Systems. Niet gericht op één organisatie maar een verzameling van componenten, patronen en richtlijnen, waar iedere overheidsorganisatie zijn eigen huisstijl op kan toepassen.
 
-[Meer informatie het NL Design System](/handboek/introductie/)
+[Meer informatie het NL Design System](/handboek/introductie)
 
 ## Het kernteam
 

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -23,37 +23,31 @@ Leuk dat je er bent! Of je nu mee wilt helpen aan het NL Design System of simpel
 
 Het NL Design System zit net even anders in elkaar als andere Design Systems. Niet gericht op één organisatie maar een verzameling van componenten, patronen en richtlijnen, waar iedere overheidsorganisatie zijn eigen huisstijl op kan toepassen.
 
-[Meer informatie het NL Design System](../introductie.md)
+[Meer informatie het NL Design System](/handboek/introductie/)
 
 ## Het kernteam
 
 Er is een vast kernteam dat werkt aan het NL Design System. Het kernteam werkt op dagelijkse basis samen met verschillende disciplines vanuit de community. Denk aan designers, developers maar ook copywriters en accessibility specialisten.
 
-[Meer informatie over het Kernteam](../../project/kernteam.mdx)
-
-## De community
-
-Binnen de community zijn designers bezig met verschillende projecten. Door als designers samen te werken kunnen we informatie en inzichten met elkaar uitwisselen. Zo leren we elke keer iets bij.
-
-[Meer informatie over de community voor designers](community.md)
+[Meer informatie over het Kernteam](/project/kernteam)
 
 ## Ontwerpprogramma’s
 
 Of je nu Sketch, Adobe XD, Framer, of Paint gebruikt, er is geen afhankelijkheid als het gaat om ontwerpprogramma. Wel hebben het kernteam, en reeds aangesloten organisaties een voorkeur voor Figma.
 
-[Meer informatie over Figma structuur en gebruik](figma-structuur.mdx)
+[Meer informatie over Figma structuur en gebruik](/handboek/designer/figma-structuur)
 
 ## Design tokens
 
 De componenten van het NL Design System hebben van zichzelf geen specifieke huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen maken we gebruik van ‘Design tokens’.
 
-[Meer informatie over design tokens](../design-tokens/README.mdx)
+[Meer informatie over design tokens](/handboek/huisstijl/design-tokens)
 
 ## Design tokens en Figma
 
-Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen ondersteuning voor design tokens. Daarom maken we gebruik van de [Token Studio](https://tokens.studio/).
+Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen ondersteuning voor design tokens. Daarom maken we gebruik van de [Tokens Studio](https://tokens.studio/).
 
-[Meer informatie over Figma structuur en gebruik](figma-structuur.mdx)
+[Meer informatie over Figma structuur en gebruik](/handboek/designer/figma-structuur)
 
 ## Stijl, componenten, patronen en templates
 
@@ -63,29 +57,33 @@ Zoals aangegeven kan iedere organisatie zijn eigen huisstijl toepassen. En toch 
 
 [Bekijk de stijl documentatie](/richtlijnen/stijl)
 
+### Start-thema
+
+Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/design-tokens/).
+
 ### Voorbeeld thema
 
-Het NL Design System heeft van zichzelf geen huisstijl. Maar om de werking en kracht van design tokens aan te tonen maken we wel gebruik van een [‘Voorbeeld’ thema](voorbeeld-thema.md).
+Met het '[Voorbeeld-thema](/handboek/huisstijl/themas/voorbeeld-thema)' laten we zien hoe je een eigen thema kunt doorvoeren op basis van het [Start-thema](/handboek/huisstijl/themas/start-thema). Het dient als 'voorbeeld'.
 
 ### Componenten
 
 Het NL Design System bevat een heleboel componenten. Die hebben we allemaal op een rijtje gezet.
 
-[Bekijk het componenten overzicht](../../componenten/README.mdx)
+[Bekijk het componenten overzicht](/componenten)
 
 Op componenten passen we het estafettemodel toe.
 
-[Meer informatie over het estafettemodel](../estafettemodel.mdx)
+[Meer informatie over het estafettemodel](/handboek/estafettemodel)
 
-Op dit moment zijn we druk bezig om de NL Design System Figma Bibliotheek te vullen met 'Community' componenten. Geleidelijk aan zullen deze de status 'Candidate' en 'Hall of Fame' gaan krijgen.
+Op dit moment zijn we druk bezig om de NL Design System Figma Bibliotheek te vullen met 'Community' en 'Candidate' componenten. Samen werken we toe naar componenten met de status ‘Hall of Fame’.
 
-[Meer informatie over Figma structuur en gebruik](figma-structuur.mdx)
+[Meer informatie over Figma structuur en gebruik](/handboek/designer/figma-structuur)
 
 #### Bijdragen aan componenten
 
 Mis je een component? Zou je een component graag aangepast zien? Heb je input voor de documentatie? Of nog beter heb je ooit onderzoek gedaan naar een component?
 
-[Neem contact op](../../project/kernteam.mdx), dan zetten we de component op [de backlog](https://github.com/nl-design-system/backlog).
+[Neem contact op](/project/kernteam), dan zetten we de component op [de backlog](https://github.com/nl-design-system/backlog/issues).
 
 ### Patronen en Templates
 
@@ -93,23 +91,23 @@ Op dit moment ligt onze focus bij de componenten. Maar die componenten komen nat
 
 Daarom willen we alvast een lijst opstellen van patronen en templates die voor verschillende organisaties van toepassing kunnen zijn. Zelf denken we aan een zoekresultaat met filter en sorteer opties. Maar ook aan een formulier dat uit meerdere stappen bestaat.
 
-[Bekijk het patronen en templates overzicht](../../voorbeelden/README.md)
+[Bekijk het patronen en templates overzicht](/voorbeelden)
 
 #### Bijdragen aan patronen en templates
 
 Mis je een patroon of template? Heb je input voor de documentatie? Of nog beter, heb je ooit onderzoek gedaan naar een patroon of template?
 
-[Neem contact op](../../project/kernteam.mdx), dan zetten we het patroon of template op [de backlog](https://github.com/nl-design-system/backlog/projects/1).
+[Neem contact op](/project/kernteam), dan zetten we het patroon of template op [de backlog](https://github.com/nl-design-system/backlog/issues).
 
 ## Onderzoek
 
 Design, code en documentatie stoelen we graag op onderzoek. Hiervoor speuren we het web af naar inzichten. Maar we vragen ook de community, jou dus, om hulp. Heb je gebruikersonderzoek gedaan en inzichten opgedaan die voor de gehele community waardevol zijn? Dan horen we dat graag.
 
-[Bekijk het onderzoek overzicht](../../voorbeelden/onderzoek/README.md)
+[Bekijk het onderzoek overzicht](/voorbeelden/onderzoek/)
 
 ## Op de hoogte blijven
 
-Wil je niets missen van de ontwikkelingen van het NL Design System? Er zijn [verschillende manieren om op de hoogte te blijven](../../project/blijf-op-de-hoogte.mdx).
+Wil je niets missen van de ontwikkelingen van het NL Design System? Er zijn [verschillende manieren om op de hoogte te blijven](/project/blijf-op-de-hoogte).
 
 ---
 
@@ -119,4 +117,4 @@ Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun
 
 ## Vragen
 
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](/project/kernteam).

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -59,7 +59,7 @@ Zoals aangegeven kan iedere organisatie zijn eigen huisstijl toepassen. En toch 
 
 ### Start-thema
 
-Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-token).
+Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 
 ### Voorbeeld thema
 

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -59,7 +59,7 @@ Zoals aangegeven kan iedere organisatie zijn eigen huisstijl toepassen. En toch 
 
 ### Start-thema
 
-Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/design-tokens/).
+Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-token).
 
 ### Voorbeeld thema
 

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -29,7 +29,7 @@ Het NL Design System zit net even anders in elkaar als andere Design Systems. Ni
 
 Er is een vast kernteam dat werkt aan het NL Design System. Het kernteam werkt op dagelijkse basis samen met verschillende disciplines vanuit de community. Denk aan designers, developers maar ook copywriters en accessibility specialisten.
 
-[Meer informatie over het Kernteam](/project/kernteam)
+[Meer informatie over het kernteam](/project/kernteam)
 
 ## Ontwerpprogramma’s
 

--- a/docs/handboek/designer/werken-met-nl-design-system/_figma-changelog-templates.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/_figma-changelog-templates.mdx
@@ -366,6 +366,6 @@ Soort wijziging: `patch`
 #### Voorbeelden
 
 ```md
-- Waardes zijn omgezet van `px` naar `rem` in Token Studio.
+- Waardes zijn omgezet van `px` naar `rem` in Tokens Studio.
 - Tokens in Tokens Studio zijn opnieuw gelinkt aan token documentatie in Figma.
 ```

--- a/docs/handboek/designer/werken-met-nl-design-system/design-tokens-versiebeheer.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/design-tokens-versiebeheer.mdx
@@ -31,7 +31,7 @@ Bij NL Design System maken we voor het ophogen van versienummers gebruik van ‘
 
 ### Major
 
-Het ophogen van het major deel van het versienummer gebeurt als er veranderingen zijn doorgevoerd die **niet** achterwaarts compatibel zijn. Deze veranderingen heten ook wel [breaking changes](#wat-zijn-breaking-changes). Bij het ophogen van het major deel van het versienummer springen het minor en patch deel beide terug naar 0.
+Het ophogen van het major deel van het versienummer gebeurt als er veranderingen zijn doorgevoerd die **niet** achterwaarts compatibel zijn. Deze veranderingen heten ook wel [breaking changes](#breaking-changes). Bij het ophogen van het major deel van het versienummer springen het minor en patch deel beide terug naar 0.
 
 ### Minor
 

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -23,7 +23,7 @@ Op deze pagina vind je een overzicht van alle wijzigingen in onze Figma biblioth
 
 Ben je afnemer van de bibliotheken? Dan zie je hier welke updates zijn doorgevoerd, zodat je ze waar nodig ook kunt doorvoeren in de bibliotheek van jouw organisatie. Zo blijf je up-to-date met de laatste versie van de bibliotheek.
 
-Wil je meer weten over hoe je deze changelog gebruikt? Bekijk dan de [uitleg over de changelog voor Figma bibliotheken](https://nldesignsystem.nl/handboek/designer/nieuwe-versie-publiceren/werken-met-changelog-voor-figma). En wil je weten wat de versienummers precies betekenen? Lees dan over [versiebeheer](https://nldesignsystem.nl/handboek/designer/nieuwe-versie-publiceren/versiebeheer-voor-design-tokens).
+Wil je meer weten over hoe je deze changelog gebruikt? Bekijk dan de [uitleg over de changelog voor Figma bibliotheken](/handboek/designer/werken-met-figma-changelog). En wil je weten wat de versienummers precies betekenen? Lees dan over [versiebeheer](/handboek/designer/design-tokens-versiebeheer).
 
 ## 2.0.0
 

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-migratie-stappenplan.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-migratie-stappenplan.mdx
@@ -680,7 +680,7 @@ Wil je nieuwe front-end componenten ontwikkelen? Een developer uit jouw team kan
 
 ## Wat is je volgende stap?
 
-Ga je een prototype maken en onderzoek doen? Super! Deel je vragen, inzichten en ervaringen vooral met anderen in de community. Zo leren we van elkaar. Dat kan via Slack of tijdens een [Design Open Hour](/events/design-open-hour], [Design Open Dag](events/design-open-dag) of [Heartbeat](events/heartbeat).
+Ga je een prototype maken en onderzoek doen? Super! Deel je vragen, inzichten en ervaringen vooral met anderen in de community. Zo leren we van elkaar. Dat kan via Slack of tijdens een [Design Open Hour](/events/design-open-hour), [Design Open Dag](events/design-open-dag) of [Heartbeat](events/heartbeat).
 
 Wil je zelf componenten bijdragen?
 Vet! [Lees hier hoe je zelf componenten kunt ontwikkelen](/handboek/designer/zelf-componenten-maken)

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
@@ -541,7 +541,7 @@ Wil je nieuwe front-end componenten ontwikkelen? Een developer uit jouw team kan
 
 ## Wat is je volgende stap?
 
-Ga je een prototype maken en onderzoek doen? Super! Deel je vragen, inzichten en ervaringen vooral met anderen in de community. Zo leren we van elkaar. Dat kan via Slack of tijdens een [Design Open Hour](/events/design-open-hour], [Design Open Dag](events/design-open-dag) of [Heartbeat](events/heartbeat).
+Ga je een prototype maken en onderzoek doen? Super! Deel je vragen, inzichten en ervaringen vooral met anderen in de community. Zo leren we van elkaar. Dat kan via Slack of tijdens een [Design Open Hour](/events/design-open-hour), [Design Open Dag](events/design-open-dag) of [Heartbeat](events/heartbeat).
 
 Wil je zelf componenten bijdragen?
 Vet! [Lees hier hoe je zelf componenten kunt ontwikkelen](/handboek/designer/zelf-componenten-maken)

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
@@ -16,15 +16,7 @@ keywords:
   - design tokens
 ---
 
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
-
 # Figma stappenplan
-
-<SpotlightSection>
-  **Let op!** We werken momenteel aan een nieuwe versie van de Figma-bibliotheken. Daardoor kan de onderstaande
-  documentatie afwijken van de werkelijkheid. In de komende weken wordt deze bijgewerkt. Heb je vragen? Twijfel niet en
-  [neem contact op met het kernteam](/project/kernteam).
-</SpotlightSection>
 
 Je kunt dit stappenplan gebruiken voor 3 doelen:
 

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-structuur.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-structuur.mdx
@@ -12,6 +12,7 @@ keywords:
   - meedoen
   - figma
   - token studio
+  - tokens studio
 ---
 
 # Figma structuur

--- a/docs/handboek/designer/zelf-componenten-maken.mdx
+++ b/docs/handboek/designer/zelf-componenten-maken.mdx
@@ -46,7 +46,7 @@ In deze video laten we zien hoe je de 'Demo sticker' kan opbouwen met design tok
 
 ### Component van huisstijl voorzien
 
-Je kunt een component van huisstijl voorzien zoals je dat gewend bent (Shared Styles, Auto-layout, Variables). Zolang je deze designkeuzes uiteindelijk maar vastlegt via Token Studio. Hierdoor zijn je design tokens te koppelen met code. We vervolgen deze uitleg door direct te werken met de Tokens Studio plugin.
+Je kunt een component van huisstijl voorzien zoals je dat gewend bent (Shared Styles, Auto-layout, Variables). Zolang je deze designkeuzes uiteindelijk maar vastlegt via Tokens Studio. Hierdoor zijn je design tokens te koppelen met code. We vervolgen deze uitleg door direct te werken met de Tokens Studio plugin.
 
 #### Tokens Studio plugin gebruiken
 
@@ -176,4 +176,4 @@ Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun
 
 ## Vragen
 
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](/project/kernteam).

--- a/docs/handboek/designer/zelf-componenten-maken.mdx
+++ b/docs/handboek/designer/zelf-componenten-maken.mdx
@@ -24,7 +24,7 @@ De Figma bibliotheek van het NL Design System bevat vast (nog) niet alle compone
 
 Aan de hand van twee fictieve lokale componenten (Demo sticker en Demo card) laten we zien hoe je jouw componenten van design tokens voorziet volgens de NL Design System structuur.
 
-Voordat je begint is het verstandig dat je het [stappenplan](stappenplan.mdx) hebt doorlopen. Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+Voordat je begint is het verstandig dat je het [Figma stappenplan](/handboek/designer/figma-stappenplan) hebt doorlopen. Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](/project/kernteam).
 
 ## Demo sticker maken
 

--- a/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
@@ -275,7 +275,7 @@ Van organisaties die een thema onderhouden kun je een npm-pakketje installeren m
 
 ## Gebruik in Figma
 
-Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen ondersteuning voor design tokens. Daarom maken we gebruik van de [Token Studio](https://tokens.studio/).
+Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen ondersteuning voor design tokens. Daarom maken we gebruik van de [Tokens Studio](https://tokens.studio/).
 
 [Meer informatie over Figma structuur en gebruik](../designer/werken-met-nl-design-system/figma-structuur.mdx)
 

--- a/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
@@ -100,7 +100,7 @@ Dit zijn alle tokens die nodig zijn voor een component. Ze verkrijgen hun waarde
 
 {/* TODO: Linken naar de Component tokens van het voorbeeld thema */}
 
-[Bekijk het componenten overzicht](../../componenten)
+[Bekijk het componenten overzicht](/componenten)
 
 ## Naamgeving
 
@@ -277,7 +277,7 @@ Van organisaties die een thema onderhouden kun je een npm-pakketje installeren m
 
 Op dit moment biedt Figma, net als alle andere ontwerpprogramma's, geen ondersteuning voor design tokens. Daarom maken we gebruik van de [Tokens Studio](https://tokens.studio/).
 
-[Meer informatie over Figma structuur en gebruik](../designer/werken-met-nl-design-system/figma-structuur.mdx)
+[Meer informatie over Figma structuur en gebruik](/handboek/designer/figma-structuur)
 
 ## Huisstijl
 
@@ -379,4 +379,4 @@ Om ervoor te zorgen dat deze documentatie nuttig, relevant en up-to-date is, kun
 
 ## Vragen
 
-Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](../../project/kernteam.mdx).
+Heb je een vraag? Twijfel niet en [neem contact op met het kernteam](/project/kernteam).

--- a/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
@@ -17,7 +17,7 @@ keywords:
 
 # Start-thema en basis-tokens
 
-Vanuit het NL Design System bieden we het 'Start-thema' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-token).
+Vanuit het NL Design System bieden we het 'Start-thema' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 
 Op deze pagina lees je wat het Start-thema is, welke stijlkeuzes er zijn gemaakt en hoe de basis-tokens werken.
 
@@ -67,7 +67,7 @@ Ook deze set valt buiten ons beheer. Mis je een icoon? Neem dan contact op met [
 
 ## Basis-tokens
 
-De stijlkeuzes van het Start-thema zijn vastgelegd in een set aan basis-tokens. Deze tokens bevinden zich op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-token).
+De stijlkeuzes van het Start-thema zijn vastgelegd in een set aan basis-tokens. Deze tokens bevinden zich op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 
 Je kunt het Start-thema volledig afstemmen op de huisstijl van jouw organisatie door andere waarden toe te kennen aan de basis-tokens.
 
@@ -167,7 +167,7 @@ Het asterisk-symbool `(*)` betekent dat dit geldt voor alle tokens die met deze 
 
 :::tip[Tip]
 
-De naamgeving van deze speciale groepen wijkt bewust af van de algemene structuur. Ze sluiten aan op de naamgeving van de [Component tokens](/handboek/huisstijl/design-tokens#component-token), zodat ze beter herkenbaar zijn.
+De naamgeving van deze speciale groepen wijkt bewust af van de algemene structuur. Ze sluiten aan op de naamgeving van de [Component tokens](/handboek/huisstijl/design-tokens#component-tokens), zodat ze beter herkenbaar zijn.
 
 :::
 


### PR DESCRIPTION
- Gebroken linkjes hersteld.
- Tijdelijke Spotlight sectie boven het Figma Stappenplan verwijderd.