### PR TITLE
docs: update developer open hour werkwijze

### DIFF
--- a/.github/ISSUE_TEMPLATE/101-🫶-developer-open-hour.md
+++ b/.github/ISSUE_TEMPLATE/101-🫶-developer-open-hour.md
@@ -28,7 +28,8 @@ Tijdens Developer Open Hour kan iedereen laagdrempelig vragen over development i
 
 - [ ] Community in de gaten voor onderwerpen.
 - [ ] Developer Open Hour is aangekondigd op [Code for NL Slack](http://praatmee.codefor.nl/) in #nl-design-system-developers. Deze word gebruikt als thread.
-- [ ] Host notuleert in samenwerking met een kernteamlid in [het "Developer Open Hour Samenvatting - kladblok" Slack Canvas](https://codefornl.slack.com/docs/T68FXPFQV/F0A7F67EXPY) 1) "samenvatting" en 2) "interne notities".
+- [ ] Host regelt dat een kernteamlid deel kan nemen aan de Developer Open Hour om het gezellig te houden.
+- [ ] Host notuleert in samenwerking met dit kernteamlid in [het "Developer Open Hour Samenvatting - kladblok" Slack Canvas](https://codefornl.slack.com/docs/T68FXPFQV/F0A7F67EXPY) 1) "samenvatting" en 2) "interne notities".
 - [ ] Developer Open Hour huddle heeft plaatsgevonden, in de thread.
 - [ ] TLDR in issue is geupdate met de samenvatting van deze Developer Open Hour. Hier word gebruik gemaakt van de "samenvatting" notulen.
 - [ ] De link naar de samenvatting in de issue is gedeeld met de community in de thread en verzonden naar het #nl-design-system-developers kanaal.


### PR DESCRIPTION
In documentatie repo ipv kernteam repo, met up-to-date isuse template.

Onderdeel van https://github.com/nl-design-system/kernteam/issues/1995