### PR TITLE
docs: update commmunity theme story template with prod

### DIFF
--- a/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
@@ -249,7 +249,7 @@ import "@example/organisatie-design-tokens/src/font";
 
 ```tsx
 // packages/voorbeeld-design-tokens/documentation/{naam-component}/{prefix-organisatie}-{naam-component}.stories.tsx
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ComponentNaam } from "{react-component-library-package}";
 
 const meta = {


### PR DESCRIPTION
Noticed in production we updated this; using react-vite now.

Preview: https://documentatie-git-docs-update-commmunity-d5ce45-nl-design-system.vercel.app/handboek/estafettemodel/componenten/community/voor-organisaties#component-beschikbaar-voor-visuele-regressietests:~:text=Voeg%20de%20component%20toe%20aan%20de%20story