### PR TITLE
docs: verwijder samenvatting taak uit developer open hour

### DIFF
--- a/.github/ISSUE_TEMPLATE/101-🫶-developer-open-hour.md
+++ b/.github/ISSUE_TEMPLATE/101-🫶-developer-open-hour.md
@@ -14,8 +14,6 @@ type: Task
 
 Tijdens Developer Open Hour kan iedereen laagdrempelig vragen over development in de NL Design System community bespreken. Daarnaast proberen de developer relations engineers van het kernteam de community te motiveren vraagstukken te bespreken of presenteren in het Developer Open Hour, om de samenwerking van communities te stimuleren.
 
-{samenvatting}
-
 ## Host vanuit kernteam
 
 <!-- kernteam github user -->
@@ -29,11 +27,7 @@ Tijdens Developer Open Hour kan iedereen laagdrempelig vragen over development i
 - [ ] Community in de gaten voor onderwerpen.
 - [ ] Developer Open Hour is aangekondigd op Slack in `#nl-design-system-developers`. Het aankondigingsbericht word gebruikt als thread.
 - [ ] Host regelt dat een kernteamlid deel kan nemen aan de Developer Open Hour om het gezellig te houden.
-- [ ] Host notuleert in samenwerking met dit kernteamlid in [het "Developer Open Hour Samenvatting - kladblok" Slack Canvas](https://codefornl.slack.com/docs/T68FXPFQV/F0A7F67EXPY) 1) "samenvatting" en 2) "interne notities".
 - [ ] Developer Open Hour huddle heeft plaatsgevonden, in de thread.
-- [ ] TLDR in issue is geupdate met de samenvatting van deze Developer Open Hour. Hier word gebruik gemaakt van de "samenvatting" notulen.
-- [ ] De link naar de samenvatting in de issue is gedeeld met de community in de thread en verzonden naar het #nl-design-system-developers kanaal.
-- [ ] Interne notities, indien aanwezig, worden geplaatst als comment in [Developer Open Hour in 2026](https://github.com/nl-design-system/kernteam/issues/1822). Hier word gebruik gemaakt van de "interne notities" notulen.
 
 ## Acceptatiecriteria
 
@@ -41,6 +35,4 @@ Tijdens Developer Open Hour kan iedereen laagdrempelig vragen over development i
 
 - [ ] Developer Open Hour is vooraf aangekondigd in de community.
 - [ ] Developer Open Hour heeft plaatsgevonden.
-- [ ] Developer Open Hour samenvatting is gedeeld met de community.
-- [ ] Developer Open Hour interne notities indien aanwezig zijn opgeslagen in het verzamel issue.
 - [ ] Vervolg actiepunten zijn uitgevoerd of ingepland.


### PR DESCRIPTION
In afstemming met kernteam.