### PR TITLE
fix: remove accolade at end of link text

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,7 +160,7 @@ export const getProjectFrameworks = (project: ComponentProject): ProjectFramewor
         const brand = /^(.+) URL/.exec(name)[1];
         const description =
           brand === 'Storybook'
-            ? `${alias} (${frameworkName}) in Storybook van ${project.title}}`
+            ? `${alias} (${frameworkName}) in Storybook van ${project.title}`
             : `${alias} (${frameworkName}) op ${brand}`;
         return {
           brand: brand.toLowerCase(),


### PR DESCRIPTION
Removes accolade at:

<img width="466" height="394" alt="Screenshot 2025-12-15 at 17 38 24" src="https://github.com/user-attachments/assets/557ad68b-6721-4dab-9f88-7e56ed46b55f" />
