### PR TITLE
docs: link toevoegen naar uitbreiden

### DIFF
--- a/docs/handboek/componenten-gebruiken.mdx
+++ b/docs/handboek/componenten-gebruiken.mdx
@@ -139,7 +139,7 @@ Volg onderstaande stappen als je een functionaliteit mist binnen een Community c
 >
 > - Maak een issue aan in de betreffende repository.
 > - Maak een fork en een pull request aan.
-> - Breid de Figma component uit door een duplicaat onder de reeds bestaande Community component te plaatsen.
+> - [Breid de Figma component uit](/handboek/designer/zelf-componenten-uitbreiden) door een duplicaat onder de reeds bestaande Community component te plaatsen.
 > - Plaats een link naar het issue, de PR of ontwerp in het Slack kanaal [#nl-design-system-developers](https://codefornl.slack.com/archives/C01DAT4TRPF) of [#nl-design-system-designers](https://codefornl.slack.com/archives/C01D78C2E4E) en noem hier de naam van de organisatie. Kernteamleden volgen deze kanalen ook. Zij kunnen eventueel specifieke personen op de hoogte brengen van de wens.
 > - Bespreek je wens tijdens een [Developer](/events/developer-open-hour) of [Design Open Hour](/events/design-open-hour) wanneer mensen van de betreffende organisatie aanwezig zijn.
 


### PR DESCRIPTION
Link vanuit 'Component gebruiken' pagina naar 'Zelf componenten uitbreiden als designer pagina'.