### PR TITLE
docs: add rijkshuisstijl community to community implementaties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,7 @@ export type PROJECT_ID =
   | 'AMSTERDAM'
   | 'RVO'
   | 'LOGIUS'
+  | 'RIJKSHUISSTIJL_COMMUNITY'
   | 'DEN_HAAG';
 
 export interface ProjectTask {


### PR DESCRIPTION
Deel van https://github.com/nl-design-system/kernteam/issues/1260: Voor Rijkshuisstijl community een bord aanmaken en zorgen dat deze beschikbaar is in de componenten progress.