### PR TITLE
build: update component progress 1.0.1-alpha.127

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.4",
-    "@nl-design-system/component-progress": "1.0.1-alpha.126",
+    "@nl-design-system/component-progress": "1.0.1-alpha.127",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
       '@nl-design-system/component-progress':
-        specifier: 1.0.1-alpha.126
-        version: 1.0.1-alpha.126
+        specifier: 1.0.1-alpha.127
+        version: 1.0.1-alpha.127
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)
@@ -2146,8 +2146,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4':
     resolution: {integrity: sha512-POlUBxviNooS6NpzyH6v3MJ+WwQEqMYj3VcJcX4oDRdRsxoYgsq4GDm3C55IhJ12nPKnd/F5DD+RBomviSkgxg==}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.126':
-    resolution: {integrity: sha512-kb0Rtlt2oh5Ny/AHpz7p5bhkAZjDGhZz0kNahYQ5dLMj9tmkj3aYUNHvVepGJvI7IVOSWnBWnEeiw9WQ8QM08A==}
+  '@nl-design-system/component-progress@1.0.1-alpha.127':
+    resolution: {integrity: sha512-Ki1gRVbyX2TNuDPGKYCpA15XGIuBPfFSii1wX9O7CI0Ezqftyj2w3/6MteKxZRcA2Rf2i9bMq+Yi2LJQjkmdrA==}
 
   '@nl-design-system/eslint-config@1.0.0':
     resolution: {integrity: sha512-ypsu7zBN26tVLdnbcK2+He2l+QK33qNtHGlBY0CY5x8wWkCQULSH+10E+rUIAf+kBHKdQkgr5+W60qyj97a66Q==}
@@ -10947,7 +10947,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4': {}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.126': {}
+  '@nl-design-system/component-progress@1.0.1-alpha.127': {}
 
   '@nl-design-system/eslint-config@1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
This PR will update the component progress to version 1.0.1-alpha.127.

Adds to https://github.com/nl-design-system/kernteam/issues/1367 and https://github.com/nl-design-system/kernteam/issues/1368.

Preview: [Page Footer](https://documentatie-git-build-update-component-e7ba3d-nl-design-system.vercel.app/page-footer/), [Page Header](https://documentatie-git-build-update-component-e7ba3d-nl-design-system.vercel.app/page-header/).