### PR TITLE
docs: fix design system week timeblocked events for outlook

### DIFF
--- a/static/dsweek-2025/1-digitale-gebruikerservaring-bij-de-overheid.ics
+++ b/static/dsweek-2025/1-digitale-gebruikerservaring-bij-de-overheid.ics
@@ -21,7 +21,7 @@ DESCRIPTION:Anton neemt ons mee in de verkenning van 1 digitale gebruikerserva
 UID:964fbb52-f51a-4948-893c-624b6a2afca0
 SUMMARY:1 digitale gebruikerservaring bij de overheid - door Anton Olivier
 DTSTART;TZID=Europe/Amsterdam:20251030T130000
-DTEND;TZID=Europe/Amsterdam:20251030T133000
+DTEND;TZID=Europe/Amsterdam:20251030T134500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/anwb-design-system.ics
+++ b/static/dsweek-2025/anwb-design-system.ics
@@ -23,7 +23,7 @@ DESCRIPTION:Loes deelt hoe het design system van de ANWB volledig is herbouwd en
 UID:d64f95d1-0f53-40c0-b0b5-75a22a9a0d1a
 SUMMARY: Het ANWB Design System herbouwd: toegankelijk en toekomstgericht - door Loes Kockelmans
 DTSTART;TZID=Europe/Amsterdam:20251029T163000
-DTEND;TZID=Europe/Amsterdam:20251029T170000
+DTEND;TZID=Europe/Amsterdam:20251029T171500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/design-systems-en-AI.ics
+++ b/static/dsweek-2025/design-systems-en-AI.ics
@@ -22,7 +22,7 @@ DESCRIPTION:Egor neemt ons mee in de wereld van AI en ontwerpsystemen. Wat kun
 UID:879f4395-f6fd-40d8-91e2-10d68bb88e1f
 SUMMARY:Design Systems & AI - door Egor Kloos
 DTSTART;TZID=Europe/Amsterdam:20251028T150000
-DTEND;TZID=Europe/Amsterdam:20251028T153000
+DTEND;TZID=Europe/Amsterdam:20251028T154500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/een-design-system-bouwen-aan-vertrouwen.ics
+++ b/static/dsweek-2025/een-design-system-bouwen-aan-vertrouwen.ics
@@ -21,7 +21,7 @@ DESCRIPTION:Evalien deelt in haar sessie de lessen die DUO de afgelopen jaren 
 UID:c3b53154-1ed9-44e5-b69d-4a6a31190063
 SUMMARY:Een Design System: Bouwen aan vertrouwen - door Evalien Wiersma
 DTSTART;TZID=Europe/Amsterdam:20251030T150000
-DTEND;TZID=Europe/Amsterdam:20251030T153000
+DTEND;TZID=Europe/Amsterdam:20251030T154500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/estonia-design-system.ics
+++ b/static/dsweek-2025/estonia-design-system.ics
@@ -22,7 +22,7 @@ DESCRIPTION:TEDI is het ontwerpsysteem voor de Estse overheidssector. Wat twee j
 UID:93d0fc4a-889e-44a1-a7eb-9c490465f5f8
 SUMMARY:TEDI: het nieuwe ontwerpsysteem van de Estse overheid - door Siret Tuula, Kärolin Kivisikk en Tönis Tobre
 DTSTART;TZID=Europe/Amsterdam:20251027T130000
-DTEND;TZID=Europe/Amsterdam:20251027T133000
+DTEND;TZID=Europe/Amsterdam:20251027T134500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/gebruikersonderzoek-en-co-creatie.ics
+++ b/static/dsweek-2025/gebruikersonderzoek-en-co-creatie.ics
@@ -22,7 +22,7 @@ DESCRIPTION:Kimberly en Ted nemen je mee in universeel ontwerp: ontwerpen voor 
 UID:9c744d89-14a2-443a-8668-d97c9e7c47f2
 SUMMARY:Gebruikersonderzoek en co-creatie - door Kimberly Brinkhuis en Ted van der Togt
 DTSTART;TZID=Europe/Amsterdam:20251029T130000
-DTEND;TZID=Europe/Amsterdam:20251029T133000
+DTEND;TZID=Europe/Amsterdam:20251029T134500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/helsinki-design-system.ics
+++ b/static/dsweek-2025/helsinki-design-system.ics
@@ -25,7 +25,7 @@ DESCRIPTION:Het Helsinki Design System is een bekroond open-sourceproject dat vo
 UID:23b35855-535e-4b6c-85e7-071d595a98e1
 SUMMARY:Helsinki Design System - Balancing Documentation Workflow in a Design System Project - door Päivi Jalava en Juan Cubilla
 DTSTART;TZID=Europe/Amsterdam:20251028T163000
-DTEND;TZID=Europe/Amsterdam:20251028T170000
+DTEND;TZID=Europe/Amsterdam:20251028T171500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/hoe-maak-je-algoritmes-begrijpelijk-voor-burgers.ics
+++ b/static/dsweek-2025/hoe-maak-je-algoritmes-begrijpelijk-voor-burgers.ics
@@ -23,7 +23,7 @@ DESCRIPTION:Claudia en Baukje nemen je mee in de vraag hoe je begrijpelijk uitle
 UID:cdfe9e6a-0595-42a0-88b7-2a00dd2a1e06
 SUMMARY:Hoe maak je algoritmes begrijpelijk voor burgers? Onderzoek & beeldtaal - door Claudia Vermeulen en Baukje Faber
 DTSTART;TZID=Europe/Amsterdam:20251029T150000
-DTEND;TZID=Europe/Amsterdam:20251029T153000
+DTEND;TZID=Europe/Amsterdam:20251029T154500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/practical-tests-for-assessing-accessibility.ics
+++ b/static/dsweek-2025/practical-tests-for-assessing-accessibility.ics
@@ -21,7 +21,7 @@ DESCRIPTION:Sinds 2020 is er in Luxemburg hard gewerkt aan drie testmethodes voo
 UID:b4056558-8e30-4731-b2a3-b131f5dd53d3
 SUMMARY:290 Practical Tests for Assessing Accessibility - door Alain Vagner
 DTSTART;TZID=Europe/Amsterdam:20251027T150000
-DTEND;TZID=Europe/Amsterdam:20251027T153000
+DTEND;TZID=Europe/Amsterdam:20251027T154500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/prototypen-en-nl-design-system.ics
+++ b/static/dsweek-2025/prototypen-en-nl-design-system.ics
@@ -22,7 +22,7 @@ DESCRIPTION:Jeffrey neemt je mee in de rol van prototyping bij het ontwikkelen v
 UID:d0e216e2-0dfe-4232-865f-91e8d10c7d1a
 SUMMARY:Prototypen & NL Design System - door Jeffrey Lauwers
 DTSTART;TZID=Europe/Amsterdam:20251029T110000
-DTEND;TZID=Europe/Amsterdam:20251029T113000
+DTEND;TZID=Europe/Amsterdam:20251029T114500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z

--- a/static/dsweek-2025/toegankelijke-componenten-bij-nl-design-system.ics
+++ b/static/dsweek-2025/toegankelijke-componenten-bij-nl-design-system.ics
@@ -23,7 +23,7 @@ DESCRIPTION:Renate laat zien hoe componenten in een Community-gedreven design sy
 UID:2acd2d26-522c-4e11-944c-62767af986e6
 SUMMARY:Toegankelijke componenten bij NL Design System - door Renate Roke
 DTSTART;TZID=Europe/Amsterdam:20251028T110000
-DTEND;TZID=Europe/Amsterdam:20251028T113000
+DTEND;TZID=Europe/Amsterdam:20251028T114500
 CLASS:PUBLIC
 PRIORITY:5
 DTSTAMP:20250929T104513Z


### PR DESCRIPTION
No need to update IDs: since only this param has changed, it'll neatly update the existing event in the user's calendar when re-uploading.