### PR TITLE
fix: add `download` attribute to make Algolia ignore calendar invites

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -4,6 +4,17 @@ import { clsx } from 'clsx';
 
 import type { PropsWithChildren } from 'react';
 
-export const Link = ({ className, ...props }: PropsWithChildren<Props>) => (
-  <DocusaurusLink className={clsx('utrecht-link', 'utrecht-link--html-a', className)} {...props} />
-);
+export const Link = ({ className, href, ...props }: PropsWithChildren<Props>) => {
+  // Links to files with the ".ics" file extension are downloads.
+  // Downloads should be ignored by crawlers such as Algolia, resulting in less crawler warnings.
+  const download = /\.ics([?#]|$)/i.test(href);
+  console.log(href, download);
+  return (
+    <DocusaurusLink
+      className={clsx('utrecht-link', 'utrecht-link--html-a', download && 'utrecht-link--download', className)}
+      href={href}
+      download={download}
+      {...props}
+    />
+  );
+};


### PR DESCRIPTION
Helaas werkt dit niet, nog even uitzoeken waarom niet :(

Getest met deze pagina: http://nldesignsystem.nl/events/developer-open-hour/aanmelden/bedankt

De console.log komt voorbij voor diverse linkjes, maar niet voor de ics linkjes.

Bedoeld om deze warning op te lossen:

<img width="1185" height="466" alt="Screenshot 2025-09-02 at 11 03 44" src="https://github.com/user-attachments/assets/4d0a12ed-d276-40ab-8a0a-c0483181ca9a" />
