### PR TITLE
fix: remove token outline-offset from button json

### DIFF
--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -68,11 +68,6 @@ Candidate component ‘Button’ is toegevoegd aan de bibliotheek.
         "$type": "dimension",
         "$value": "{basis.pointer-target.min-inline-size}"
       },
-      "outline-offset": {
-        "$type": "other",
-        "$value": "0px",
-        "$description": "[code-only]"
-      },
       "padding-block-end": {
         "$type": "dimension",
         "$value": "{basis.space.block.md}"


### PR DESCRIPTION
Token `nl.button.outline-offset` is verwijderd uit JSON codeblock.