### PR TITLE
fix: add missing 4xl font-size and line-height tokens in start-thema docs

### DIFF
--- a/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
@@ -227,6 +227,7 @@ Voor elke lettergrootte is er een corresponderende basis-token voor regelhoogte 
 - `basis.text.line-height.xl`
 - `basis.text.line-height.2xl`
 - `basis.text.line-height.3xl`
+- `basis.text.line-height.4xl`
 
 De waarden zijn 'unitless' (zonder eenheid) genoteerd, zodat de regelhoogte automatisch meebeweegt met de gekozen lettergrootte.
 


### PR DESCRIPTION
Add 'basis.text.font-size.4xl' to font size tokens.

Vond deze door validatie-errors in de theme-wizard app. De [docs](https://nldesignsystem.nl/handboek/huisstijl/themas/start-thema/#lettergrootte) zeggen ook "Er zijn zeven basis-tokens beschikbaar" terwij er maar zes stonden.