### PR TITLE
build: update component progress 1.0.1-alpha.144

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.4",
-    "@nl-design-system/component-progress": "1.0.1-alpha.136",
+    "@nl-design-system/component-progress": "1.0.1-alpha.144",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
       '@nl-design-system/component-progress':
-        specifier: 1.0.1-alpha.136
-        version: 1.0.1-alpha.136
+        specifier: 1.0.1-alpha.144
+        version: 1.0.1-alpha.144
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)
@@ -2176,8 +2176,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4':
     resolution: {integrity: sha512-POlUBxviNooS6NpzyH6v3MJ+WwQEqMYj3VcJcX4oDRdRsxoYgsq4GDm3C55IhJ12nPKnd/F5DD+RBomviSkgxg==}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.136':
-    resolution: {integrity: sha512-uW+NpaiMpZmgPhcCoKGXNsy0BRH/aFrVFTyBrfhirsFie8wY9nFN3gkw4VcleMZrKXGYSy1pSfsBGD7BxtOBMA==}
+  '@nl-design-system/component-progress@1.0.1-alpha.144':
+    resolution: {integrity: sha512-zKVpOctC3WfggAAmU+YtzNoDZ5fe2i7DbAa3Fq+M/5nkvsALCJOhG3hQxjUQXZ+oo7O+FHROP0aLGS89n8BJDQ==}
 
   '@nl-design-system/eslint-config@1.0.0':
     resolution: {integrity: sha512-ypsu7zBN26tVLdnbcK2+He2l+QK33qNtHGlBY0CY5x8wWkCQULSH+10E+rUIAf+kBHKdQkgr5+W60qyj97a66Q==}
@@ -11430,7 +11430,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4': {}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.136': {}
+  '@nl-design-system/component-progress@1.0.1-alpha.144': {}
 
   '@nl-design-system/eslint-config@1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
This PR will update the component progress to version 1.0.1-alpha.144.

[Preview](https://documentatie-git-build-update-component-6f4c82-nl-design-system.vercel.app/componenten/).