### PR TITLE
docs: selecteer candidate project bord wanneer component community status bereikt

### DIFF
--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -187,6 +187,7 @@ Doel: iedereen kan zien dat de component nu richting Candidate wil.
 
 - Verander het label 'Help Wanted' van het backlog issue naar 'Community'.
 - Verander het label 'Help Wanted' van de GitHub Discussion naar 'Community'.
+- Selecteer bij ‘Projects’ het volgende projectenbord: Components - 3 - Candidate.
 - Filter het [Candidate bord](https://github.com/orgs/nl-design-system/projects/32) op de component door te zoeken op `{naam-component}`.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.

--- a/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
+++ b/docs/handboek/component-bijdragen/help-wanted-stappenplan.mdx
@@ -413,7 +413,7 @@ Deze stap kan enkel worden uitgevoerd door het kernteam.
 
 - Voeg het 'Help Wanted' label toe aan de GitHub Discussion.
 - Voeg het 'Help Wanted' label toe aan het backlog issue.
-- Selecteer bij ‘Projects’ het volgende projectenbord: Components - 2 - Community
+- Selecteer bij ‘Projects’ het volgende projectenbord: Components - 2 - Community.
 - Filter het [Community bord](https://github.com/orgs/nl-design-system/projects/29/views/1) op de component door op `{naam-component}` te zoeken.
 - Kopieer de URL na het filteren.
 - Voeg onderstaande tekst toe als comment aan de GitHub Discussion.


### PR DESCRIPTION
Preview: https://documentatie-git-docs-selecteer-candida-0849e9-nl-design-system.vercel.app/handboek/estafettemodel/componenten/help-wanted-stappenplan/