### PR TITLE
docs: update personal access token section

### DIFF
--- a/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
@@ -199,7 +199,7 @@ Een repository kan je zien als de hoofdmap van je project. Binnen deze repositor
 Afhankelijk van de situatie van jouw organisatie zal worden bepaald waar het JSON bestand moet komen staan.
 
 **Situatie A**  
-Jouw organisatie heeft al een map met design tokens binnen de [NL Design System 'themes repository'](https://github.com/nl-design-system/themes).
+Jouw organisatie heeft al een map met design tokens binnen de [NL Design System 'themes' repository](https://github.com/nl-design-system/themes).
 
 - Controleer wanneer de laatste wijziging op de design tokens heeft plaatsgevonden.
 - Bekijk wie deze wijzigingen heeft gedaan.
@@ -209,7 +209,7 @@ Jouw organisatie heeft al een map met design tokens binnen de [NL Design System 
 Zijn de wijzigingen recent? En ken je de persoon die ze heeft gedaan? Stem dan even met elkaar af. Kom je er niet uit? Stel je vraag gerust in Slack.
 
 **Situatie B**  
-Jouw organisatie heeft nog géén map binnen de [NL Design System 'themes repository'](https://github.com/nl-design-system/themes). En dat wil je wel.
+Jouw organisatie heeft nog géén map binnen de [NL Design System 'themes' repository](https://github.com/nl-design-system/themes). En dat wil je wel.
 
 [Neem contact op met het kernteam](/project/kernteam).
 


### PR DESCRIPTION
GitHub heeft de interface voor het aanmaken van een Personal Access Token weer aangepast. Dus is deze stap in het Figma Stappenplan ook aangepast.