### PR TITLE
fix: link to github

### DIFF
--- a/docs/handboek/developer/01-index.mdx
+++ b/docs/handboek/developer/01-index.mdx
@@ -20,7 +20,7 @@ import { Card } from "@utrecht/card-react/css";
 
 ## Community
 
-Er zijn al veel developers die gebruik maken van NL Design System en actief bijdragen in de community. Dit gebeurt op [Slack](/slack/), in de [Developer Open Hour](/events/developer-open-hour/), in de [Rijkshuisstijl Community](/community/community-sprints/rijkshuisstijl-community/) en op [GitHub](/handboek/developer/introductie/).
+Er zijn al veel developers die gebruik maken van NL Design System en actief bijdragen in de community. Dit gebeurt op [Slack](/slack/), in de [Developer Open Hour](/events/developer-open-hour/), in de [Rijkshuisstijl Community](/community/community-sprints/rijkshuisstijl-community/) en op [GitHub](/github/).
 
 De leukste updates worden ook gedeeld in de tweewekelijkse [Heartbeat](/events/heartbeat/) die je zelfs vanaf 2022 terug kunt kijken.
 


### PR DESCRIPTION
Ik kreeg een DM dat de link op de introductiepagina naar dezelfde pagina ging 🙈 hierbij de fix