### PR TITLE
docs: candidate linkjes naar Figma gewijzigd

### DIFF
--- a/docs/componenten/code-block/_usage.md
+++ b/docs/componenten/code-block/_usage.md
@@ -77,4 +77,4 @@ export const MyPage = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Code Block](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=16013-20518&t=VLuBXH3mk0TIqsiJ-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Code Block](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13778-3553).

--- a/docs/componenten/code/_usage.md
+++ b/docs/componenten/code/_usage.md
@@ -68,4 +68,4 @@ export const MyPage = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Code](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=16013-20509&t=j0HWpfOYWPeYBX0r-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Code](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13778-1279).

--- a/docs/componenten/color-sample/_usage.md
+++ b/docs/componenten/color-sample/_usage.md
@@ -101,4 +101,4 @@ export const MyPage = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Color Sample](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=15527-33899&t=j0HWpfOYWPeYBX0r-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Color Sample](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13781-17931).

--- a/docs/componenten/data-badge/_usage.md
+++ b/docs/componenten/data-badge/_usage.md
@@ -71,4 +71,4 @@ export const MyPage = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Data Badge](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=16013-20496&t=btcSpHPZOXM2P8BA-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Data Badge](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13781-18012).

--- a/docs/componenten/heading/_usage.md
+++ b/docs/componenten/heading/_usage.md
@@ -134,4 +134,4 @@ export const MyComponent = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Code](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=15862-1610&t=0Pfnum6S0ChsWQDW-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Heading](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=153-1039).

--- a/docs/componenten/link/_usage.md
+++ b/docs/componenten/link/_usage.md
@@ -74,4 +74,4 @@ export const MyPage = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Link](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=15527-6188&t=ZSZqzM6JyRQFQVSy-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Link](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13587-214136).

--- a/docs/componenten/mark/_usage.md
+++ b/docs/componenten/mark/_usage.md
@@ -66,4 +66,4 @@ export const MyComponent = () => {
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — mark](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=15527-33132&t=GQQ2sAXlU56nNksS-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Mark](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=13787-19085).

--- a/docs/componenten/number-badge/_usage.md
+++ b/docs/componenten/number-badge/_usage.md
@@ -82,4 +82,4 @@ export const MyComponent = () => <NumberBadge value="42" />;
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — number-badge](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=16036-18152&t=05MMm59Zv67e65gd-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Number Badge](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=1233-4271).

--- a/docs/componenten/paragraph/_usage.md
+++ b/docs/componenten/paragraph/_usage.md
@@ -87,4 +87,4 @@ Je kunt de React component zo gebruiken:
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Paragraph](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=150-734&node-type=canvas&t=SxsN8cwA5f9cXqQx-0).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Paragraph](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=150-734).

--- a/docs/componenten/skip-link/_usage.md
+++ b/docs/componenten/skip-link/_usage.md
@@ -63,4 +63,4 @@ export const MyComponent = () => <SkipLink href="#inhoud">Direct naar de hoofdin
 
 ## Figma
 
-De Figma component staat in [NL Design System Voorbeeld Bibliotheek — skip-link](https://www.figma.com/design/shhwGcqPLi2CapK0P1zz8O/NLDS---Voorbeeld---Bibliotheek?node-id=16036-18152&t=05MMm59Zv67e65gd-4).
+De Figma component staat in [NL Design System Voorbeeld Bibliotheek — Skip Link](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=2217-10122).


### PR DESCRIPTION
- Linkjes vanuit Candidate detailpagina naar Figma gewijzigd.
- Schrijfwijze gelijk getrokken
- Foutje dat 'Code' werd genoemd, waar 'Heading' bedoelt werd, hersteld.