### PR TITLE
fix: link to correct design systems week sign up thanks url

### DIFF
--- a/docs/community/events/design-systems-week/en/sign-up.mdx
+++ b/docs/community/events/design-systems-week/en/sign-up.mdx
@@ -22,7 +22,7 @@ We are now busy with all the preparations. Leave your info to receive updates!
   listId="pcqhthkfma"
   emailFieldId="9djAFMjpOP"
   firstNameFieldId="Z4algALizb"
-  thanksPage="https://nldesignsystem.nl/events/design-systems-week/sign-up/thanks"
+  thanksPage="https://nldesignsystem.nl/events/design-systems-week/en/sign-up/thanks"
   laPostaId="iyihtuzpiq"
   language={{ id: "pWGlUo870J", value: "2" /* 2=en */ }}
 />


### PR DESCRIPTION
Report from community that page linked to Not Found. Sign ups were still correctly processed, just that the redirect URL to the thanks page was incorrect. This change fixes this.