### PR TITLE
ci: group docusaurus and storybook dependencies in separate PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,21 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      docusaurus:
+        applies-to: "version-updates"
+        patterns:
+          - "@docusaurus/*"
+        update-types:
+          - "patch"
+          - "minor"
+      storybook:
+        applies-to: "version-updates"
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+        update-types:
+          - "patch"
+          - "minor"
       patch-and-minor-dependencies:
         applies-to: "version-updates"
         update-types:


### PR DESCRIPTION
The current open dependabot PR has 60+ changes to check.

Creating more focused groups of dependencies makes it easier to review in isolation.