### PR TITLE
docs: fix broken gebruikersonderzoeken link

### DIFF
--- a/docs/community/community-sprints/mijn-services-community/mijn-services-community.mdx
+++ b/docs/community/community-sprints/mijn-services-community/mijn-services-community.mdx
@@ -65,7 +65,7 @@ Bekijk de links en documentatie die horen bij deze Community Sprint:
 - [MijnServices Community Sprintbord op GitHub](https://github.com/orgs/nl-design-system/projects/34)
 - [NL Design System - MijnServices Community - Templates](https://www.figma.com/design/pB5d6RlVSa1B088Xpm1sSo/2025---MijnServices---Templates--Voorheen--Overheidsbrede-portalen-)
 - [MijnServices Community Storybook](https://nl-design-system.github.io/mijn-services/)
-- [Gebruikersonderzoeken getagd met "Mijn Omgeving" op Gebruikersonderzoeken.nl](https://gebruikersonderzoeken.nl/docs/tags/mijn-omgeving)
+- [Gebruikersonderzoeken getagd met "Mijn Omgeving" op Gebruikersonderzoeken.nl](https://gebruikersonderzoeken.nl/docs/thema/mijn-omgeving)
 
 Bekijk hieronder de YouTube afspeellijst met de video's van de MijnServices Community.
 


### PR DESCRIPTION
Since tags URL was changed to thema. Will notify kernteam for redirect.