### PR TITLE
docs: cdn gebruiken

### DIFF
--- a/docs/handboek/developer/cdn-migratie.mdx
+++ b/docs/handboek/developer/cdn-migratie.mdx
@@ -15,13 +15,13 @@ import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 </Paragraph>
 
-Vind alle plekken waar de [CDN in je prototype](./cdn.mdx) wordt gebruikt. Een handige manier is om te kijken welke andere servers voorkomen in de Network tab van de Developer Tools, wanneer je het prototype bekijkt in de browser. Je kunt ook in de code zoeken naar de URL van de CDN, wanneer je die weet.
+Zoek alle plekken waar je de [CDN in je prototype](./cdn.mdx) gebruikt. Bekijk hiervoor de Network-tab in de Developer Tools van je browser. Zoek welke andere servers daar voorkomen. Ken je de URL van de CDN? Zoek deze dan direct op in de code.
 
 De aanpassingen van de code van je prototype die nodig zijn, zijn heel erg afhankelijk van welke build tools je gaat gebruiken. De volgende voorbeelden laten zien hoe je naar [Vite](https://vite.dev) kan migreren.
 
 ### Dependencies installeren
 
-Vind alle npm packages die in de code van je prototype worden genoemd om vanaf een CDN te laden. In de Network tab van de Developer Tools staan vaak meer npm pacakges dan nodig zijn voor deze stap, omdat je indirecte dependencies niet zelf moet installeren, dus beperk je tot de npm packages in de code.
+Zoek in de code naar npm-packages die je via een CDN laadt. In de Network-tab staan vaak te veel packages. Dit komt door indirecte dependencies. Die hoef je niet zelf te installeren. Beperk je daarom alleen tot de npm-packages in de code.
 
 Installeer elke npm dependency met `pnpm add`, en noem hetzelfde versienummer als die bekend is. Bijvoorbeeld, wanneer de volgende code in je prototype staat:
 
@@ -63,7 +63,7 @@ De CSS en Web Fonts worden meestal vanaf de CDN ingeladen met een `<link>` eleme
 <link rel="stylesheet" href="https://unpkg.com/@nl-design-system-candidate/button-css@1.1.0/dist/button.css" />
 ```
 
-De CSS wordt in Vite ingeladen vanuit JavaScript in plaats van via HTML, omdat daar de verwijzingen naar npm packages werken:
+Bij Vite wordt de CSS ingeladen vanuit JavaScript in plaats van via HTML:
 
 ```html
 <script>

--- a/docs/handboek/developer/cdn.mdx
+++ b/docs/handboek/developer/cdn.mdx
@@ -43,7 +43,7 @@ Start-thema kun je gebruiken met `<html class="thema-theme">`:
 
 Wanneer een lettertype beschikbaar is op Fontsource, gebruik dan een CDN voor npm packages om het lettertype toe te voegen door te verwijzen naar het CSS-bestand met de `@font-face` code.
 
-Op de "Install" pagina van Fontsource vind je de naam van de CSS package. Klik op de link naar "NPM" om naar de documentatie van de npm package te gaan. Bij de [npm package van Noto Sans](https://www.npmjs.com/package/@fontsource/noto-serif) staat bijvoorbeeld:
+Klik op de link naar "NPM" om naar de documentatie van de npm package te gaan. Bij de [npm package van Noto Sans](https://www.npmjs.com/package/@fontsource/noto-serif) staat bijvoorbeeld:
 
 ```js
 import "@fontsource/noto-serif"; // Defaults to weight 400
@@ -59,7 +59,7 @@ Gebruik deze informatie over de bestandsnamen om een `<link>` element te maken v
 
 ### Lettertypes zonder open source licentie
 
-Sommige organisaties gebruiken een lettertype met betaalde licentie. Dit soort lettertypes zijn vaak niet beschikbaar via een gratis CDN, en mogen vaak niet gebruikt worden voor prototypes met de bestaande licentie. Bekijk de documentatie van die huisstijl voor verdere instructies of contactgegevens voor hulp.
+Sommige organisaties gebruiken een lettertype met een betaalde licentie. Lettertype met een betaalde licentie staan vaak niet op een gratis CDN. Ook mag je ze meestal niet gebruiken voor prototypes.
 
 Gebruik als oplossing een alternatief lettertype voor je prototype. Vaak is er een open source lettertype dat er op lijkt. Stel het open source lettertype in als fallback.
 
@@ -154,7 +154,7 @@ Web Fonts:
 
 Let op dat de versienummers verouderd kunnen zijn, wanneer je later verder werkt aan een prototype.
 
-Upgrade je prototype eerst naar de laatste versies van dependencies, wanneer je gebruik wilt maken van de nieuwste mogelijkheden. Let op dat door breaking changes het prototype kapot kan gaan, wanneer het versienummer voor de punt hoger wordt!
+Upgrade je prototype eerst naar de laatste versies van dependencies, wanneer je gebruik wilt maken van de nieuwste mogelijkheden. Let op dat door [breaking changes](/handboek/developer/changes/) het prototype kapot kan gaan, wanneer het versienummer voor de punt hoger wordt!
 
 ## Migreer van een CDN naar pnpm
 

--- a/static/css-component-prototype.html
+++ b/static/css-component-prototype.html
@@ -24,7 +24,10 @@
     <link rel="stylesheet" href="https://unpkg.com/@utrecht/component-library-css@9/dist/index.css" />
   </head>
   <body>
-    <h1 class="nl-heading nl-heading--level-1">Heading 1</h1>
+    <h1 class="nl-heading nl-heading--level-1">Prototype met CSS componenten</h1>
+    <p class="nl-paragraph">
+      Bekijk de broncode van deze pagina om te zien hoe de componenten en design tokens zijn geladen vanaf een CDN.
+    </p>
     <h2 class="nl-heading nl-heading--level-2">Heading 2</h2>
     <h3 class="nl-heading nl-heading--level-3">Heading 3</h3>
     <h4 class="nl-heading nl-heading--level-4">Heading 4</h4>

--- a/static/html-component-prototype.html
+++ b/static/html-component-prototype.html
@@ -27,8 +27,8 @@
     <link rel="stylesheet" href="https://unpkg.com/@utrecht/component-library-css@9/dist/html.css" />
   </head>
   <body>
-    <h1>Heading 1</h1>
-    <h2>Heading 2</h2>
+    <h1>Prototype met HTML componenten</h1>
+    <p>Bekijk de broncode van deze pagina om te zien hoe de componenten en design tokens zijn geladen vanaf een CDN.</p>
     <h3>Heading 3</h3>
     <h4>Heading 4</h4>
     <h5>Heading 5</h5>


### PR DESCRIPTION
Dit is PR 1 van 2, er is nog meer nodig om aan alle acceptpatiecriteria, maar dit lijkt me een goed begin.

Preview:
- [Content-Delivery Network (CDN) gebruiken](https://documentatie-git-docs-cdn-nl-design-system.vercel.app/handboek/developer/cdn/)
- [Migreer van een CDN naar pnpm](https://documentatie-git-docs-cdn-nl-design-system.vercel.app/handboek/developer/cdn-migratie/)
- [Voorbeeld met CSS componenten en het Voorbeeld-thema](https://documentatie-git-docs-cdn-nl-design-system.vercel.app/css-component-prototype.html)
- [Voorbeeld met HTML componenten en het Voorbeeld-thema](https://documentatie-git-docs-cdn-nl-design-system.vercel.app/html-component-prototype.html)


SonarQube issues met subresource integrity ga ik in de volgende PR fixen: https://github.com/nl-design-system/documentatie/pull/3866