### PR TITLE
docs: verwijzen naar Start-thema en schrijfwijze met streepje

### DIFF
--- a/docs/community/events/heartbeat/videos.mdx
+++ b/docs/community/events/heartbeat/videos.mdx
@@ -41,7 +41,7 @@ Renate vertelt over de nieuwe richtlijnen voor tekstopmaak en waar je allemaal r
 
 {/* Heartbeat #102 */}
 
-Charlotte update ons over de verbetering en uitbreiding van de Community Sprint pagina. Aline vertelt hoe de Rijkshuisstijl Community werkt met NL Design System. Jeffrey neemt ons mee in de Basis tokens inclusief het Start thema.
+Charlotte update ons over de verbetering en uitbreiding van de Community Sprint pagina. Aline vertelt hoe de Rijkshuisstijl Community werkt met NL Design System. Jeffrey neemt ons mee in de Basis tokens inclusief het Start-thema.
 
 <VideoPlayer videoId="9sh2FDt3-Og" />
 

--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -149,9 +149,9 @@ Als kernteam maken we de component beschikbaar in de ['Themes' repository](https
 
 ## Visuele regressietests zijn beschikbaar in de Thema Storybook
 
-Doel: De component wordt voorzien van het Voorbeeld thema, en organisaties worden geïnformeerd wanneer aanpassingen in de component gevolgen hebben voor hun thema.
+Doel: De component wordt voorzien van het Start-thema, en organisaties worden geïnformeerd wanneer aanpassingen in de component gevolgen hebben voor hun thema.
 
-- Component wordt voorzien van het Voorbeeld thema.
+- Component wordt voorzien van het Start-thema.
 - Communiceren dat men de component kan gaan gebruiken en dat daar automatisch visuele regressietests op zullen plaatsvinden.
 
 **🚩 Checkpoint**: Visuele regressietest

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -61,7 +61,7 @@ Zoals aangegeven kan iedere organisatie zijn eigen huisstijl toepassen. En toch 
 
 Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 
-### Voorbeeld thema
+### Voorbeeld-thema
 
 Met het '[Voorbeeld-thema](/handboek/huisstijl/themas/voorbeeld-thema)' laten we zien hoe je een eigen thema kunt doorvoeren op basis van het [Start-thema](/handboek/huisstijl/themas/start-thema). Het dient als 'voorbeeld'.
 

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-hygiene.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-hygiene.mdx
@@ -58,14 +58,14 @@ Een schetsbestand om snel ideeën uit te werken, te delen of vast te leggen.
 
 ##### Voorbeeld bibliotheken
 
-Duplicaten van onze Figma bibliotheken met het [Voorbeeld thema](/handboek/huisstijl/themas/voorbeeld-thema). Hiermee laten we zien hoe organisaties de bibliotheken kunnen toepassen.
+Duplicaten van onze Figma bibliotheken met het [Voorbeeld-thema](/handboek/huisstijl/themas/voorbeeld-thema). Hiermee laten we zien hoe organisaties de bibliotheken kunnen toepassen.
 
 - [Bekijk 'NL Design System - Bibliotheek - Voorbeeld'](https://www.figma.com/design/0J3EiRpZH3LJ0cx396XLNC/NL-Design-System---Bibliotheek---Voorbeeld?node-id=197-664&t=6q27i1PaV5ZFstxx-1)
 - [Bekijk 'NL Design System - ToDo Bibliotheek - Voorbeeld'](https://www.figma.com/design/ig29egqH8dyyWY1oe03OC0/NL-Design-System---ToDo-Bibliotheek---Voorbeeld?node-id=0-1&t=0JUFZYgSsC4NLwHu-1)
 
 ##### Voorbeeld templates
 
-Bestand met complete templates, opgebouwd uit componenten uit de 2 Figma bibliotheken met het Voorbeeld thema.
+Bestand met complete templates, opgebouwd uit componenten uit de 2 Figma bibliotheken met het Voorbeeld-thema.
 
 [Bekijk het bestand 'NL Design System - Templates - Voorbeeld' in Figma](https://www.figma.com/design/taAnsV55PVP0cmw18BnMDk/NL-Design-System---Templates---Voorbeeld?node-id=1-3&t=3lZPNWC5lsZzFZKO-1)
 

--- a/docs/handboek/designer/zelf-thema-maken.mdx
+++ b/docs/handboek/designer/zelf-thema-maken.mdx
@@ -28,7 +28,7 @@ Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/the
 
 Op basis van het [Start-thema](/handboek/huisstijl/themas/start-thema) hebben we ook een '[Voorbeeld-thema](/handboek/huisstijl/themas/voorbeeld-thema)' gemaakt. Hiermee laten we zien hoe je een eigen thema kunt opzetten. Dit dient als voorbeeld en inspiratie.
 
-![Stijl van het Voorbeeld-thema uitgebeeld door middel van een violet vlak waarop met witte letters staat geschreven: Voorbeeld thema. Uitgesproken en vriendelijk. Rechts staat in dezelfde violet kleur Nederland afgebeeld als illustratie.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_voorbeeld-thema_stijl.png)
+![Stijl van het Voorbeeld-thema uitgebeeld door middel van een violet vlak waarop met witte letters staat geschreven: Voorbeeld-thema. Uitgesproken en vriendelijk. Rechts staat in dezelfde violet kleur Nederland afgebeeld als illustratie.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_voorbeeld-thema_stijl.png)
 
 ## Zelf aan de slag
 

--- a/docs/handboek/huisstijl-vastleggen/themas/voorbeeld-thema.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/voorbeeld-thema.mdx
@@ -23,7 +23,7 @@ Op deze pagina lees je wat het doel en de stijl is van het 'Voorbeeld-thema'.
 
 Met het Voorbeeld-thema laten we zien hoe je een eigen thema kunt doorvoeren op basis van het [Start-thema](/handboek/huisstijl/themas/start-thema). Het dient als 'voorbeeld' en laat zien hoe je met een paar slimme aanpassingen je eigen huisstijl kunt toepassen.
 
-![Stijl van het Voorbeeld-thema uitgebeeld door middel van een violet vlak waarop met witte letters staat geschreven: Voorbeeld thema. Uitgesproken en vriendelijk. Rechts staat in dezelfde violet kleur Nederland afgebeeld als illustratie.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_voorbeeld-thema_stijl.png)
+![Stijl van het Voorbeeld-thema uitgebeeld door middel van een violet vlak waarop met witte letters staat geschreven: Voorbeeld-thema. Uitgesproken en vriendelijk. Rechts staat in dezelfde violet kleur Nederland afgebeeld als illustratie.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_voorbeeld-thema_stijl.png)
 
 ## Stijl van het Voorbeeld-thema
 

--- a/docs/richtlijnen/formulieren/description/6-target-size/_guideline.md
+++ b/docs/richtlijnen/formulieren/description/6-target-size/_guideline.md
@@ -10,4 +10,4 @@ Een minimale grootte van het aanklikbare gedeelte is nodig om te voldoen aan het
 
 ![Formfield met textbox van 48 pixels hoog, en formfield met radiobuttons van 24 pixels hoog.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_formulier_description_size.png)
 
-Voor het 'Voorbeeld thema' maken we gebruik van een grootte van 24x24 bij checkboxes en radio buttons. En houden we een grootte van 48x48px aan voor componenten zoals buttons en text inputs. Dit sluit mooi aan bij de spacing scale van het voorbeeld thema.
+Voor het 'Start-thema' maken we gebruik van een grootte van 24x24 bij checkboxes en radio buttons. En houden we een grootte van 48x48px aan voor componenten zoals buttons en text inputs. Dit sluit mooi aan bij de spacing scale van het Start-thema.

--- a/docs/richtlijnen/stijl/icons/1-functional/_guideline.md
+++ b/docs/richtlijnen/stijl/icons/1-functional/_guideline.md
@@ -4,4 +4,4 @@ Bij functionele iconen is het belangrijk dat ze simpel van vorm zijn. Hierdoor k
 
 ![Button met pijl icoon, foutmelding met uitroepteken icoon, en link met potloot icoon.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_iconen_functioneel.png)
 
-Voor het 'Voorbeeld thema' maken we gebruik van een selectie uit de [Tabler iconenset](https://tabler-icons.io/).
+Voor het 'Start-thema' maken we gebruik van een selectie uit de [Tabler iconenset](https://tabler-icons.io/).

--- a/docs/richtlijnen/stijl/icons/2-toptasks/_guideline.md
+++ b/docs/richtlijnen/stijl/icons/2-toptasks/_guideline.md
@@ -2,6 +2,6 @@
 
 Toptaak iconen zijn gedetailleerder dan functionele iconen. Dat kan ook makkelijk omdat ze groter worden ingezet. Toptaak iconen helpen bezoekers van gemeentelijke websites om sneller bij de juiste informatie te komen.
 
-Voor het 'Voorbeeld thema' maken we gebruik van de outline versie van de iconenset: [Gemeenten iconen](https://www.gemeenteniconen.nl/). Deze iconenset wordt Open Source aangeboden. Je mag deze iconen dus ook gebruiken voor jouw organisatie.
+Voor het 'Start-thema' maken we gebruik van de outline versie van de iconenset: [Gemeenten iconen](https://www.gemeenteniconen.nl/). Deze iconenset wordt Open Source aangeboden. Je mag deze iconen dus ook gebruiken voor jouw organisatie.
 
 [Ga naar gemeenteniconen.nl](https://www.gemeenteniconen.nl) voor meer informatie over het gebruik.

--- a/docs/richtlijnen/stijl/icons/README.mdx
+++ b/docs/richtlijnen/stijl/icons/README.mdx
@@ -46,9 +46,9 @@ Vanuit het NL Design System gebruiken we twee iconensets. De iconen in deze sets
 - [Aria-label is a xenophobe - Heydon Heydon Pickering](https://heydonworks.com/article/aria-label-is-a-xenophobe/).  
   Artikel over het gebruik van Aria-label en de problemen die hierbij kunnen optreden bij het vertalen van een webpagina.
 - [Tabler icons - Codecalm](https://tabler-icons.io/).  
-  De iconenset die we bij het NL Design System gebruiken voor de functionele iconen van het Voorbeeld thema.
+  De iconenset die we bij het NL Design System gebruiken voor de functionele iconen van het Start-thema.
 - [Gemeenteniconen.nl](https://www.gemeenteniconen.nl).  
-  De iconenset die we bij het NL Design System gebruiken voor het Voorbeeld thema.
+  De iconenset die we bij het NL Design System gebruiken voor het Start-thema.
 
 ## Deel je gebruikersonderzoek
 

--- a/docs/richtlijnen/stijl/space/1-spacing-scale/_guideline.md
+++ b/docs/richtlijnen/stijl/space/1-spacing-scale/_guideline.md
@@ -4,4 +4,4 @@ Om ruimte consistent toe te passen is het verstandig om te werken met een vaste 
 
 ![13 losse blokjes die steeds breeder worden. Onder elk blok staat een getal](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_ruimte_spacing-scale.png)
 
-Ook bij het Voorbeeld thema maken we gebruik van een spacing scale. Sterker nog, we hebben meerdere spacing scales. Één voor elk [spacing concept](/richtlijnen/stijl/ruimte/spacing-concepten).
+Ook bij het Start-thema maken we gebruik van een spacing scale. Sterker nog, we hebben meerdere spacing scales. Één voor elk [spacing concept](/richtlijnen/stijl/ruimte/spacing-concepten).

--- a/docs/richtlijnen/stijl/typography/4-font/_guideline.md
+++ b/docs/richtlijnen/stijl/typography/4-font/_guideline.md
@@ -28,7 +28,7 @@ Individuele lettervormen zouden genoeg van vorm moeten verschillen waardoor ze n
 
 ## Letterafstand
 
-Een combinatie van de letters 'r' en 'n' (rn)' zou een duidelijke ruimte moeten hebben om verwarring te voorkomen met letter 'm'. Hier kun je via `letter-spacing` invloed op uitoefenen. Momenteel maken we hier geen gebruik van binnen het Voorbeeld thema.
+Een combinatie van de letters 'r' en 'n' (rn)' zou een duidelijke ruimte moeten hebben om verwarring te voorkomen met letter 'm'. Hier kun je via `letter-spacing` invloed op uitoefenen. Momenteel maken we hier geen gebruik van binnen het Start-thema.
 
 ![De letters 'r' en 'n' zijn twee keer afgebeeld. Bij heeft eerste voorbeeld is er voldoende letter afstand. Bij het tweede voorbeeld is er te weinig letter afstand. Bij het tweede voorbeeld staat een rood kruis.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_typografie_letter-afstand.png)
 


### PR DESCRIPTION
Met deze PR wordt er in de documentatie nu eerst naar het Start-thema verwezen. Daarnaast wordt de schrijfwijze gelijk getrokken met een streepje.