### PR TITLE
feat: add nldesignsystem.nl/slack for convenience

### DIFF
--- a/docs/project/slack.mdx
+++ b/docs/project/slack.mdx
@@ -1,0 +1,70 @@
+---
+title: Slack · Project
+slug: /slack/
+hide_title: true
+hide_table_of_contents: true
+sidebar_label: Slack
+pagination_label: Slack
+description: Wij hebben chatkanelen in Slack, lees hier hoe je mee kan doen.
+keywords:
+  - chat
+  - Code for NL
+  - codefor.nl
+  - global-design-system
+  - huddle
+  - nl design system
+  - nl-design-system
+  - nl-design-system-a11y
+  - nl-design-system-content
+  - nl-design-system-designers
+  - nl-design-system-developers
+  - rijkshuisstijl-community
+  - Slack
+---
+
+import { ButtonLink } from "@site/src/components/ButtonLink";
+import { IconChevronRight } from "@tabler/icons-react";
+import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+
+# Slack voor NL Design System
+
+NL Design System werkt met de [Slack van de Code for NL community](https://codefornl.slack.com/). Je kunt jezelf aanmelden via het formulier op [praatmee.codefor.nl](https://praatmee.codefor.nl), iedereen is welkom!
+
+<ActionGroup>
+  <ButtonLink href="https://praatmee.codefor.nl/" appearance="primary-action">
+    {"Doe mee op Slack"}
+    <IconChevronRight />
+  </ButtonLink>
+</ActionGroup>
+
+## Chatkanalen
+
+- **[#nl-design-system](https://codefornl.slack.com/archives/C7KDQRXMZ)**: kanaal voor algemene vragen, aankondingen, en voor oproepen aan de community tijdens het [Estafettemodel](/handboek/estafettemodel/).
+- **[#nl-design-system-a11y](https://codefornl.slack.com/archives/C07059B0VK7)**: kanaal voor toegankelijkheidsspecialisten om onderling samen te werken aan [richtlijnen](/richtlijnen/), acceptatiecriteria voor toegankelijkheid en [WCAG pagina's](/wcag/).
+- **[#nl-design-system-content](https://codefornl.slack.com/archives/C01E0C94QG4)**: kanaal om contentmakers te bereiken, en voor samenwerken aan de [richtlijnen voor content](/richtlijnen/content/). Het is hier nog wat rustig, maar daar komt binnenkort misschien verandering in!
+- **[#nl-design-system-designers](https://codefornl.slack.com/archives/C01D78C2E4E)**: kanaal om designers te bereiken. Je kunt hier samenwerken, vragen stellen over design, UX, Figma, enzovoorts. Developers zijn ook welkom!
+- **[#nl-design-system-developers](https://codefornl.slack.com/archives/C01DAT4TRPF)**: kanaal om developers te bereiken. Je kunt hier samenwerken, vragen stellen, breaking changes aankondigen, enzovoorts. Designers zijn ook welkom!
+- **[#rijkshuisstijl-community](https://codefornl.slack.com/archives/C05AQK9R41G)**: kanaal voor de [Rijkshuisstijl Community](/community/community-sprints/rijkshuisstijl-community/), waar mensen kennis uitwisselen en samenwerken aan websites die de [Rijkshuisstijl](http://rijkshuisstijl.nl) gebruiken.
+
+Op de NL Design System kanalen is onze [Code of Conduct](/coc/) van toepassing.
+
+## Huddle
+
+Via Slack kun je met meerdere personen videobellen en je scherm delen, dat heet een "[Slack Huddle](https://slack.com/intl/en-gb/help/articles/4402059015315-Use-huddles-in-Slack)". In de community werken veel mensen vaak samen via een Slack Huddle, dus als je mensen hoort spreken over een "huddle" weet je nu wat het is!
+
+## Bijeenkomsten in Slack
+
+We doen veel [community bijeenkomsten](https://nldesignsystem.nl/community/events/overzicht/) in een Slack Huddle. Wanneer je eenmaal in Slack zit dan kun je met een druk op de knop meedoen. Je kunt je voor diverse events aanmelden via onze website, zodat je een uitnodiging krijgt voor je kalender en je een herinnering kunt instellen.
+
+Community Events die in Slack plaats vinden:
+
+- [Design Open Hour](/events/design-open-hour/)
+- [Developer Open Hour](/events/developer-open-hour/)
+- [MijnServices](/community/community-sprints/mijn-services-community/) Open Hour
+- [Rijkshuisstijl Community Open Hour](/events/rijkshuisstijl-community-open-hour/)
+- Rijkshuisstijl Community sprint planning
+- Rijkshuisstijl Community sprint retro
+
+## Bedankt, Code for NL!
+
+Hartelijk dank aan [Code for NL](http://codefor.nl), die het mogelijk maakt dat de NL Design System community via Slack kan samenwerken!

--- a/footerConfig.ts
+++ b/footerConfig.ts
@@ -30,8 +30,8 @@ const footer: Footer = {
           href: 'https://github.com/nl-design-system/backlog',
         },
         {
-          label: 'Storybook',
-          href: 'https://nl-design-system.github.io/themes',
+          label: 'Slack',
+          href: '/slack/',
         },
         {
           label: 'Figma',

--- a/sidebarConfig.ts
+++ b/sidebarConfig.ts
@@ -398,6 +398,7 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
+        { type: 'doc', id: 'project/slack' },
       ],
     },
   ],


### PR DESCRIPTION
- nieuwe pagina met informatie over Slack, even 30 minuutjes lopen typen
- "Storybook" link in de Page Footer vervangen door "Slack"
  - Storybook is niet erg representatief, dus goed dat die link weg is zonder context
  - Slack is nu vindbaar in de homepage
- URL is nldesignsystem.nl/slack, zodat we die makkelijk kunnen aankondigen en ondertitelen in meetings
- tekst kan vast nog beter, maar dat kunnen we inplannen in een sprint


Branch deployment: [/slack/](https://documentatie-git-docs-slack-nl-design-system.vercel.app/slack/)