### PR TITLE
feat: use browser apis instead of docusaurus to get search queryies

### DIFF
--- a/src/components/NewsletterSignUp.tsx
+++ b/src/components/NewsletterSignUp.tsx
@@ -1,4 +1,3 @@
-import { useLocation } from '@docusaurus/router';
 import {
   Button,
   ButtonGroup,
@@ -16,6 +15,7 @@ import {
 import type { PropsWithChildren } from 'react';
 import { useRef } from 'react';
 import { useForm } from 'react-hook-form';
+import { useIsBrowser } from '../hooks/use-is-browser';
 
 interface NewsletterSignUpProps {
   listId: string;
@@ -92,7 +92,8 @@ export const NewsletterSignUp = ({
   } = useForm<{ [key: string]: string }>();
   const form = useRef(null);
   const IS_ENGLISH = language?.value === '2';
-  const { search } = useLocation();
+  const isBrowser = useIsBrowser();
+  const search = isBrowser ? window.location.search : '';
   const params = new URLSearchParams(search);
   const prefillEmail = params.get('prefillEmail');
   const prefillName = params.get('prefillName');

--- a/src/pages/contrast/index.tsx
+++ b/src/pages/contrast/index.tsx
@@ -1,4 +1,3 @@
-import { useLocation } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { Canvas } from '@site/src/components/Canvas/Canvas';
 import type { CanvasContainerType } from '@site/src/components/Canvas/Canvas';
@@ -20,6 +19,7 @@ import Color from 'color';
 import type { HTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 import './index.css';
 import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import { useIsBrowser } from '@site/src/hooks/use-is-browser';
 
 const ExampleIcon = () => (
   <Icon style={{ '--utrecht-icon-size': '128px' }}>
@@ -105,8 +105,9 @@ const LargeTextExample = (): ReactNode => (
 
 const ContrastPage = () => {
   const { siteConfig } = useDocusaurusContext();
-  const { search } = useLocation();
+  const isBrowser = useIsBrowser();
 
+  const search = isBrowser ? window.location.search : '';
   const params = new URLSearchParams(search);
   let backgroundColor = params.get('background-color');
   let color = params.get('color');


### PR DESCRIPTION
closes: #3703

Hoe te testen: ga naar deze pagina en zie dat de naam en email vooringevuld worden:
https://documentatie-git-feat-use-browser-apis-18f2c9-nl-design-system.vercel.app/community/sluit-je-aan?prefillName=peter&prefillEmail=peter@example.com
