### PR TITLE
fix: hide theme unlisted banner

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -319,6 +319,10 @@ p {
   padding-inline-start: 48px;
 }
 
+.theme-unlisted-banner {
+  display: none;
+}
+
 /* stylelint-disable -- Overwriting DocSearch, we don't have control over the markup. */
 .DocSearch {
   --docsearch-subtle-color: var(--ma-docsearch-button-border-color);


### PR DESCRIPTION
In plaats van [een hele Swizzle](https://github.com/nl-design-system/documentatie/pull/3656) kunnen we ook met CSS de banner verstoppen.

Onderdeel van https://github.com/nl-design-system/documentatie/issues/3655