### PR TITLE
chore: remove calendar redirect

### DIFF
--- a/docs/componenten/calendar/index.mdx
+++ b/docs/componenten/calendar/index.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 sidebar_label: Calendar
 pagination_label: Calendar
 description: Een kalender waarin je een beschikbare datum kan kiezen.
-slug: /Calendar
+slug: /calendar
 keywords:
   - afspraak
   - appointment

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -163,7 +163,6 @@ Redirect 301 "/belangenorganisatie" "/community/belangenorganisaties/aanmelden/"
 RedirectMatch 307 "^/factsheets/?$" "/factsheets/managers"
 
 # Temporary redirects until the component is part of help-wanted board
-Redirect 307 "/calendar" "/componenten"
 Redirect 307 "/character-count" "/componenten"
 Redirect 307 "/form-field-radio-option" "/componenten"
 Redirect 307 "/form-field-checkbox-option" "/componenten"


### PR DESCRIPTION
Ik kwam erachter dat de calendar een slug had met een hoofdletter en dat dat de reden is dat de redirect niet een probleem vormde in het overzicht. Deze PR trekt het recht met andere componenten