### PR TITLE
docs: candidate aliases as keywords for form field label

### DIFF
--- a/docs/componenten/form-field-label/index.mdx
+++ b/docs/componenten/form-field-label/index.mdx
@@ -13,9 +13,13 @@ keywords:
   - form field label
   - form input
   - form label
+  - formlabel
   - formulier
   - formulierelement
+  - input label
   - label
+  - text label
+  - textlabel
 ---
 
 {/* @license CC0-1.0 */}


### PR DESCRIPTION
Vanuit de Candidate "Zoekwoorden" stap, en het bestaande canvas.