### PR TITLE
docs: fix links naar amsterdam storybook en figma in help wanted stappenplan

### DIFF
--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -209,8 +209,8 @@ Het kernteam houdt deze set van organisaties aan. Hiermee hebben we een mooie mi
 
 #### Amsterdam
 
-- [Storybook](https://amsterdam.github.io/design-system/?path=/docs/docs-intro--docs)
-- [Figma](https://www.figma.com/file/9IGm6IdPUYizBNGsUnueBd/Standaard-Design-Library---Desktop?type=design&node-id=1222%3A39437&t=nLmwomuRhjnfhbCa-1)
+- [Storybook](https://amsterdam.github.io/design-system/)
+- [Figma](https://www.figma.com/design/E0nTk27onToN81KLMNgd2c/Amsterdam-Design-System---Community-Edition--Community-)
 - [GitHub](https://github.com/amsterdam/design-system) ([CSS componenten](https://github.com/Amsterdam/design-system/tree/develop/packages/css/src/components))
 
 #### Den Haag


### PR DESCRIPTION
Onderdeel van feedback op het stappenplan naar aanleiding van Estafettemodeldag 10 oktober.

- Storybook introductie pagina is veranderd van https://amsterdam.github.io/design-system/?path=/docs/docs-intro--docs naar https://designsystem.amsterdam/?path=/docs/docs-introduction--docs. Permanente oplossing is om pad niet mee te geven: hiermee word je automatisch naar introductie pagina verwezen.
- Figma was nog de link naar de gesloten omgeving, deze is nu gewijzigd naar de Community Edition.

Preview: https://documentatie-git-docs-fix-links-naar-am-932918-nl-design-system.vercel.app/handboek/estafettemodel/componenten/help-wanted-stappenplan/#amsterdam
