### PR TITLE
fix: Restore missing external link icon css

### DIFF
--- a/docs/richtlijnen/README.mdx
+++ b/docs/richtlijnen/README.mdx
@@ -17,6 +17,7 @@ keywords:
 
 import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
 import { OverviewPage } from "@site/src/components/OverviewPage";
+import "./styles.css";
 
 # Richtlijnen NL Design System
 

--- a/docs/richtlijnen/styles.css
+++ b/docs/richtlijnen/styles.css
@@ -1,0 +1,6 @@
+.nlds-icon-ext {
+  background-image: url("../../src/icons/external-link.svg");
+  background-position: right center;
+  background-repeat: no-repeat;
+  padding-right: 24px;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -802,10 +802,3 @@ ams-page-footer {
 .nl-skip-link {
   z-index: 10000;
 }
-
-.nlds-icon-ext {
-  background-image: url("../icons/external-link.svg");
-  background-position: right center;
-  background-repeat: no-repeat;
-  padding-right: 24px;
-}


### PR DESCRIPTION
Restores the missing `.nlds-icon-ext` class in `src/css/custom.css`.\n\nThis fixes the missing icon issue on [Richtlijnen > Formulieren > Links > Link in nieuwe tab](https://nldesignsystem.nl/richtlijnen/formulieren/links/nieuwe-tab/).

closes https://github.com/nl-design-system/documentatie/issues/3043

Origineel: https://nldesignsystem.nl/richtlijnen/formulieren/links/nieuwe-tab/#geef-aan-als-een-link-in-een-nieuwe-tab-opent
Preview: https://documentatie-git-fix-missing-external-l-573d27-nl-design-system.vercel.app/richtlijnen/formulieren/links/nieuwe-tab/#geef-aan-als-een-link-in-een-nieuwe-tab-opent