### PR TITLE
docs: schrijfwijzer voor WCAG-pagina's

### DIFF
--- a/docs/project/schrijfwijzer/afbeeldingen.mdx
+++ b/docs/project/schrijfwijzer/afbeeldingen.mdx
@@ -1,0 +1,55 @@
+---
+title: Afbeeldingen
+hide_title: true
+sidebar_label: Afbeeldingen
+sidebar_position: 7
+pagination_label: Afbeeldingen
+description: Afbeeldingen voor communicatie vanuit het project NL Design System.
+keywords:
+  - kernteam
+---
+
+import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+
+{/* @license CC0-1.0 */}
+
+# Afbeeldingen
+
+## Toestemming voor gebruik
+
+{/* TODO: Herschrijf dit hoofdstukje */}
+
+Gebruik nooit zomaar afbeeldingen van internet. Krijg je een afbeelding aangeleverd? Check dan of je deze mag gebruiken en of bronvermelding nodig is. Maak je zelf foto's op een evenement of bijeenkomst? Vraag dan altijd toestemming aan de aanwezigen of je de foto mag delen.
+
+## Toegankelijkheid
+
+Wanneer afbeeldingen veel tekst erin hebben, beoordeel dan of een rich text alternatief gebruiksvriendelijker en toegankelijker zou zijn.
+
+Een afbeelding heeft een alt-tekst nodig. In de alt-tekst beschrijf je wat er op de afbeelding staat. Houd afbeeldingen daarom zo simpel mogelijk.
+
+## Screenshots
+
+Gebruik PNG voor het opslaan van screenshots, niet een lossy formaat zoals JPEG. Laat het optimaliseren van afbeeldingen over aan de software voor de website. In de toekomst kunnen nieuwe technieken voor optimalisaties gebruikt worden, en dan is het handig dat het bronbestand van hoge kwaliteit nog beschikbaar is.
+
+Zorg voor een rustige layout van de pagina door afbeeldingen en video's te gebruiken met consistente formaten. Gebruik voor screenshots de volgende formaten die relevant zijn voor [WCAG-succescriterium 1.4.10 Reflow](/wcag/1.4.10/), tenzij er een belangrijke reden is om een ander formaat te gebruiken.
+
+- 1280 × 1024 pixels: 100% zoom
+- 320 × 256 pixels: 400% zoom
+- 256 × 320 pixels: 400% zoom, portretmodus
+- 1024 ×1280 pixels: 100% zoom, landschapsmodus
+
+Een handige manier om screenshots in een vast formaat te maken is via de Chrome Developer Tools. Je kunt Devices aanmaken die je "WCAG 100%" en "WCAG 400%" noemt, zodat je makkelijk de website op het juiste formaat kunt instellen. Maak dan een screenshot via de developer tools.
+
+Bekijk een video over hoe dit werkt: [4 ways to capture screenshots in Chrome DevTools](https://youtu.be/tL-R9KzZA0s?t=55)
+
+Zorg dat screenshots er niet onscherp uit zien op high-end beeldschermen. Maak daarom screenshots met een pixel density van tenminste 2 dots per pixel. Gebruik een apparaat met een pixel-density van tenminste 2 dots per pixel, of simuleer een hoge pixel density via de Device instellingen in Developer Tools. Beeldschermen van Apple en high-end mobiele telefoons voldoen hieraan.
+
+### Gedateerde screenshots
+
+Afbeeldingen kunnen na een paar jaar de indruk wekken dat ze gedateerd zijn. De kans bestaat dat door een oude screenshot de hele pagina gedateerd voelt. Afbeeldingen moeten daarom periodiek vernieuwd worden. Maak de afweging of hebben van de afbeelding opweegt tegen het onderhoud dat er voor nodig is.
+
+Een screenshot zonder de user interface van de browser of het besturingssysteem zal minder snel gedateerd zijn. Maak een screenshots van websites daarom alleen van de website zelf, via de Developer Tools.
+
+## Vector-afbeeldingen
+
+SVG afbeeldingen zijn soms beter! Gebruik `fill="currentColor"` in plaats van vaste kleuren, zodat de illustratie zich aanpast in dark mode en in forced colors mode. Gebruik `<svg>` in de HTML van de pagina, gebruik niet `<img src="image.svg">`

--- a/docs/project/schrijfwijzer/beslissingen.mdx
+++ b/docs/project/schrijfwijzer/beslissingen.mdx
@@ -2,8 +2,8 @@
 title: Beslissingen voor schrijfwijze
 hide_title: true
 sidebar_label: Beslissingen voor schrijfwijze
-sidebar_position: 7
-navigation_order: 7
+sidebar_position: 8
+navigation_order: 8
 pagination_label: Beslissingen voor schrijfwijze
 description: Beslissingen voor de schrijfwijze binnen het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/index.mdx
+++ b/docs/project/schrijfwijzer/index.mdx
@@ -35,7 +35,7 @@ Maak het makkelijk voor mensen om de actie te onthouden, want dat is belangrijke
 
 ### Wees precies
 
-Zeg precies wat je bedoelt. Veel mensen schrijven graag teksten met understatement, eufemisme, ironie, sarcasme, beeldspraak, uitdrukkingen en spreekwoorden. Dat is prima in chatgesprekken, maar doe dit niet in de documentatie.
+Zeg precies wat je bedoelt. Veel mensen schrijven graag teksten met understatement, eufemisme, ironie, sarcasme, beeldspraak, [ideomatische uitdrukkingen](https://www.w3.org/Translations/WCAG22-nl/#dfn-idioms) en spreekwoorden. Dat is prima in chatgesprekken, maar doe dit niet in de documentatie.
 
 ### Duidelijke taal
 
@@ -68,6 +68,7 @@ Kies voor een vriendelijke toon en wees niet belerend. We willen mensen motivere
 - Schrijf actief en vermijd de lijdende vorm. Actief is bijvoorbeeld: ‘we kunnen snel schakelen’. Lijdend is bijvoorbeeld: ‘er kan snel geschakeld worden’
 - Vermijd tekst tussen haakjes. Gebruik gewoon een nieuwe zin.
 - Vermijd bijzinnen zoveel mogelijk.
+- Vermijd archaïsche woorden en zinsbouw.
 - Begin liever een tweede zin dan onnodig een komma gebruiken.
 
 ### Afkortingen
@@ -79,7 +80,7 @@ Voorleessoftware en vertaalsoftware werken beter als tekst voluit is geschreven.
 
 Ga er vanuit dat lezers niet bekend zijn met de namen en afkortingen van overheidsorganisaties:
 
-- Schrijf namen van organisaties de eerste keer voluit. Denk aan Kamer van Koophandel (KVK) of Rijksdienst voor Ondernemend Nederland (RVO). Niet iedereen kent alle bedrijfsafkortingen.
+- Schrijf namen van organisaties de eerste keer voluit. Bijvoorbeeld: Kamer van Koophandel (KVK) of Rijksdienst voor Ondernemend Nederland (RVO). Niet iedereen kent alle bedrijfsafkortingen.
 
 ### Vraagvorm
 
@@ -121,29 +122,11 @@ Lees meer in de [richtlijnen voor toegankelijke linkteksten](/richtlijnen/conten
 
 ## Afbeeldingen \{#afbeeldingen\}
 
-{/* TODO: Herschrijf dit hoofdstukje */}
-
-- Gebruik nooit zomaar afbeeldingen van internet. Krijg je een afbeelding aangeleverd? Check dan of je deze mag gebruiken en of bronvermelding nodig is. Maak je zelf foto's op een evenement of bijeenkomst? Vraag dan altijd toestemming aan de aanwezigen of je de foto mag delen.
-- Gebruik ook geen afbeeldingen met veel tekst erin.
-- Een afbeelding heeft een alt-tekst nodig. In de alt-tekst beschrijf je wat er op de afbeelding staat. Houd afbeeldingen daarom zo simpel mogelijk.
+[Lees meer over werken met afbeeldingen](./afbeeldingen.mdx).
 
 ## Video \{#video\}
 
-We delen vaak opnames van [bijeenkomsten in de community](/community/events/overzicht/), zodat iedereen op een eigen moment de presentatie kan bekijken. Gebruik hiervoor de YouTube Video component die geen cookies van derden plaatst.
-
-Soms plaatsen we een schermopname in de documentatie, bijvoorbeeld om te laten zien hoe een component of patroon werkt. Overleg met de productmanager voordat je een video publiceert, omdat een video voor documentatie relatief veel werk is om up-to-date te houden.
-
-### Ondertitels
-
-Maak altijd ondertitels voor video's die op de website worden gedeeld. Overleg met de projectmanager of de productmanager voordat je video's publiceert, om zeker te weten dat er capaciteit is om ook ondertitels te maken.
-
-Voor video's die het kernteam publiceert is een afspraak met een vaste organisatie die de onderitels toevoegt aan YouTube video's. Aan de opnames van de Heartbeat en de Design Systems Week worden de onderitels automatisch toegevoegd, op initiatief van de ondertitelaar.
-
-Voeg ondertitels toe via een bestandformaat voor ondertitels. Gebruik nooit video's met hardcoded ondertitels.
-
-### Link naar video
-
-Deel video's door een link te maken naar de webpagina op onze website waar de video staat, in plaats de link naar YouTube delen. Op deze manier blijven de links werken, als we in de toekomst een andere platform gebruiken voor video.
+[Lees meer over werken met video](./video.mdx).
 
 ## Meer tips
 

--- a/docs/project/schrijfwijzer/pagina-opbouw.mdx
+++ b/docs/project/schrijfwijzer/pagina-opbouw.mdx
@@ -29,6 +29,8 @@ import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 Begin elke pagina met een introductie-alinea met een aantrekkelijke tekst die concreet zegt waar de pagina over gaat. Deel gelijk de essentie, maak er geen teaser van.
 
+Een introductie-alinea moet geen links bevatten.
+
 {/* TODO: Wanneer is een tekst aantrekkelijk genoeg voor een Lead Paragraph? */}
 
 ## Gebruik tussenkoppen
@@ -38,6 +40,10 @@ Begin elke pagina met een introductie-alinea met een aantrekkelijke tekst die co
 - Gebruik tussenkopjes met het juiste kopniveau.
 
 Lees meer in de [richtlijnen over koppen](/richtlijnen/content/tekstopmaak/koppen/).
+
+## Tekst na een kop
+
+Zorg dat de betekenis van de tekst na een tussenkop niet afhankelijk is van inhoud van de kop. Bijvoorbeeld niet een kop "Onvoldoende contrast" en de tekst "Dit is een van de meestvoorkomende problemen". Maak een tekst die duidelijk is zonder kop, zonder de kop letterlijk te herhalen. Bijvoorbeeld, wel: "De meeste websites gebruiken een te laag contrast voor sommige onderdelen."
 
 ## URL
 

--- a/docs/project/schrijfwijzer/reviews.mdx
+++ b/docs/project/schrijfwijzer/reviews.mdx
@@ -2,8 +2,8 @@
 title: Reviews
 hide_title: true
 sidebar_label: Reviews
-sidebar_position: 8
-navigation_order: 8
+sidebar_position: 9
+navigation_order: 9
 pagination_label: Reviews
 description: Reviews voor NL Design System communicatie.
 keywords:

--- a/docs/project/schrijfwijzer/video.mdx
+++ b/docs/project/schrijfwijzer/video.mdx
@@ -1,0 +1,34 @@
+---
+title: Video
+hide_title: true
+sidebar_label: Video
+sidebar_position: 7
+pagination_label: Video
+description: Video's in communicatie vanuit het project NL Design System.
+keywords:
+  - kernteam
+---
+
+import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+
+{/* @license CC0-1.0 */}
+
+# Video
+
+We delen vaak opnames van [bijeenkomsten in de community](/community/events/overzicht/), zodat iedereen op een eigen moment de presentatie kan bekijken.
+
+Soms plaatsen we een schermopname in de documentatie, bijvoorbeeld om te laten zien hoe een component of patroon werkt. Overleg met de productmanager voordat je een video publiceert, omdat een video voor documentatie relatief veel werk is om up-to-date te houden.
+
+## Ondertitels
+
+Maak altijd ondertitels voor video's die op de website worden gedeeld. Overleg met de projectmanager of de productmanager voordat je video's publiceert, om zeker te weten dat er capaciteit is om ook ondertitels te maken.
+
+Voor video's die het kernteam publiceert is een afspraak met een vaste organisatie die de onderitels toevoegt aan YouTube video's. Aan de opnames van de Heartbeat en de Design Systems Week worden de ondertitels automatisch toegevoegd, op initiatief van de ondertitelaar.
+
+Voeg ondertitels toe via een bestandformaat voor ondertitels. Gebruik nooit video's met hardcoded ondertitels.
+
+Lees meer WebVTT-bestanden gebruiken voor ondertitels op het web: [Improving Video Accessibility with WebVTT — CSS-tricks](https://css-tricks.com/improving-video-accessibility-with-webvtt/)
+
+## Link naar video
+
+Deel video's door een link te maken naar de webpagina op onze website waar de video staat, in plaats de link naar YouTube delen. Op deze manier blijven de links werken, als we in de toekomst een ander platform gebruiken voor video. Het is ook beter voor privacy: op onze eigen site kunnen we de YouTube Video instellen om geen cookies van derden te gebruiken.

--- a/docs/project/schrijfwijzer/wcag.mdx
+++ b/docs/project/schrijfwijzer/wcag.mdx
@@ -1,0 +1,256 @@
+---
+title: Aanpak voor WCAG-pagina's
+hide_title: true
+sidebar_label: WCAG-pagina's
+sidebar_position: 2
+pagination_label: WCAG-pagina's
+description: Aanpak voor WCAG-pagina's op de NL Design System website.
+keywords:
+  - kernteam
+---
+
+import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+
+{/* @license CC0-1.0 */}
+
+# Aanpak voor WCAG-pagina's
+
+{/* Er is een GitHub Project board om bij of de WCAG-pagina's al voldoen aan de schrijfwijzer: */}
+{/* https://github.com/orgs/nl-design-system/projects/95 */}
+
+<Paragraph lead>
+  De WCAG-pagina's zijn een praktische aanvulling op de abstracte teksten in de officiële specificatie. Mensen die voor
+  het eerst een toegankelijke website maken leren waar ze op moeten letten. De WCAG-pagina's zijn ook een startpunt voor
+  NL Design System oplossingen voor problemen die zijn gevonden bij een toegankelijkheidsonderzoek.
+</Paragraph>
+
+De hoofdstructuur van de pagina moet begrijpelijk zijn voor een breed publiek. De introductie, de koppenstructuur en eerste zin na koppen zijn daarom minder technisch. Via de hoofdstructuur moet het voor iedereen mogelijk zijn om relevante informatie te vinden. Daarmee kan iedereen oplossingen doorsturen naar een collega of een klant.
+
+Developers, designers en contentmakers willen concrete oplossingen vinden. Bijvoorbeeld nadat ze een toegankelijkheidsonderzoek hebben gelezen, of juist voordat ze aan de slag gaan met een nieuw project. Ga er vanuit dat de lezer samenwerkt met mensen die toegankelijke websites maken, maar dat niet elke lezer voorkennis heeft van toegankelijkheid, hulpmiddelen voor toegankelijkheid of web development.
+
+De WCAG-pagina's zijn geen vervanging voor WCAG. Het is een manier om kennis te maken met WCAG en oplossingen te vinden er om er aan te voldoen. De pagina's geven daarom algemene uitleg en staan verder vol met links naar de componenten, richtlijnen, patronen, templates en hulpmiddelen van NL Design System.
+
+## Schrijfwijze van WCAG-pagina's
+
+### Herkenbaar
+
+Noem eerst voorbeelden en situaties die het meest waarschijnlijk zijn dat de lezer ze herkent. Situaties de vaak voorkomen of heel concrete voorbeelden zijn het meest herkenbaar.
+
+Wel:
+
+> Zorg ervoor dat een bezoeker het scherm niet fysiek hoeft te draaien om een webpagina goed te kunnen gebruiken.
+
+Deze beschrijving is heel herkenbaar, want de meeste mensen draaien een smartphone afhankelijk van de situatie, of kennen mensen die dat doen.
+
+Niet:
+
+> Een website is staand en liggend gelijkwaardig.
+
+"Gelijkwaardig" is een asbtract woord, in plaats van een concrete situatie. "Staand" en "liggend" is jargon, en mogelijk verwarrend in plaats van herkenbaar.
+
+### Relevant
+
+Bedenk of onderzoek welke situaties heel relevant zijn voor een zo breed mogelijke doelgroep, zodat zowel developers, designers als contentmakers goed kunnen inschatten of het WCAG-succescriterium voor hen relevant is.
+
+Wel: noem de situaties die verreweg het meest voorkomen in toegankelijkheidsrapporten.
+
+> 1.1.1 Niet-tekstuele content:
+> [Noem afbeeldingen met een tekstbeschrijving, iconen die extra betekenis geven.]
+
+Niet: heel abstract beschrijven dat het over afbeeldingen gaat, en wel CAPTCHA's als uitzondering noemen.
+
+> 1.1.1 Niet-tekstuele content:
+>
+> Alle niet-tekstuele content die aan de gebruiker wordt gepresenteerd, heeft een tekstalternatief dat een gelijkwaardig doel dient.
+> Uitzonderingen zijn bedieningselementen en invoer met een toegankelijke naam, op tijd gebaseerde media, een test of oefening, content bedoeld om een specifieke zintuiglijke ervaring te creëren, CAPTCHA's en niet-tekstuele content bedoeld voor decoratie.
+
+### Uitzonderingen niet te prominent
+
+Begin niet met uitzonderingen en uitzonderlijke situaties, die belangrijk voelen omdat WCAG ze noemt. Als ze in de praktijk niet gelijk voor verwarring zorgen, dan kun je de uitzonderingen verderop bespreken. Of je kunt expliciet noemen dat het belangrijk is om de de WCAG specificatie te lezen voor details en uitzonderingen.
+
+### Niet abstract
+
+Vermijd abstracte beschrijvingen, want daarvoor is WCAG zelf al bedoeld. We verwijzen op elke pagina door naar de WCAG specificatie, voor de precieze details.
+
+### Scanbare tekst
+
+Begin elke alinea met de kern van het verhaal, en ga daarna verder in op details. Zo houd je de aandacht vast, en kunnen lezers het voor hun relevante tekstonderdeel vinden.
+
+### Begrijpelijk
+
+De tekst moet begrijpelijk zijn voor lezers die geen voorkennis hebben van WCAG, maar die wel gewend zijn aan websites te werken.
+
+### Testbaar
+
+Vraag niet om iets te testen, zonder informatie hoe. Bijvoorbeeld niet alleen: "Controleer de HTML-structuur" of "test met CSS uitgeschakeld". Maak duidelijk hoe je de beoordeling kan doen, bijvoorbeeld met een link naar een externe website.
+
+### Geen voorkennis
+
+Wees concreet, en ga niet uit van voorkennis. Bijvoorbeeld niet: "denk aan componenten zoals Link en Button" of "denk aan screenreadergebruikers", omdat de betekenis verschilt van persoon tot persoon.
+
+### Geen onduidelijkheid
+
+Gebruik geen twijfelwoorden, waarmee je voorkomt dat de lezer actie onderneemt. Bijvoorbeeld: “meestal”, “vaak” of “soms”. Het is belangrijk om concreet uit te leggen wat de uitzonderingen zijn, die worden bedoeld.
+
+### Geen frustratie
+
+Laat in de documentatie geen frustratie blijken over problemen die vaak voorkomen. Of dat hoe makkelijk de oplossing is, niet in verhouding staat tot de impact op gebruikers. Of dat designers, developers en product owners soms hun eigen belang meer prioriteit geven dan toegankelijkheid.
+
+### Jargon
+
+Vermijd jargon in de koppen, de introductiealinea en het begin van teksten. Gebruik in eerste instantie termen die duidelijk zijn voor een breed publiek. Maak het op deze manier mogelijk de betekenis van jargon af te leiden uit de context.
+
+Deze aanpak helpt ook bij voldoen aan [WCAG-succescriterium 3.1.3 Ongebruikelijke woorden](/wcag/3.1.3/). Dit WCAG-succescriterium is niet verplicht voor de [NL Design System Baseline](/baseline/), maar is zeker de moeite waard in de WCAG-pagina's.
+
+Voorbeelden van jargon, en mogelijke alternatieven:
+
+- "navigeren" betekent voor een breed publiek iets voor een reis op zee, maar als jargon staat het voor toetsenbordnavigatie of browsen naar een andere pagina. Een betere algemene term is: "toetsenbordbediening".
+- "tabben" is niet een algemeen bekende term. Het is duidelijker om te zeggen: "Ga met de `Tab`-toets naar ...".
+
+Wanneer developers en designers een bepaald jargon gewend zijn, gebruik liever dat jargon dan de doelgroep van specialisten afschrikken met een zeer ongebruikelijk term. Als het niet mogelijk is om de betekenis af te leiden uit de context, bied dan een link aan waar het jargon wordt uitgelegd. Bijvoorbeeld: gebruik "screenreader" in plaats van "schermvoorlezer", maar leg de term wel uit met een link.
+
+## Oplossingen in NL Design System
+
+### Consistent met het design system
+
+Gebruik de namen van [componenten uit het design system](/componenten/), en gebruik dezelfde termen voor concepten zoals [states](/handboek/developer/conventies/states/), varianten en anatomie. Schrijf namen van componenten met een hoofdletter. Bijvoorbeeld: Accordion, Button. Lezers kunnen met consistente termen makkelijker oplossingen vinden in het design system.
+
+{/* TODO: Gebruik de documentatie voor algemene API conventies, wanneer de naamgeving nog niet bepaald is voor een component. */}
+{/* https://github.com/nl-design-system/documentatie/issues/1078 */}
+
+De meeste namen zijn gekozen in samenwerking met de [NL Design System Community](/community/), als een stap in het [Estafettemodel](/handboek/estafettemodel/).
+
+### Links naar componenten
+
+Link naar componenten van NL Design System die je kunt gebruiken als oplossing voor een ontoegankelijke situatie. Bijvoorbeeld:
+
+- [WCAG-succescriterium 2.4.1 Blokken omzeilen](/wcag/2.4.1/) heeft een link naar de [Skip Link](/skip-link/) component.
+- [WCAG-succescriterium 1.3.2 Betekenisvolle volgorde](/wcag/1.3.2/) heeft een link naar de [Heading Group](/heading-group/) component.
+
+### Links naar richtlijnen
+
+Maak een link naar richtlijnen van NL Design System die relevant zijn om de website goed krijgen voor het WCAG succescriterium. Bijvoorbeeld:
+
+- [WCAG-succescriterium 1.3.1 Info en relaties](/wcag/1.3.1/) heeft een link naar de [contentrichtlijnen voor een opsomming zonder de juiste opmaak](/richtlijnen/content/tekstopmaak/opsommingen/#lijst-elementen)
+
+### Integratie met het design system ecosysteem
+
+Componenten gebruiken is niet altijd de beste oplossing, vaak gaat het om een kleine aanpassing van het visueel ontwerp of een aanpassing van de paginastructuur.
+
+Link naar andere oplossingen die NL Design System heeft om te voldoen aan dit WCAG succescriterium. Bijvoorbeeld:
+
+- [WCAG-succescriterium 1.4.3 Contrast (minimum)](/wcag/1.4.3/) en [WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11/) hebben een link naar het [hulpmiddel voor Contrast van kleuren](/contrast/).
+- [WCAG-succescriterium 2.4.1 Blokken omzeilen](/wcag/2.4.1/) heeft een link naar een template met de Skip Link en Cookie Banner.
+- De [NL Design System Baseline](/baseline/) heeft een overzicht van browsers en hulpmiddelen waarmee je kunt testen.
+
+### Voldoet aan het design system
+
+Stel oplossingen voor die voldoen aan het design system. Geef geen advies dat niet klopt met de richtlijnen.
+
+Wanneer een codevoorbeeld tot de essentie teruggebracht is voor de duidelijkheid, dan kan het zijn dat het niet voldoet aan het design system. Noem dat dan expliciet, en verwijs door naar een andere pagina in het design system. De volledige oplossing staat dan bijvoorbeeld in een component, richtlijn of template.
+
+## Opbouw van een WCAG-pagina
+
+Een WCAG-pagina is compleet wanneer het de volgende onderdelen bevat, en er geen belangrijke informatie mist in één van de onderdelen:
+
+- Metadata, in Markdown frontmatter
+- Paginatitel
+- Uitleg
+  - Lead Paragraph
+  - Gedetailleerd vervolg op introductietekst
+- Veelgemaakte fouten
+- Hoe te testen
+- Relevante links
+- W3C referenties
+- Help deze richtlijn verbeteren
+
+### Introductie-alinea
+
+In aanvulling op de [algemene schrijfwijzer voor een introductie-alinea](./pagina-opbouw.mdx#introductie-alinea), is er een specifieke aanpak voor de introductie-alinea van WCAG-pagina's.
+
+#### Positief beginnen
+
+Begin op een positieve noot. Beschrijf hoe succes er uit ziet. Niet alleen voor een specifieke beperking of hulpmiddel, maar ook in het algemeen.
+
+Bijvoorbeeld niet:
+
+> Developers maken vaak geen gebruik van standaard HTML-elementen, en daardoor zijn websites vaak niet toegankelijkheid met een toetsenbord.
+
+#### Nog niet technisch
+
+Gebruik geen termen die alleen developers en designers kennen, omdat de introductie-alinea voor een brede doelgroep is. Optimaliseer voor het F-patroon, waarbij mensen koppen en het begin van teksten als eerste scannen.
+
+#### Ook duidelijk zonder context
+
+Zorg dat de introductie-alinea helemaal op zichzelf duidelijk is. De tekst moet onafhankelijk zijn van de hoofdkop — maak ook geen verwijzingen naar de hoofdkop. Eindig niet met een cliffhanger.
+
+### Veelgemaakte fouten
+
+1. Het doel van het patroon, de gewenste situatie.
+1. Een beschrijving van wanneer de situatie onvoldoende toegankelijk is. Wees duidelijk dat dan de implementatie fout is, en niet het patroon, wanneer een toegankelijke implementatie in principe wel mogelijk is.
+1. Een beschrijving hoe je dat kan testen.
+1. Informatie over de beste oplossing, waar mogelijk met links naar bestaande informatie in het design system.
+1. Door wie het kan worden opgelost.
+1. Indien er nog geen component of richtlijn is met een oplossing: een voldoende uitgebreide beschrijving van de oplossing. Deze tekst kan later verhuisd kan worden naar een specifieke pagina.
+
+#### Koppen: niet technisch waar mogelijk
+
+Vermijd technische termen in een kop, als je het anders kunt oplossen. Vermijd bijvoorbeeld volgende termen in een kop.
+
+- "DOM-volgorde"
+- "DOM-structuur"
+- Namen van CSS properties
+- Namen van APIs
+
+Vaak is een goed alternatief voor technische termen gebruiken, om de user experience te beschrijven.
+
+### Hoe te testen
+
+Wanneer mensen begrijpen waar het WCAG succescriterium over gaat, en ze herkennen dat het relevant is voor hun website, dan willen dat waar mogelijk ze kunnen controleren of hun website goed werkt.
+
+Wanneer voorkennis nodig is om te testen, maak dan duidelijk wie dit het best kan doen. Bijvoorbeeld: "Met een screenreader", "Met Developer Tools", "Met een browser". Wanneer iemand een project wil testen, dan kunnen ze hiermee de mensen vinden met de juiste vaardigheden.
+
+### Relevante links
+
+Plaats uitleg bij elke link, zodat de relevantie van de link beoordelen niet onnodig tijd kost van de bezoeker. Maak duidelijk wie de doelgroep is, en in welke situatie de bezoeker verder zou moeten lezen op deze externe website.
+
+#### Verdiepende informatie
+
+De uitleg bij een link naar kan bijvoorbeeld verwoord worden als call to action: "Lees meer op de website van Apple om te leren hoe je met de screenreader VoiceOver alle Links en Headings op een pagina kan vinden."
+
+#### Commerciële oplossingen
+
+Voor toegankelijkheid bestaan vaak concurrerende commerciële oplossingen. Vermijd verwijzingen naar commerciële organisaties, dat is de meest praktische oplossing om discussies te vermijden. Blogs van toegankelijkheidsspecialisten zijn onvermijdelijk, maar verwijs naar gevariëerde websites.
+
+## Technisch advies
+
+Voorkom dat mensen websites die prima werken, ten onrechte gaan aanpassen, doordat richtlijnen stellig bepaalde technieken afraden. Het is goed om aandacht te geven aan technieken die een risico voor toegankelijkheid zijn. Maar geef altijd voldoende informatie om zelf te testen of een situatie onvoldoende toegankelijk is.
+
+## Markdown snippets
+
+De documentatie gebruikt op veel plekken Markdown snippets, voor herbruikbare teksten. Markdown snippets herken je aan de underscore voor de bestandsnaam: `_snippet.md`.
+
+Zorg dat de informatie in snippets niet alleen duidelijk is in de context van de pagina waar jij de snippet voor gebruikt. Controleer ook dat de betekenis van andere pagina’s niet per ongeluk verandert.
+
+## Test met gebruikers
+
+Test de documentatie met gebruikers, wanneer je de mogelijkheid hebt. Wanneer de pagina voldoet aan de schrijfwijzer, is het een goed moment om te controleren of alle aannames kloppen.
+
+Voorbeelden van onderzoeksvragen:
+
+- Kan de betekenis van jargon uit de context afgeleid worden?
+- Wordt het gebruikte jargon inderdaad door specialisten, of blijkt dat het jargon alleen bekend is bij een kleinere groep?
+- Vinden mensen de koppenstructuur handig?
+- Welke onderdelen van de pagina vinden mensen het meest relevant voor zichzelf?
+- Welke onderdelen van de pagina vinden mensen niet relevant voor zichzelf?
+- Begrijpen mensen wat ze kunnen doen voor dit WCAG-succescriterium?
+- Kunnen mensen de WCAG-pagina uitleggen aan iemand anders?
+- Vinden mensen de voorbeelden herkenbaar en relevant?
+- Kunnen mensen het probleem uit hun WCAG-EM onderzoekrapport herkennen in deze pagina?
+- Kunnen mensen een oplossing vinden in NL Design System, voor situaties die ze herkennen in hun eigen website?
+
+Buiten scope:
+
+- Begrijpen mensen het WCAG-succescriterium? Hiervoor moeten mensen de WCAG-specificatie zelf lezen.
+
+Lees meer over [onderzoeken doen op gebruikersonderzoeken.nl](https://gebruikersonderzoeken.nl/docs/onderzoek-doen/).


### PR DESCRIPTION
Preview van de belangrijkste pagina: [Aanpak voor WCAG-pagina's](https://documentatie-git-docs-wcag-schrijfwijzer-nl-design-system.vercel.app/project/schrijfwijzer/wcag/)