### PR TITLE
chore: align page structure for candidate components

### DIFF
--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -87,14 +87,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -156,6 +148,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -70,6 +70,10 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <ComponentAliases component={component} />
 
+## Anatomie
+
+<ComponentAnatomy component={component} illustration={CodeIllustration} />
+
 ## Candidate component gebruiken
 
 Let op: Gebruik de component [Code Block](/code-block) als de code meerdere regels beslaat.
@@ -81,18 +85,6 @@ Let op: Gebruik de component [Code Block](/code-block) als de code meerdere rege
 <Markdown omitH1 headingLevel={3}>
   <Usage />
 </Markdown>
-
-## Anatomie
-
-<ComponentAnatomy component={component} illustration={CodeIllustration} />
-
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
 
 ## Acceptatiecriteria
 
@@ -155,6 +147,14 @@ Let op: Gebruik de component [Code Block](/code-block) als de code meerdere rege
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -94,14 +94,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -187,6 +179,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -97,14 +97,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -185,6 +177,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -91,14 +91,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -173,6 +165,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -101,14 +101,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -261,6 +253,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -82,14 +82,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -164,6 +156,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -76,14 +76,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -153,6 +145,15 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
+
 ## Help component verbeteren
 
 <HelpImproveComponent component={component} headingLevel={3} />

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -90,14 +90,6 @@ export const component = componentProgress.find((item) => item.number === issueN
   <Usage />
 </Markdown>
 
-## Definition of Done
-
-<DefinitionOfDone component={component} headingLevel={3} />
-
-## Community implementaties
-
-<Implementations component={component} headingLevel={3} />
-
 ## Acceptatiecriteria
 
 <AcIntro />
@@ -159,6 +151,14 @@ export const component = componentProgress.find((item) => item.number === issueN
     },
   ]}
 />
+
+## Community implementaties
+
+<Implementations component={component} headingLevel={3} />
+
+## Definition of Done
+
+<DefinitionOfDone component={component} headingLevel={3} />
 
 ## Help component verbeteren
 


### PR DESCRIPTION
De pagina's hadden nu niet allemaal dezelfde opbouw. Dat is niet voorspelbaar of handig. Op de https://nldesignsystem.nl/skip-link pagina stond hij nu goed, dus met deze PR is dat ook doorgevoerd voor de andere 9 Candidate componenten

De structuur in de sidebar is
1. Anatomie
2. Candidate component gebruiken
3. Acceptatiecriteria / Checklist voor toegankelijkheid
4. Community implementaties
5. Definition of Done
6. Help component verbeteren