### PR TITLE
ci: opt in to pnpm v11 for pnpm audit with an environment variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,9 +28,16 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm audit --audit-level critical --ignore-registry-errors
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -77,9 +84,16 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm audit --audit-level critical --ignore-registry-errors
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -113,9 +127,16 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm audit --audit-level critical --ignore-registry-errors
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,16 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm audit --audit-level critical --ignore-registry-errors
+          pnpm audit --audit-level critical
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/handboek/developer/05-infrastructuur/07-pnpm-audit.md
+++ b/docs/handboek/developer/05-infrastructuur/07-pnpm-audit.md
@@ -26,6 +26,15 @@ Om te voorkomen dat hackers controle kunnen krijgen over de software releases va
 
 Op deze manier stopt de GitHub Action wanneer in de dependencies een npm package is gevonden, waarvan inmiddels bekend is dat het onveilig kan zijn.
 
+:::info[Goed om te weten]
+Op dit moment (april 2026) zijn er problemen met `pnpm audit`; om precies te zijn, het onderliggende npm audit endpoint kan een foutmelding teruggeven ("This endpoint is being retired").
+Het is onduidelijk hoe lang dit gaat spelen.
+Deze melding krijg je bij gebruik van pnpm v10.
+Mocht het voorkomen, dan kun je in de audit stap gebruik maken van pnpm v11.
+Hiervoor moet in GitHub de `ENABLE_PNPM_AUDIT_V11` op `1` worden gezet.
+Een beheerder kan dit op repository- of organisatieniveau voor je instellen.
+:::
+
 ## Snel ingrijpen
 
 Wanneer een security vulnerability bekend wordt, zoals [SHA1-Hulud](https://snyk.io/blog/sha1-hulud-npm-supply-chain-incident/), wil je snel kunnen ingrijpen en voorkomen dat de kwaadaardige npm package wordt geïnstalleerd op een plek waar gevoelige "environment secrets" uit kunnen lekken.


### PR DESCRIPTION
This PR updates the pnpm audit command to use the v11 version of the command, and adds guidance to the website.

It only affects the pnpm audit command, and does not affect the other pnpm commands like pnpm install.
You have to opt in to this by setting the `ENABLE_PNPM_AUDIT_V11` environment variable to `1`.
You can choose to do this on the repository level or on the organization level.

See https://github.com/nl-design-system/beheer/issues/70 for more details.