### PR TITLE
feat: voorbereiding om het "candidate - new" bord te gebruiken (#1602)

### DIFF
--- a/src/components/ComponentPage.tsx
+++ b/src/components/ComponentPage.tsx
@@ -29,14 +29,21 @@ export const DefinitionOfDone = ({ component, headingLevel }: ComponentPageSecti
   const relayOrderedProjects =
     relayProjects && relayProjectIds.map((id) => relayProjects.find((project) => project.id === id)).filter(Boolean);
 
+  // TODO: https://github.com/nl-design-system/kernteam/issues/1601 om Candidate - New te hernoemen naar Candidate, en Candidate - oud te archiveren. Dit doen we wanneer Yolijn terug is, to be safe.
+  const getProjectTitle = (project) =>
+    ['Candidate - New', 'Candidate - Oud'].includes(project.title) ? 'Candidate' : project.title;
+
   return (
     component && (
       <AccordionProvider
         sections={relayOrderedProjects.map((project) => ({
-          className: clsx('definition-of-done', project && `definition-of-done--${toKebabCase(project.title)}`),
+          className: clsx(
+            'definition-of-done',
+            project && `definition-of-done--${toKebabCase(getProjectTitle(project))}`,
+          ),
           headingLevel: headingLevel,
           expanded: false,
-          label: project ? `${project.title} - ${project.progress.value} van ${project.progress.max}` : '',
+          label: project ? `${getProjectTitle(project)} - ${project.progress.value} van ${project.progress.max}` : '',
           body: project && (
             <>
               <TaskList>
@@ -52,7 +59,7 @@ export const DefinitionOfDone = ({ component, headingLevel }: ComponentPageSecti
               </TaskList>
               <Paragraph>
                 <Link href={`${project.url}?filterQuery=${component.title}`}>
-                  {project.title} projectbord op GitHub
+                  {getProjectTitle(project)} projectbord op GitHub
                 </Link>
               </Paragraph>
             </>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,6 +150,10 @@ export const getProjectFrameworks = (project: ComponentProject): ProjectFramewor
   const frameworkNames = getProjectFrameworkNames(project);
   const alias = getComponentAlias(project);
 
+  // TODO: https://github.com/nl-design-system/kernteam/issues/1601 om Candidate - New te hernoemen naar Candidate, en Candidate - oud te archiveren. Dit doen we wanneer Yolijn terug is, to be safe.
+  const getProjectTitle = (project) =>
+    ['Candidate - New', 'Candidate - Oud'].includes(project.title) ? 'Candidate' : project.title;
+
   // Then group the tasks for each framework
   // { brand:'github', name: 'GitHub URL (CSS)', id: '...', value: '...', description: '...' }
   return frameworkNames.map((frameworkName) => {
@@ -159,7 +163,7 @@ export const getProjectFrameworks = (project: ComponentProject): ProjectFramewor
         const brand = /^(.+) URL/.exec(name)[1];
         const description =
           brand === 'Storybook'
-            ? `${alias} (${frameworkName}) in Storybook van ${project.title}`
+            ? `${alias} (${frameworkName}) in Storybook van ${getProjectTitle(project)}`
             : `${alias} (${frameworkName}) op ${brand}`;
         return {
           brand: brand.toLowerCase(),


### PR DESCRIPTION
Weergeef "Candidate - New" en "Candidate - Oud" als "Candidate".

Part of https://github.com/nl-design-system/kernteam/issues/1602