### PR TITLE
build: update component progress 1.0.1-alpha.123

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.4",
-    "@nl-design-system/component-progress": "1.0.1-alpha.120",
+    "@nl-design-system/component-progress": "1.0.1-alpha.123",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
       '@nl-design-system/component-progress':
-        specifier: 1.0.1-alpha.120
-        version: 1.0.1-alpha.120
+        specifier: 1.0.1-alpha.123
+        version: 1.0.1-alpha.123
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)
@@ -1978,8 +1978,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4':
     resolution: {integrity: sha512-POlUBxviNooS6NpzyH6v3MJ+WwQEqMYj3VcJcX4oDRdRsxoYgsq4GDm3C55IhJ12nPKnd/F5DD+RBomviSkgxg==}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.120':
-    resolution: {integrity: sha512-J+KvyHSjg9YNe8KJ1FMaMFp85y/UI7X+ALDGn8wbUCGLHbI4wGxNITsllHD0KS6MWjkfCTnFOz0rQzWz9OTVxw==}
+  '@nl-design-system/component-progress@1.0.1-alpha.123':
+    resolution: {integrity: sha512-NX0YsoaiHQYXlypcnYlOgg2Abm/KNmddcuPsXQY3CvcD8wbKlZ9sdiM1MLTD6wuUDKeRvDDCIgDcS+uz7DQpIA==}
 
   '@nl-design-system/eslint-config@1.0.0':
     resolution: {integrity: sha512-ypsu7zBN26tVLdnbcK2+He2l+QK33qNtHGlBY0CY5x8wWkCQULSH+10E+rUIAf+kBHKdQkgr5+W60qyj97a66Q==}
@@ -10682,7 +10682,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4': {}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.120': {}
+  '@nl-design-system/component-progress@1.0.1-alpha.123': {}
 
   '@nl-design-system/eslint-config@1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
This PR will update the component progress to version 1.0.1-alpha.123.

Updates Form Field from Help Wanted to Community. [Before (Live)](https://nldesignsystem.nl/form-field). [After (Preview)](https://documentatie-git-build-update-component-f9b343-nl-design-system.vercel.app/form-field).