### PR TITLE
docs: add figma changes 6.6.1

### DIFF
--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -30,6 +30,23 @@ Wil je meer weten over hoe je deze changelog gebruikt? Bekijk dan de [uitleg ov
 - [Component met design tokens overnemen in Figma](https://youtu.be/RZA4WtAGK1Y)
 - [Versienummer wijzigen in Figma](https://youtu.be/PPPT6oxIdWo)
 
+## 6.6.1
+
+19 december 2025
+
+Schaduw bij Table component hersteld
+
+- [Bekijk Table in de NL Design System - Bibliotheek](https://www.figma.com/design/FqAr99wvrlHxTJYAHkFRQN/NL-Design-System---Bibliotheek?node-id=26701-285).
+- Ga binnen het frame 'Documentatie - Table' naar de sectie 'Responsive gedrag'.
+- In de voorbeelden vind je de fixed layers 'utrecht-table-container-shadow-right' en 'utrecht-table-container-shadow-left'.
+- Selecteer layer 'utrecht-table-container-shadow-right' en hernoem deze naar 'table-container-box-shadow-inline-end'.
+- Zet in de Figma properties 'Clip content' uit.
+- Selecteer layer 'utrecht-table-container-shadow-left' en hernoem deze naar 'table-container-box-shadow-inline-start'.
+- Zet in de Figma properties 'Clip content' uit.
+- Ga naar het frame 'Demo - Table'.
+- Selecteer layer 'utrecht-table-container-shadow-right' en hernoem deze naar 'table-container-box-shadow-inline-end'.
+- Zet in de Figma properties 'Clip content' uit.
+
 ## 6.6.0
 
 18 december 2025


### PR DESCRIPTION
Bugfix tijdens Design Open Dag waarbij de schaduw was weggevallen door Figma's Clip Content funtie.