### PR TITLE
Overbodige import cleanup

### DIFF
--- a/.changeset/candidate-cleanup.md
+++ b/.changeset/candidate-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@nl-design-system-unstable/documentation": minor
+---
+
+Overbodige imports verwijderd.

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -41,7 +41,6 @@ keywords:
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import CodeBlockIllustration from "@nl-design-system-candidate/code-block-docs/docs/anatomy/anatomy.svg";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -38,7 +38,6 @@ keywords:
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import CodeIllustration from "@nl-design-system-candidate/code-docs/docs/anatomy/anatomy.svg";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
@@ -50,7 +49,6 @@ import Wcag144 from "@nl-design-system-unstable/documentation/componenten/ac/_wc
 import Wcag141 from "@nl-design-system-unstable/documentation/wcag/summaries/_1.4.1-summary.md";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
-import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import { Checklist } from "@site/src/components/Checklist";
 import {
   DefinitionOfDone,

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -45,7 +45,6 @@ keywords:
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import ColorSampleIllustration from "@nl-design-system-candidate/color-sample-docs/docs/anatomy/anatomy.svg";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -49,7 +49,6 @@ keywords:
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import DataBadgeIllustration from "@nl-design-system-candidate/data-badge-docs/docs/anatomy/anatomy.svg";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -44,7 +44,6 @@ keywords:
 {/* @license CC0-1.0 */}
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import HeadingIllustration from "@nl-design-system-candidate/heading-docs/docs/anatomy/anatomy.svg";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -43,7 +43,6 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -34,7 +34,6 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -29,7 +29,6 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import NumberBadgellustration from "@nl-design-system-candidate/number-badge-docs/docs/anatomy/anatomy.svg";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -47,7 +47,6 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
-import AcIntro from "@nl-design-system-unstable/documentation/componenten/ac/_ac_intro.md";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
@@ -84,7 +83,6 @@ import Wcag2411 from "@nl-design-system-unstable/documentation/wcag/summaries/_2
 import Wcag321 from "@nl-design-system-unstable/documentation/wcag/summaries/_3.2.1-summary.md";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 import { ComponentAnatomy } from "@site/src/components/ComponentAnatomy";
-import { CriteriaList } from "@site/src/components/ComponentCriteriaList";
 import {
   DefinitionOfDone,
   HelpImproveComponent,


### PR DESCRIPTION
overbodige ac-intro en criterialist imports verwijderen van candidate component pagina's 