### PR TITLE
feat: replace docusaurus link component for native a element

### DIFF
--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -1,5 +1,5 @@
-import DocusaurusLink from '@docusaurus/Link';
 import type { Props } from '@docusaurus/Link';
+import { BareLink } from '@site/src/components/Link';
 import { clsx } from 'clsx';
 
 import type { PropsWithChildren } from 'react';
@@ -9,5 +9,5 @@ export interface ButtonLinkProps extends Props {
 }
 
 export const ButtonLink = ({ appearance, ...props }: PropsWithChildren<ButtonLinkProps>) => (
-  <DocusaurusLink className={clsx('utrecht-button-link', `utrecht-button-link--${appearance}`)} {...props} />
+  <BareLink className={clsx('utrecht-button-link', `utrecht-button-link--${appearance}`)} {...props} />
 );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,9 +1,40 @@
-import DocusaurusLink from '@docusaurus/Link';
 import type { Props } from '@docusaurus/Link';
 import { clsx } from 'clsx';
 
 import type { PropsWithChildren } from 'react';
 
-export const Link = ({ className, ...props }: PropsWithChildren<Props>) => (
-  <DocusaurusLink className={clsx('utrecht-link', 'utrecht-link--html-a', className)} {...props} />
-);
+/**
+ * Link component with stable trailing slash and target
+ * @private - Only to be used in this file and ButtonLink
+ */
+export const BareLink = ({ children, ...props }: PropsWithChildren<Props>) => {
+  const { to, href, ..._props } = props;
+  let dest = to || href;
+
+  const url = new URL(dest, 'https://nldesignsystem.nl');
+
+  // Internal link
+  if (url.origin === 'https://nldesignsystem.nl') {
+    // add trailing slash
+    url.pathname = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
+
+    // keep internal links relative
+    dest = url.toString().replace('https://nldesignsystem.nl', '');
+  }
+
+  // Exteral link
+  else {
+    _props.target = '_blank';
+    _props.rel = 'noopener noreferrer';
+  }
+
+  return (
+    <a href={dest} {..._props}>
+      {children}
+    </a>
+  );
+};
+
+export const Link = ({ className, ...props }: PropsWithChildren<Props>) => {
+  return <BareLink className={clsx('utrecht-link', 'utrecht-link--html-a', className)} {...props} />;
+};


### PR DESCRIPTION
closes: #3701
closes: #3702

Te testen op de pagins:
* https://documentatie-next-git-feat-replace-docu-e0e5d5-nl-design-system.vercel.app/ (link in de paragraaf onder het kopje `Wie doen er al mee`)
* https://documentatie-git-feat-replace-docusauru-7da8df-nl-design-system.vercel.app/slack (button `Doe mee op slack`) 