### PR TITLE
build: update component progress 1.0.1-alpha.152

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.4",
-    "@nl-design-system/component-progress": "1.0.1-alpha.149",
+    "@nl-design-system/component-progress": "1.0.1-alpha.152",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4
       '@nl-design-system/component-progress':
-        specifier: 1.0.1-alpha.149
-        version: 1.0.1-alpha.149
+        specifier: 1.0.1-alpha.152
+        version: 1.0.1-alpha.152
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)
@@ -2191,8 +2191,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4':
     resolution: {integrity: sha512-POlUBxviNooS6NpzyH6v3MJ+WwQEqMYj3VcJcX4oDRdRsxoYgsq4GDm3C55IhJ12nPKnd/F5DD+RBomviSkgxg==}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.149':
-    resolution: {integrity: sha512-E1vx5D8++AcoVT9RDhcViAWCOftNc3sxaTlExUtKVCygoCjSE/zTlNTg596+tNQ7JnBltenKRCde5ac1bGU3Fg==}
+  '@nl-design-system/component-progress@1.0.1-alpha.152':
+    resolution: {integrity: sha512-8t3QAVQXDbXFHxZgSnlyQ0/yS/GjLDQOB7abMHCH8I9n904+6wwyPMuW/KPZg0RBlteW8Qky3ixhzP9aUS0QJA==}
 
   '@nl-design-system/eslint-config@1.0.0':
     resolution: {integrity: sha512-ypsu7zBN26tVLdnbcK2+He2l+QK33qNtHGlBY0CY5x8wWkCQULSH+10E+rUIAf+kBHKdQkgr5+W60qyj97a66Q==}
@@ -11460,7 +11460,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.4': {}
 
-  '@nl-design-system/component-progress@1.0.1-alpha.149': {}
+  '@nl-design-system/component-progress@1.0.1-alpha.152': {}
 
   '@nl-design-system/eslint-config@1.0.0(eslint@9.20.1(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
This PR will update the component progress to version 1.0.1-alpha.152.

Helpt onder andere de Alert op het Rijkshuisstijl Community bord: [preview](https://documentatie-git-build-update-component-c2443f-nl-design-system.vercel.app/alert/).