### PR TITLE
chore: use sha pinning for all GitHub Actions

### DIFF
--- a/.github/workflows/require-autosquash.yml
+++ b/.github/workflows/require-autosquash.yml
@@ -13,6 +13,6 @@ jobs:
 
     steps:
       - name: Block Autosquash Commits
-        uses: xt0rted/block-autosquash-commits-action@v2.2.0
+        uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions