### PR TITLE
fix: broken links

### DIFF
--- a/docs/handboek/developer/01-index.mdx
+++ b/docs/handboek/developer/01-index.mdx
@@ -20,9 +20,9 @@ import { Card } from "@utrecht/card-react/css";
 
 ## Community
 
-Er zijn al veel developers die gebruik maken van NL Design System en actief bijdragen in de community. Dit gebeurt op [Slack](../../project//slack.mdx), in de [Developer Open Hour](../../community/events/developer-open-hour/developer-open-hour.mdx), in de [Rijkshuisstijl Community](../../community/community-sprints/rijkshuisstijl-community/rijkshuisstijl-community.mdx) en op [GitHub](./06-infrastructuur/02-github.md).
+Er zijn al veel developers die gebruik maken van NL Design System en actief bijdragen in de community. Dit gebeurt op [Slack](/slack/), in de [Developer Open Hour](/events/developer-open-hour/), in de [Rijkshuisstijl Community](/community/community-sprints/rijkshuisstijl-community/) en op [GitHub](/handboek/developer/introductie/).
 
-De leukste updates worden ook gedeeld in de tweewekelijkse [Heartbeat](../../community/events/heartbeat/heartbeat.mdx) die je zelfs vanaf 2022 terug kunt kijken.
+De leukste updates worden ook gedeeld in de tweewekelijkse [Heartbeat](/events/heartbeat/) die je zelfs vanaf 2022 terug kunt kijken.
 
 ## Aan de slag
 

--- a/docs/handboek/developer/02-aan-de-slag/01-prototypes/02-cdn.mdx
+++ b/docs/handboek/developer/02-aan-de-slag/01-prototypes/02-cdn.mdx
@@ -160,4 +160,4 @@ Upgrade je prototype eerst naar de laatste versies van dependencies, wanneer je 
 
 ## Migreer van een CDN naar pnpm
 
-De dependencies op de aanbevolen manier installeren via pnpm is één van de eerste stappen wanneer je het prototype gaat doorontwikkelen voor productie. Lees verder hoe van een [CDN naar naar pnpm migreren](./cdn-migratie.mdx) werkt.
+De dependencies op de aanbevolen manier installeren via pnpm is één van de eerste stappen wanneer je het prototype gaat doorontwikkelen voor productie. Lees verder hoe van een [CDN naar naar pnpm migreren](/handboek/developer/cdn-migratie/) werkt.

--- a/docs/handboek/developer/02-aan-de-slag/01-prototypes/03-cdn-migratie.mdx
+++ b/docs/handboek/developer/02-aan-de-slag/01-prototypes/03-cdn-migratie.mdx
@@ -17,7 +17,7 @@ import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 </Paragraph>
 
-Zoek alle plekken waar je de [CDN in je prototype](./cdn.mdx) gebruikt. Bekijk hiervoor de Network-tab in de Developer Tools van je browser. Zoek welke andere servers daar voorkomen. Ken je de URL van de CDN? Zoek deze dan direct op in de code.
+Zoek alle plekken waar je de [CDN in je prototype](/handboek/developer/cdn/) gebruikt. Bekijk hiervoor de Network-tab in de Developer Tools van je browser. Zoek welke andere servers daar voorkomen. Ken je de URL van de CDN? Zoek deze dan direct op in de code.
 
 De aanpassingen van de code van je prototype die nodig zijn, zijn heel erg afhankelijk van welke build tools je gaat gebruiken. De volgende voorbeelden laten zien hoe je naar [Vite](https://vite.dev) kan migreren.
 

--- a/docs/handboek/developer/03-conventies/06-versionering/12-changesets.md
+++ b/docs/handboek/developer/03-conventies/06-versionering/12-changesets.md
@@ -54,7 +54,7 @@ Gebruik de volgende richtlijnen bij het kiezen van een versie:
 - **`minor`** → Voor nieuwe functionaliteiten.
 - **`major`** → Voor breaking changes.
 
-Voor meer informatie over het kiezen van de juiste versie, zie [SemVer: Major, Minor of Patch?](./12-changes.md).
+Voor meer informatie over het kiezen van de juiste versie, zie [Semantic Versioning](/handboek/developer/semver-conventie/).
 
 ## Schrijf een changelog
 


### PR DESCRIPTION
Broken links die ik tegenkwam in warnings en fix terwijl ik wacht op een andere build, ie:

```
[WARNING] Markdown link with URL `./cdn-migratie.mdx` in source file "docs/handboek/developer/02-aan-de-slag/01-prototypes/02-cdn.mdx" (163:177) couldn't be resolved. 
[WARNING] Markdown link with URL `./cdn.mdx` in source file "docs/handboek/developer/02-aan-de-slag/01-prototypes/03-cdn-migratie.mdx" (20:30) couldn't be resolved. 
[WARNING] Markdown link with URL `./12-changes.md` in source file "docs/handboek/developer/03-conventies/06-versionering/12-changesets.md" (57:64) couldn't be resolved. 
[WARNING] Markdown link with URL `../../project//slack.mdx` in source file "docs/handboek/developer/01-index.mdx" (23:119) couldn't be resolved. 
[WARNING] Markdown link with URL `./06-infrastructuur/02-github.md` in source file "docs/handboek/developer/01-index.mdx" (23:379) couldn't be resolved.
```

Fixes gedaan op:
- https://nldesignsystem.nl/handboek/developer/introductie/ -> https://documentatie-git-fix-broken-links-nl-design-system.vercel.app/handboek/developer/introductie/
- https://nldesignsystem.nl/handboek/developer/cdn/ -> https://documentatie-git-fix-broken-links-nl-design-system.vercel.app/handboek/developer/cdn/ 
- https://nldesignsystem.nl/handboek/developer/cdn-migratie/ -> https://documentatie-git-fix-broken-links-nl-design-system.vercel.app/handboek/developer/cdn-migratie/
- https://nldesignsystem.nl/handboek/developer/changeset-conventie/ -> https://documentatie-git-fix-broken-links-nl-design-system.vercel.app/handboek/developer/changeset-conventie/