### PR TITLE
docs: voeg gerelateerde componenten toe als tekst voor Alert Dialog en gerelateerde componenten (#3160)

### DIFF
--- a/docs/componenten/alert-dialog/index.mdx
+++ b/docs/componenten/alert-dialog/index.mdx
@@ -45,6 +45,11 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert/">Alert</a>, <a href="/modal-dialog/">Modal Dialog</a>,{" "}
+  <a href="/dialog/">Dialog</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/alert/index.mdx
+++ b/docs/componenten/alert/index.mdx
@@ -46,6 +46,11 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert-dialog/">Alert Dialog</a>,{" "}
+  <a href="/notification-banner/">Notification Banner</a>, <a href="/note/">Note</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/dialog/index.mdx
+++ b/docs/componenten/dialog/index.mdx
@@ -38,6 +38,11 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert-dialog/">Alert Dialog</a>, <a href="/drawer/">Drawer</a>,{" "}
+  <a href="/modal-dialog/">Modal Dialog</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/drawer/index.mdx
+++ b/docs/componenten/drawer/index.mdx
@@ -35,6 +35,10 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/modal-dialog/">Modal Dialog</a>, <a href="/dialog/">Dialog</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/modal-dialog/index.mdx
+++ b/docs/componenten/modal-dialog/index.mdx
@@ -45,6 +45,11 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert-dialog/">Alert Dialog</a>, <a href="/drawer/">Drawer</a>,{" "}
+  <a href="/dialog/">Dialog</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/note/index.mdx
+++ b/docs/componenten/note/index.mdx
@@ -30,6 +30,10 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert/">Alert</a>, <a href="/notification-banner/">Notification Banner</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />

--- a/docs/componenten/notification-banner/index.mdx
+++ b/docs/componenten/notification-banner/index.mdx
@@ -49,6 +49,10 @@ export const component = componentProgress.find((item) => item.number === issueN
 
 <Introduction component={component} headingLevel={1} description={description} />
 
+<p>
+  Gerelateerde componenten: <a href="/alert/">Alert</a>, <a href="/note/">Note</a>.
+</p>
+
 ## Definition of Done
 
 <DefinitionOfDone component={component} headingLevel={3} />


### PR DESCRIPTION
Closes #3160

Gebaseerd op Aliassen, zoals gedaan voor bijv Code: https://nldesignsystem.nl/code/#:~:text=Ook%20bekend%20als%3A%20Monotype%2C%20Monospace%20en%20Code%20Snippet.

Previews:

[Alert](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/alert/)
[Alert Dialog](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/alert-dialog/)
[Dialog](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/dialog/)
[Drawer](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/drawer/)
[Modal Dialog](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/modal-dialog/)
[Note](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/note/)
[Notification Banner](https://documentatie-git-docs-3160-voeg-gerelat-dc25e2-nl-design-system.vercel.app/notification-banner/)