### PR TITLE
fix: ontbrekende taalcode toevoegen aan global design systems-link (#2580)

### DIFF
--- a/docs/project/README.mdx
+++ b/docs/project/README.mdx
@@ -1,0 +1,22 @@
+---
+title: Project
+hide_title: true
+hide_table_of_contents: true
+---
+
+{/* @license CC0-1.0 */}
+
+import { OverviewPage } from "@site/src/components/OverviewPage";
+import DocCardList from "@theme/DocCardList";
+
+<OverviewPage excludeDocIDs={["project/README", "project/global-design-system"]} />
+<DocCardList
+  items={[
+    {
+      type: "link",
+      href: "/project/global-design-system",
+      label: <span lang="en">Global Design System</span>,
+      description: <span lang="en">Links to global design systems for governments.</span>,
+    },
+  ]}
+/>

--- a/docs/project/_category_.json
+++ b/docs/project/_category_.json
@@ -1,3 +1,0 @@
-{
-  "label": "Project"
-}

--- a/navConfig.ts
+++ b/navConfig.ts
@@ -46,7 +46,7 @@ const navbar: Navbar = {
     },
     {
       type: 'doc',
-      docId: 'project',
+      docId: 'project/README',
       position: 'left',
       label: 'Project',
       className: 'utrecht-link',

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -408,10 +408,8 @@ const sidebars: SidebarsConfig = {
       collapsible: false,
       className: 'sidebar__main-category',
       link: {
-        type: 'generated-index',
-        title: 'Project',
-        slug: 'project',
-        keywords: ['Project', 'overzicht'],
+        type: 'doc',
+        id: 'project/README',
       },
       items: [
         { type: 'doc', id: 'project/over-nl-design-system' },


### PR DESCRIPTION
## Samenvatting
Fix voor ontbrekende taalcode in link (en begeleidende tekst) naar de global design systems-pagina.  

Gerelateerd issue: #2580  

## Wijzigingen
- Taalcode toegevoegd aan de link  
- Begeleidende tekst aangepast  