### PR TITLE
docs: update checkpoint status

### DIFF
--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -413,10 +413,7 @@ Deze stap kan enkel worden uitgevoerd door het kernteam.
 
 - Voeg het 'Help Wanted' label toe aan de GitHub Discussion.
 - Voeg het 'Help Wanted' label toe aan het backlog issue.
-- Selecteer bij ‘Projects’ de volgende extra projecten:
-  - Components - 2 - Community
-  - Components - 3 - Candidate
-  - Components - 4 - Hall of Fame
+- Selecteer bij ‘Projects’ het volgende projectenbord: Components - 2 - Community
 - Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op de component door op `{naam-component}` te zoeken.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.


### PR DESCRIPTION
Het selecteren van de Candidate en Hall of Fame borden als stap er uit.