### PR TITLE
build: update component progress 1.0.1-alpha.148

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.4",
-    "@nl-design-system/component-progress": "1.0.1-alpha.146",
+    "@nl-design-system/component-progress": "1.0.1-alpha.148",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
       '@nl-design-system/component-progress':
-        specifier: 1.0.1-alpha.146
-        version: 1.0.1-alpha.146
+        specifier: 1.0.1-alpha.148
+        version: 1.0.1-alpha.148
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)
@@ -2191,8 +2191,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4':
     resolution: {integrity: sha512-POlUBxviNooS6NpzyH6v3MJ+WwQEqMYj3VcJcX4oDRdRsxoYgsq4GDm3C55IhJ12nPKnd/F5DD+RBomviSkgxg==}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.146':
-    resolution: {integrity: sha512-kyomqGEPs+h5QJqE3ZF3u+Ef778VDdR3RZdqgEzM3aOLly4bvJ2Tas+6EHQcnp5Jb7l6DXS9QJxNbk0X3U2Y6A==}
+  '@nl-design-system/component-progress@1.0.1-alpha.148':
+    resolution: {integrity: sha512-qpogxDayRMq7UbWqD6gt2mX0MKts/4u4lVmMB8JQ6t+gIvzw9PfFXDW7A65EFfoHgNUnZ824xq1CHdIUDtW95A==}
 
   '@nl-design-system/eslint-config@1.0.0':
     resolution: {integrity: sha512-ypsu7zBN26tVLdnbcK2+He2l+QK33qNtHGlBY0CY5x8wWkCQULSH+10E+rUIAf+kBHKdQkgr5+W60qyj97a66Q==}
@@ -11460,7 +11460,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4': {}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.146': {}
+  '@nl-design-system/component-progress@1.0.1-alpha.148': {}
 
   '@nl-design-system/eslint-config@1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
This PR will update the component progress to version 1.0.1-alpha.148.

[Preview](https://documentatie-git-build-update-component-897244-nl-design-system.vercel.app/login-link/).