### PR TITLE
build: remove changeset causing ci errors

### DIFF
--- a/.changeset/link-style-switch.md
+++ b/.changeset/link-style-switch.md
@@ -1,5 +1,0 @@
----
-"@nl-design-system-unstable/start-design-tokens": patch
----
-
-Verouderde Figma Style uit Todo Bibliotheek weggewerkt.


### PR DESCRIPTION
The changeset referred to a non-existant package.

Fixes, for example, https://github.com/nl-design-system/documentatie/actions/runs/19362007600/job/55395977144