### PR TITLE
docs: add figma changes 5.2.1

### DIFF
--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -34,7 +34,7 @@ Wil je meer weten over hoe je deze changelog gebruikt? Bekijk dan de [uitleg ov
 
 1 december 2025
 
-Bugfix: Juiste font-weight token koppelen voor Candidate component Heading level 4
+Bugfix: Juiste font-weight token gekoppeld aan Candidate component Heading level 4.
 
 - [Ga naar de pagina van Heading](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=153-1039).
 - Selecteer het frame 'nl-heading'.


### PR DESCRIPTION
Gevonden door Aline. Font-weight token voor Heading Level 4 verwees nog naar die van Utrecht.