### PR TITLE
docs: documentatie voor Thema's

### DIFF
--- a/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
@@ -16,7 +16,7 @@ keywords:
 
 # Thema's
 
-De componenten van het NL Design System hebben van zichzelf geen specifieke huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen, maken we gebruik van ‘[design tokens](/handboek/huisstijl/design-tokens)’.
+De componenten van NL Design System hebben van zichzelf geen specifieke huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen, maken we gebruik van ‘[design tokens](/handboek/huisstijl/design-tokens)’.
 
 ![Drie dezelfde interfaces. Eén zonder stijling. Twee met een eigen huisstijl](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_design-tokens_no-style-and-style.png)
 

--- a/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
@@ -16,4 +16,20 @@ keywords:
 
 # Thema's
 
-Deze documentatie is nog in ontwikkeling.
+De componenten van het NL Design System hebben van zichzelf geen specifieke huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen, maken we gebruik van ‘[design tokens](/handboek/huisstijl/design-tokens)’.
+
+![Drie dezelfde interfaces. Één zonder stijling. Twee met een eigen huisstijl](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_design-tokens_no-style-and-style.png)
+
+Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
+
+![Stijl van het Start-thema: een donkerblauw vlak met witte letters ‘Start-thema. Eenvoudig en neutraal.’ Rechts een illustratie van Nederland in dezelfde kleur.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_start-thema_stijl.png)
+
+Op basis van het [Start-thema](/handboek/huisstijl/themas/start-thema) hebben we ook een '[Voorbeeld-thema](/handboek/huisstijl/themas/voorbeeld-thema)' gemaakt. Hiermee laten we zien hoe je een eigen thema kunt opzetten. Dit dient als voorbeeld en inspiratie.
+
+![Stijl van het Voorbeeld-thema uitgebeeld door middel van een violet vlak waarop met witte letters staat geschreven: Voorbeeld-thema. Uitgesproken en vriendelijk. Rechts staat in dezelfde violet kleur Nederland afgebeeld als illustratie.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_voorbeeld-thema_stijl.png)
+
+## Zelf aan de slag
+
+Als developer [aan de slag met een eigen thema](/developer/aan-de-slag).
+
+Als designer aan de slag met een eigen thema? Volg dan het [Figma Stappenplan](/handboek/designer/figma-stappenplan). Daarin leggen we stap voor stap uit hoe je het Start-thema en de basis-tokens kunt aanpassen naar de huisstijl van jouw organisatie.

--- a/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
@@ -20,7 +20,7 @@ De componenten van het NL Design System hebben van zichzelf geen specifieke huis
 
 ![Drie dezelfde interfaces. Eén zonder stijling. Twee met een eigen huisstijl](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_design-tokens_no-style-and-style.png)
 
-Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
+Vanuit NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 
 ![Stijl van het Start-thema: een donkerblauw vlak met witte letters ‘Start-thema. Eenvoudig en neutraal.’ Rechts een illustratie van Nederland in dezelfde kleur.](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/img_start-thema_stijl.png)
 

--- a/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/themas.mdx
@@ -18,7 +18,7 @@ keywords:
 
 De componenten van het NL Design System hebben van zichzelf geen specifieke huisstijl. Iedere organisatie kan zijn eigen huisstijl op de componenten toepassen. Om dat voor elkaar te krijgen, maken we gebruik van ‘[design tokens](/handboek/huisstijl/design-tokens)’.
 
-![Drie dezelfde interfaces. Één zonder stijling. Twee met een eigen huisstijl](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_design-tokens_no-style-and-style.png)
+![Drie dezelfde interfaces. Eén zonder stijling. Twee met een eigen huisstijl](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/meedoen_design-tokens_no-style-and-style.png)
 
 Vanuit het NL Design System bieden we het '[Start-thema](/handboek/huisstijl/themas/start-thema/)' aan. De stijl van dit Start-thema hebben we vastgelegd in een set aan 'basis-tokens'. Deze basis-tokens leven op het ['Common' niveau](/handboek/huisstijl/design-tokens#common-tokens).
 


### PR DESCRIPTION
Op de pagina Thema's staat nu nog 'Deze documentatie is nog in ontwikkeling.'. De content van '[Zelf een thema maken](https://www.nldesignsystem.nl/handboek/designer/zelf-thema-maken)' leent zich prima al opvulling. Onderaan wordt dan verwezen naar de specifieke documentatie voor developers en designers.