### PR TITLE
docs: candidate aliases as keywords for text input

### DIFF
--- a/docs/componenten/text-input/index.mdx
+++ b/docs/componenten/text-input/index.mdx
@@ -12,14 +12,24 @@ keywords:
   - form control
   - formulier
   - formulierelement
+  - formfield
   - form field
+  - form input
+  - formulier-stap
   - input
   - input field
+  - inputfield
+  - invoerveld
+  - invulveld
+  - tekstveld
+  - tekstinvoer
   - text box
   - textbox
   - text entry
   - text field
   - text input
+  - textinput
+  - veld
 ---
 
 {/* @license CC0-1.0 */}


### PR DESCRIPTION
Vanuit de Candidate "Zoekwoorden" stap, en het bestaande canvas.