### PR TITLE
docs: verwijder communicatie & pr stap uit community stappenplan

### DIFF
--- a/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/component-bijdragen/community-stappenplan/voor-kernteam.mdx
@@ -257,7 +257,6 @@ This PR will update the component progress to version {versienummer}.
 Doel: Credits geven aan mensen die hebben bijgedragen vanuit de community. De rest van community informeren en enthousiasmeren om ook naar Community, Candidate en Hall of Fame toe te werken.
 
 - Voeg het label '📣 Promotion' toe aan het backlog issue.
-- Selecteer bij ‘Projects’ het project 'Communicatie & PR'.
 
 ### Communityleden selecteren voor credits
 


### PR DESCRIPTION
Zoals besproken met Yolijn is deze stap niet meer van toepassing.