### PR TITLE
docs: fix table documentation

### DIFF
--- a/docs/componenten/table/index.mdx
+++ b/docs/componenten/table/index.mdx
@@ -39,7 +39,7 @@ import Guidelines from "./\_guidelines.md";
 {/* Add name and description for the component */}
 export const title = "Table";
 export const description = "Structureert data in rijen en kolommen.";
-export const issueNumber = "39";
+export const issueNumber = 39;
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
@@ -59,6 +59,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Guidelines />
 </Markdown>
 
-## Help <>{title}</> verbeteren
+## Help component verbeteren
 
 <HelpImproveComponent component={component} headingLevel={3} />


### PR DESCRIPTION
Op de table pagina werd geen informatie uit Component Progress getoond én stond nog een gekke titel onderaan.

- [x] Het issue nummer is nu een nummer. Bleek namelijk een string te zijn, daarom kon hij de informatie niet vinden
- [x] Titel voor Help verbeteren van het component in lijn gebracht met de andere component pagina's