### PR TITLE
ci: remove publish-website job that uses GitHub Pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,24 +101,3 @@ jobs:
           name: screenshots
           path: tmp/screenshots/
           retention-days: 7
-
-  publish-website:
-    runs-on: ubuntu-latest
-    needs: continuous-integration
-    if: github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Checkout release branch
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: "Restore build artifact: website"
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: website
-          path: build/
-
-      - name: Continuous Deployment to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
-        with:
-          branch: gh-pages
-          folder: build/


### PR DESCRIPTION
This is hosted in Vercel. Removing this job cleans up usage of an old action (JamesIves/github-pages-deploy-action).

After this is merged, it is probably a good idea to disable GH Pages through terraform.
