### PR TITLE
feat: add navigation order frontmatter

### DIFF
--- a/docs/baseline/2026-04.mdx
+++ b/docs/baseline/2026-04.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline april 2026
 sidebar_position: -202604
+navigation_order: -202604
 pagination_label: Baseline april 2026
 description: De softwareversies waarmee we in april 2026 voor NL Design System testen voor Baseline support.
 slug: /baseline/2026-04

--- a/docs/baseline/Archief/2024-12.mdx
+++ b/docs/baseline/Archief/2024-12.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline december 2024
 sidebar_position: -202412
+navigation_order: -202412
 pagination_label: Baseline december 2024
 description: De softwareversies waarmee we in december 2024 voor NL Design System testen voor Baseline support.
 slug: /baseline/2024-12

--- a/docs/baseline/Archief/2025-04.mdx
+++ b/docs/baseline/Archief/2025-04.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline april 2025
 sidebar_position: -202504
+navigation_order: -202504
 pagination_label: Baseline april 2025
 description: De softwareversies waarmee we in april 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-04

--- a/docs/baseline/Archief/2025-05.mdx
+++ b/docs/baseline/Archief/2025-05.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline mei 2025
 sidebar_position: -202505
+navigation_order: -202505
 pagination_label: Baseline mei 2025
 description: De softwareversies waarmee we in mei 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-05

--- a/docs/baseline/Archief/2025-06.mdx
+++ b/docs/baseline/Archief/2025-06.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline juni 2025
 sidebar_position: -202506
+navigation_order: -202506
 pagination_label: Baseline juni 2025
 description: De softwareversies waarmee we in juni 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-06

--- a/docs/baseline/Archief/2025-07.mdx
+++ b/docs/baseline/Archief/2025-07.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline juli 2025
 sidebar_position: -202507
+navigation_order: -202507
 pagination_label: Baseline juli 2025
 description: De softwareversies waarmee we in juli 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-07

--- a/docs/baseline/Archief/2025-08.mdx
+++ b/docs/baseline/Archief/2025-08.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline augustus 2025
 sidebar_position: -202508
+navigation_order: -202508
 pagination_label: Baseline augustus 2025
 description: De softwareversies waarmee we in augustus 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-08

--- a/docs/baseline/Archief/2025-09.mdx
+++ b/docs/baseline/Archief/2025-09.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline september 2025
 sidebar_position: -202509
+navigation_order: -202509
 pagination_label: Baseline september 2025
 description: De softwareversies waarmee we in september 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-09

--- a/docs/baseline/Archief/2025-10.mdx
+++ b/docs/baseline/Archief/2025-10.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline oktober 2025
 sidebar_position: -202510
+navigation_order: -202510
 pagination_label: Baseline oktober 2025
 description: De softwareversies waarmee we in oktober 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-10

--- a/docs/baseline/Archief/2025-11.mdx
+++ b/docs/baseline/Archief/2025-11.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline november 2025
 sidebar_position: -202511
+navigation_order: -202511
 pagination_label: Baseline november 2025
 description: De softwareversies waarmee we in november 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-11

--- a/docs/baseline/Archief/2025-12.mdx
+++ b/docs/baseline/Archief/2025-12.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline december 2025
 sidebar_position: -202512
+navigation_order: -202512
 pagination_label: Baseline december 2025
 description: De softwareversies waarmee we in december 2025 voor NL Design System testen voor Baseline support.
 slug: /baseline/2025-12

--- a/docs/baseline/Archief/2026-02.mdx
+++ b/docs/baseline/Archief/2026-02.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline februari 2026
 sidebar_position: -202602
+navigation_order: -202602
 pagination_label: Baseline februari 2026
 description: De softwareversies waarmee we in februari 2026 voor NL Design System testen voor Baseline support.
 slug: /baseline/2026-02

--- a/docs/baseline/Archief/2026-03.mdx
+++ b/docs/baseline/Archief/2026-03.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline maart 2026
 sidebar_position: -202603
+navigation_order: -202603
 pagination_label: Baseline maart 2026
 description: De softwareversies waarmee we in maart 2026 voor NL Design System testen voor Baseline support.
 slug: /baseline/2026-03

--- a/docs/baseline/index.mdx
+++ b/docs/baseline/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Baseline
 sidebar_position: -999999
+navigation_order: -999999
 pagination_label: Baseline
 description: In de NL Design System Baseline wordt beschreven welke besturingssystemen, browsers en hulpapparatuur worden ondersteund.
 keywords:

--- a/docs/community/events/design-systems-week/eerdere-edities/2022.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2022.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2022
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Design Systems Week 2022
 slug: /events/design-systems-week-2022
 ---

--- a/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: 2023
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Videos 2023
 slug: /events/design-systems-week-2023/programma
 ---

--- a/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
@@ -6,6 +6,7 @@ hide_table_of_contents: true
 sidebar_label: 2024
 pagination_label: Design Systems Week 2024
 sidebar_position: 2
+navigation_order: 2
 slug: /events/design-systems-week-2024/programma
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24.png
 image_alt: NL Design System Design Systems Week 2024 14-17 oktober, online

--- a/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
@@ -6,6 +6,7 @@ hide_table_of_contents: true
 sidebar_label: 2025
 pagination_label: Design Systems Week 2025
 sidebar_position: 1
+navigation_order: 1
 slug: /events/design-systems-week-2025/programma
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/community-design-systems-week-2025.png
 image_alt: NL Design System Design Systems Week 2024 27-30 Oktober, online

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -7,6 +7,7 @@ hide_table_of_contents: true
 sidebar_label: About Design Systems Week
 pagination_label: About Design Systems Week
 sidebar_position: 1
+navigation_order: 1
 slug: /events/design-systems-week/en
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/community-design-systems-week-en-2025.png
 image_alt: NL Design System Design Systems Week 2024 27-30 October, online

--- a/docs/community/events/design-systems-week/en/previous-editions/2023.md
+++ b/docs/community/events/design-systems-week/en/previous-editions/2023.md
@@ -6,6 +6,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: 2023
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Videos 2023
 slug: /events/design-systems-week-2023/en/program
 ---

--- a/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
@@ -6,6 +6,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: 2024
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Videos 2024
 slug: /events/design-systems-week-2024/en/program
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24-en.png

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -6,6 +6,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: 2025
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Videos 2025
 slug: /events/design-systems-week-2025/en/program
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/dsw-24-en.png

--- a/docs/community/events/design-systems-week/index.mdx
+++ b/docs/community/events/design-systems-week/index.mdx
@@ -6,6 +6,7 @@ hide_table_of_contents: true
 sidebar_label: Over Design Systems Week
 pagination_label: Over Design Systems Week
 sidebar_position: 1
+navigation_order: 1
 slug: /events/design-systems-week
 image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/community-design-systems-week-2025.png
 image_alt: NL Design System Design Systems Week 2024 27-30 Oktober, online

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 sidebar_label: Tijdschema
 pagination_label: Tijdschema
 sidebar_position: 3
+navigation_order: 3
 slug: /events/design-systems-week-2026/tijdschema/
 ---
 

--- a/docs/community/events/heartbeat/videos.mdx
+++ b/docs/community/events/heartbeat/videos.mdx
@@ -1,5 +1,6 @@
 ---
 title: Video's van de Heartbeat
+title_sm: Video's
 description: Heartbeats vanaf 2022 terugkijken met updates van het kernteam en de community over NL Design System
 hide_title: true
 hide_table_of_contents: false

--- a/docs/componenten/index.mdx
+++ b/docs/componenten/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Overzicht
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Overzicht
 description: Een overzicht van alle gedocumenteerde componenten uit NL Design System
 keywords:

--- a/docs/componenten/index.mdx
+++ b/docs/componenten/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Componenten Overzicht
+title_sm: Overzicht
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Overzicht

--- a/docs/handboek/componenten-vinden.mdx
+++ b/docs/handboek/componenten-vinden.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Componenten vinden
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Componenten vinden
 description: Componenten gebruiken van NL Design System? Hier vind je hoe je dat aanpakt.
 keywords:

--- a/docs/handboek/definition-of-done/candidate-stappenplan/1-selectiefase.mdx
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/1-selectiefase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1. Selectiefase
 sidebar_position: 1
+navigation_order: 1
 pagination_label: 1. Selectiefase
 description: Stappen voor de Selectiefase van de Definition of Done voor Candidate
 slug: /handboek/estafettemodel/componenten/candidate/selectiefase

--- a/docs/handboek/definition-of-done/candidate-stappenplan/2-voorbereidingsfase.mdx
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/2-voorbereidingsfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2. Voorbereidingsfase
 sidebar_position: 2
+navigation_order: 2
 pagination_label: 2. Voorbereidingsfase
 description: Stappen voor de Voorbereidingsfase van de Definition of Done voor Candidate
 slug: /handboek/estafettemodel/componenten/candidate/Voorbereidingsfase

--- a/docs/handboek/definition-of-done/candidate-stappenplan/3-ontwikkelfase.mdx
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/3-ontwikkelfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3. Ontwikkelfase
 sidebar_position: 3
+navigation_order: 3
 pagination_label: 3. Ontwikkelfase
 description: Stappen voor de Ontwikkelfase van de Definition of Done voor Candidate
 slug: /handboek/estafettemodel/componenten/candidate/ontwikkelfase

--- a/docs/handboek/definition-of-done/candidate-stappenplan/4-testfase.mdx
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/4-testfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 4. Testfase
 sidebar_position: 4
+navigation_order: 4
 pagination_label: 4. Testfase
 description: Stappen voor de Testfase van de Definition of Done voor Candidate
 slug: /handboek/estafettemodel/componenten/candidate/testfase

--- a/docs/handboek/definition-of-done/candidate-stappenplan/5-publicatiefase.mdx
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/5-publicatiefase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 5. Publicatiefase
 sidebar_position: 5
+navigation_order: 5
 pagination_label: 5. Publicatiefase
 description: Stappen voor de Publicatiefase van de Definition of Done voor Candidate
 slug: /handboek/estafettemodel/componenten/candidate/publicatiefase

--- a/docs/handboek/definition-of-done/candidate-stappenplan/index.md
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/index.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Overzicht
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Overzicht
 description: Overzicht van de Definition of Done voor componenten
 slug: /handboek/estafettemodel/componenten/candidate

--- a/docs/handboek/definition-of-done/community-stappenplan/index.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Community stappenplan
+title_sm: Community
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Community

--- a/docs/handboek/definition-of-done/community-stappenplan/index.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Community
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Community
 description: Stappen voor de Community fase van Definition of Done
 slug: /handboek/estafettemodel/componenten/community

--- a/docs/handboek/definition-of-done/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-kernteam.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Kernteam
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Kernteam
 description: Stappen voor de Community fase van Definition of Done
 slug: /handboek/estafettemodel/componenten/community/voor-kernteam

--- a/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Organisaties
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Organisaties
 description: Stappen van organisaties voor de Community fase van Definition of Done
 slug: /handboek/estafettemodel/componenten/community/voor-organisaties

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/1-feedbackfase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/1-feedbackfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 1. Feedbackfase
 sidebar_position: 1
+navigation_order: 1
 pagination_label: 1. Feedbackfase
 description: Stappen voor de Feedbackfase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/feedbackfase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/2-selectiefase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/2-selectiefase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 2. Selectiefase
 sidebar_position: 2
+navigation_order: 2
 pagination_label: 2. Selectiefase
 description: Stappen voor de Selectiefase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/selectiefase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/3-voorbereidingsfase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/3-voorbereidingsfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 3. Voorbereidingsfase
 sidebar_position: 3
+navigation_order: 3
 pagination_label: 3. Voorbereidingsfase
 description: Stappen voor de Voorbereidingsfase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/voorbereidingsfase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/4-ontwikkelfase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/4-ontwikkelfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 4. Ontwikkelfase
 sidebar_position: 4
+navigation_order: 4
 pagination_label: 4. Ontwikkelfase
 description: Stappen voor de Ontwikkelfase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/ontwikkelfase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/5-testfase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/5-testfase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 5. Testfase
 sidebar_position: 5
+navigation_order: 5
 pagination_label: 5. Testfase
 description: Stappen voor de Testfase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/testfase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/6-publicatiefase.mdx
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/6-publicatiefase.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: 6. Publicatiefase
 sidebar_position: 6
+navigation_order: 6
 pagination_label: 6. Publicatiefase
 description: Stappen voor de Publicatiefase van de Definition of Done voor Hall of Fame
 slug: /handboek/estafettemodel/componenten/hall-of-fame/publicatiefase

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/index.md
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/index.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Overzicht
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Overzicht
 description: Overzicht van de Definition of Done voor Hall of Fame componenten
 slug: /handboek/estafettemodel/componenten/hall-of-fame

--- a/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
+++ b/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
@@ -1,5 +1,6 @@
 ---
 title: Help Wanted stappenplan
+title_sm: Help Wanted
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Help Wanted

--- a/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
+++ b/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Help Wanted
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Help Wanted
 description: Stappen voor de Help Wanted fase van Definition of Done
 slug: /handboek/estafettemodel/componenten/help-wanted

--- a/docs/handboek/definition-of-done/index.mdx
+++ b/docs/handboek/definition-of-done/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Overzicht
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Overzicht
 description: Definition of Done voor componenten
 slug: /handboek/estafettemodel/componenten/definition-of-done

--- a/docs/handboek/designer/figma-bestanden-overzicht.mdx
+++ b/docs/handboek/designer/figma-bestanden-overzicht.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Figma-bestanden overzicht
 sidebar_position: 6
+navigation_order: 6
 pagination_label: Figma-bestanden overzicht
 description: Overzicht van Figma-bestanden die worden beheerd door het kernteam én de community.
 slug: /figma

--- a/docs/handboek/designer/introductie.mdx
+++ b/docs/handboek/designer/introductie.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Index
 description: Het startpunt voor designers die willen meedoen met NL Design System.
 slug: /handboek/designer/introductie

--- a/docs/handboek/designer/werken-met-nl-design-system/changelog-voor-figma.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/changelog-voor-figma.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Werken met de Figma changelog
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Werken met de Figma changelog
 description: Informatie voor designers over het werken met de Figma changelog.
 slug: /handboek/designer/werken-met-figma-changelog

--- a/docs/handboek/designer/werken-met-nl-design-system/design-tokens-versiebeheer.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/design-tokens-versiebeheer.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Design tokens versiebeheer
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Design tokens versiebeheer
 description: Informatie voor designers over semver en hoe we het toepassen op de packages met design tokens.
 slug: /handboek/designer/design-tokens-versiebeheer

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Figma changelog
 sidebar_position: 6
+navigation_order: 6
 pagination_label: Figma changelog
 description: Overzicht van de wijzigingen in de Figma bibliotheken.
 slug: /handboek/designer/figma-changelog

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-hygiene.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-hygiene.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Figma hygiëne
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Figma hygiëne
 description: Informatie voor designers over Figma hygiëne.
 slug: /handboek/designer/figma-hygiene

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-stappenplan.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Figma stappenplan
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Figma stappenplan
 description: Een stappenplan om de NL Design System bibliotheken te gebruiken en eventueel een eigen thema door te voeren.
 slug: /handboek/designer/figma-stappenplan

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-structuur.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-structuur.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Figma structuur
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Figma structuur
 description: Informatie voor designers over de Figma structuur.
 slug: /handboek/designer/figma-structuur

--- a/docs/handboek/designer/werken-met-nl-design-system/index.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Werken met NL Design System
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Werken met NL Design System
 description: Informatie voor designers hoe je kunt werken met NL Design System.
 slug: /handboek/designer/werken-met-nl-design-system

--- a/docs/handboek/designer/zelf-componenten-maken.mdx
+++ b/docs/handboek/designer/zelf-componenten-maken.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Zelf componenten maken
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Zelf componenten maken
 description: Informatie voor designers over hoe je zelf componenten kunt maken in Figma met design tokens.
 slug: /handboek/designer/zelf-componenten-maken

--- a/docs/handboek/designer/zelf-componenten-uitbreiden.mdx
+++ b/docs/handboek/designer/zelf-componenten-uitbreiden.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Zelf componenten uitbreiden
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Zelf componenten uitbreiden
 description: Informatie voor designers over hoe je zelf componenten kunt uitbreiden in Figma met design tokens.
 slug: /handboek/designer/zelf-componenten-uitbreiden

--- a/docs/handboek/designer/zelf-thema-maken.mdx
+++ b/docs/handboek/designer/zelf-thema-maken.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Zelf een thema maken
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Zelf een thema maken
 description: Informatie voor designers over zelf een kan thema maken.
 slug: /handboek/designer/zelf-thema-maken

--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Estafettemodel
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Estafettemodel
 description: Het estafettemodel van NL Design System is een aanpak om samen de beste en meest bruikbare componenten, richtlijnen en patronen te maken.
 keywords:

--- a/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design tokens
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Design tokens - Introductie
 description: Design tokens introductie
 slug: /handboek/huisstijl/design-tokens

--- a/docs/handboek/huisstijl-vastleggen/themas/index.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Thema's
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Thema's
 description: Introductie van thema's binnen NL Design System.
 slug: /handboek/huisstijl/themas

--- a/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/start-thema.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Start-thema
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Start-thema
 description: Informatie over het Start-thema en de basis-tokens.
 slug: /handboek/huisstijl/themas/start-thema

--- a/docs/handboek/huisstijl-vastleggen/themas/voorbeeld-thema.mdx
+++ b/docs/handboek/huisstijl-vastleggen/themas/voorbeeld-thema.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voorbeeld-thema
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Voorbeeld-thema
 description: Informatie over het Voorbeeld-thema.
 slug: /handboek/huisstijl/themas/voorbeeld-thema

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Introductie
 description: NL Design System bevat componenten, patronen en richtlijnen, aangevuld met vele huisstijlen van organisaties die meedoen. Allemaal basisonderdelen waarover je afspraken kunt maken, gebruikersonderzoek kunt doen en van elkaar kunt leren.
 keywords:

--- a/docs/handboek/leverancier/_documenten/onderbouwing-om-aan-te-sluiten.mdx
+++ b/docs/handboek/leverancier/_documenten/onderbouwing-om-aan-te-sluiten.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Onderbouwing NL Design System
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Onderbouwing NL Design System
 description: Onderbouwing om aan te sluiten
 keywords:

--- a/docs/handboek/leverancier/_valideer-je-werk.md
+++ b/docs/handboek/leverancier/_valideer-je-werk.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Valideren
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Valideren
 description: Hoe valideer je of je werkt met het NLDS?
   - leverancier

--- a/docs/handboek/leverancier/introductie.md
+++ b/docs/handboek/leverancier/introductie.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voor leveranciers
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Voor leveranciers
 description: Waarom zou je als leverancier meedoen aan NL Design System?
   - leverancier

--- a/docs/handboek/manager/introductie.md
+++ b/docs/handboek/manager/introductie.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Voor managers
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Voor managers
 description: Waarom zou je als manager investeren in NL Design System?
   - manager

--- a/docs/handboek/naamgeving.mdx
+++ b/docs/handboek/naamgeving.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Naamgeving
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Naamgeving
 description: Naamgeving voor componenten, attributen en variaties
 keywords:

--- a/docs/handboek/organisatie/_documenten/onderbouwing-om-aan-te-sluiten.mdx
+++ b/docs/handboek/organisatie/_documenten/onderbouwing-om-aan-te-sluiten.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Onderbouwing NLDS
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Onderbouwing NLDS
 description: Onderbouwing om aan te sluiten
 keywords:

--- a/docs/handboek/organisatie/_documenten/voorbeeldtekst-aanbesteding.mdx
+++ b/docs/handboek/organisatie/_documenten/voorbeeldtekst-aanbesteding.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Aanbesteding
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Aanbesteding
 description: Voorbeeldtekst aanbesteding
 keywords:

--- a/docs/handboek/organisatie/meedoen.md
+++ b/docs/handboek/organisatie/meedoen.md
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Meedoen
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Meedoen
 description: Meedoen als organisatie
   - leverancier

--- a/docs/handboek/organisatie/meedoen.md
+++ b/docs/handboek/organisatie/meedoen.md
@@ -1,5 +1,6 @@
 ---
 title: Meedoen als organisatie
+title_sm: Meedoen
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Meedoen

--- a/docs/handboek/organisatie/vragen-over-aanbestedingen.md
+++ b/docs/handboek/organisatie/vragen-over-aanbestedingen.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Aanbestedingen
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Aanbestedingen
 description: Hoe kun je NL Design System opnemen, welke niveaus kun je kiezen en hoe krijg je de juiste expertise?
   - leverancier

--- a/docs/open-source/cc0.md
+++ b/docs/open-source/cc0.md
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Creative Commons 0
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Creative Commons
 description: NL Design System gebruikt de CC0-1.0 licentie voor documentatie.
 keywords:

--- a/docs/open-source/eupl.md
+++ b/docs/open-source/eupl.md
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: EUPL 1.2
 sidebar_position: 1
+navigation_order: 1
 pagination_label: EUPL 1.2 licentie
 description: NL Design System gebruikt de EUPL-1.2 licentie voor code en design.
 keywords:

--- a/docs/open-source/eupl.md
+++ b/docs/open-source/eupl.md
@@ -1,5 +1,6 @@
 ---
 title: EUPL 1.2 licentie
+title_sm: EUPL 1.2
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: EUPL 1.2

--- a/docs/private/doelen.mdx
+++ b/docs/private/doelen.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Doelen
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Doelen
 description: Doelen van de Definition of Done
 ---

--- a/docs/project/schrijfwijzer/beslissingen.mdx
+++ b/docs/project/schrijfwijzer/beslissingen.mdx
@@ -3,6 +3,7 @@ title: Beslissingen voor schrijfwijze
 hide_title: true
 sidebar_label: Beslissingen voor schrijfwijze
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Beslissingen voor schrijfwijze
 description: Beslissingen voor de schrijfwijze binnen het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/doelen.mdx
+++ b/docs/project/schrijfwijzer/doelen.mdx
@@ -3,6 +3,7 @@ title: Doelen
 hide_title: true
 sidebar_label: Doelen
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Doelen
 description: Doelen voor communicatie vanuit het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/doelgroepen.mdx
+++ b/docs/project/schrijfwijzer/doelgroepen.mdx
@@ -3,6 +3,7 @@ title: Doelgroepen
 hide_title: true
 sidebar_label: Doelgroepen
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Doelgroepen
 description: Doelgroepen voor NL Design System communicatie.
 keywords:

--- a/docs/project/schrijfwijzer/engels.mdx
+++ b/docs/project/schrijfwijzer/engels.mdx
@@ -3,6 +3,7 @@ title: Engels
 hide_title: true
 sidebar_label: Engels
 sidebar_position: 6
+navigation_order: 6
 pagination_label: Engels
 description: Richtlijnen voor Engelstalige communicatie vanuit het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/index.mdx
+++ b/docs/project/schrijfwijzer/index.mdx
@@ -3,6 +3,7 @@ title: Schrijfwijzer
 hide_title: true
 sidebar_label: Schrijfwijzer
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Schrijfwijzer
 description: Schrijfwijzer voor communicatie vanuit het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/nederlands.mdx
+++ b/docs/project/schrijfwijzer/nederlands.mdx
@@ -3,6 +3,7 @@ title: Nederlands
 hide_title: true
 sidebar_label: Nederlands
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Nederlands
 description: Richtlijnen voor Nederlandstalige communicatie vanuit het project NL Design System.
 keywords:

--- a/docs/project/schrijfwijzer/pagina-opbouw.mdx
+++ b/docs/project/schrijfwijzer/pagina-opbouw.mdx
@@ -3,6 +3,7 @@ title: Opbouw van een pagina
 hide_title: true
 sidebar_label: Opbouw van een pagina
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Opbouw van een pagina
 description: Opbouw van een pagina op de NL Design System website.
 keywords:

--- a/docs/project/schrijfwijzer/reviews.mdx
+++ b/docs/project/schrijfwijzer/reviews.mdx
@@ -3,6 +3,7 @@ title: Reviews
 hide_title: true
 sidebar_label: Reviews
 sidebar_position: 8
+navigation_order: 8
 pagination_label: Reviews
 description: Reviews voor NL Design System communicatie.
 keywords:

--- a/docs/richtlijnen/content/afbeeldingen/index.mdx
+++ b/docs/richtlijnen/content/afbeeldingen/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie afbeeldingen
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Content
 description: Introductie van de richtlijnen voor afbeeldingen van het NL Design System.
 slug: /richtlijnen/content/afbeeldingen

--- a/docs/richtlijnen/content/tekstopmaak/index.mdx
+++ b/docs/richtlijnen/content/tekstopmaak/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie tekstopmaak
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Content
 description: Introductie van de richtlijnen voor tekstopmaak van het NL Design System.
 slug: /richtlijnen/content/tekstopmaak

--- a/docs/richtlijnen/content/video/beschrijving.md
+++ b/docs/richtlijnen/content/video/beschrijving.md
@@ -1,5 +1,6 @@
 ---
 title: Beschrijving voor video
+title_sm: Video beschrijving
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Video beschrijving

--- a/docs/richtlijnen/content/video/flitsen.md
+++ b/docs/richtlijnen/content/video/flitsen.md
@@ -1,5 +1,6 @@
 ---
 title: Flitsen in video
+title_sm: Flitsen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Flitsen

--- a/docs/richtlijnen/content/video/index.mdx
+++ b/docs/richtlijnen/content/video/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie video
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Video
 description: Introductie van de richtlijnen voor video van het NL Design System.
 slug: /richtlijnen/content/video

--- a/docs/richtlijnen/formulieren/button/6-image-as-button/index.mdx
+++ b/docs/richtlijnen/formulieren/button/6-image-as-button/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Afbeeldingen als buttons
+title_sm: Afbeelding als button
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Afbeelding als button

--- a/docs/richtlijnen/formulieren/button/6-image-as-button/index.mdx
+++ b/docs/richtlijnen/formulieren/button/6-image-as-button/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Afbeelding als button
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Afbeelding als button
 description: Richtlijnen voor afbeeldingen als buttons.
 slug: /richtlijnen/formulieren/buttons/afbeelding-als-button

--- a/docs/richtlijnen/formulieren/button/7-disabled/index.mdx
+++ b/docs/richtlijnen/formulieren/button/7-disabled/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Disabled submitbuttons
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Disabled submitbuttons
 description: Richtlijnen voor disabled submitbuttons.
 slug: /richtlijnen/formulieren/buttons/disabled-submitbuttons

--- a/docs/richtlijnen/formulieren/button/index.mdx
+++ b/docs/richtlijnen/formulieren/button/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie Buttons
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Buttons in een formulier
 description: Richtlijnen voor het ontwerp en de code van buttons (knoppen) in een formulier.
 slug: /richtlijnen/formulieren/buttons

--- a/docs/richtlijnen/formulieren/button/index.mdx
+++ b/docs/richtlijnen/formulieren/button/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Buttons in een formulier
+title_sm: Introductie Buttons
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie Buttons

--- a/docs/richtlijnen/formulieren/confirmation/1-success/index.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/1-success/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Duidelijke succesmelding
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Duidelijke succesmelding
 description: Richtlijnen voor vermelding na succesvol verzenden.
 slug: /richtlijnen/formulieren/bevestigingspagina/succesmelding

--- a/docs/richtlijnen/formulieren/confirmation/index.mdx
+++ b/docs/richtlijnen/formulieren/confirmation/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie bevestigingspagina
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Bevestigingspagina
 description: Een bevestigingspagina informeert gebruikers dat hun data met succes is verstuurd en wat de eventuele vervolgacties zijn.
 slug: /richtlijnen/formulieren/bevestigingspagina/

--- a/docs/richtlijnen/formulieren/description/index.mdx
+++ b/docs/richtlijnen/formulieren/description/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie descriptions
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Descriptions in een formulier
 description: Richtlijnen voor het toepassen van descriptions in een formulier.
 slug: /richtlijnen/formulieren/descriptions/

--- a/docs/richtlijnen/formulieren/error/index.mdx
+++ b/docs/richtlijnen/formulieren/error/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie foutmeldingen
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Foutmeldingen
 description: Als een veld niet goed is ingevuld, moet voor iedereen duidelijk zijn wat er niet klopt. Hoe help je de gebruiker het beste als die onjuiste of onvolledige informatie invult?
 slug: /richtlijnen/formulieren/foutmeldingen/

--- a/docs/richtlijnen/formulieren/fieldset/index.mdx
+++ b/docs/richtlijnen/formulieren/fieldset/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie fieldsets
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Fieldsets
 description: Groepeer formuliervelden die bij elkaar horen in een fieldset met een beschrijvende legend.
 slug: /richtlijnen/formulieren/fieldsets/

--- a/docs/richtlijnen/formulieren/help/index.mdx
+++ b/docs/richtlijnen/formulieren/help/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie voorkom fouten
 sidebar_position: 13
+navigation_order: 13
 pagination_label: Voorkom fouten in een formulier
 description: Richtlijnen voor het voorkomen van fouten door hulp te bieden aan de gebruiker in een formulier.
 slug: /richtlijnen/formulieren/voorkom-fouten/

--- a/docs/richtlijnen/formulieren/keyboard-behaviour/index.mdx
+++ b/docs/richtlijnen/formulieren/keyboard-behaviour/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie toetsenbordnavigatie
 sidebar_position: 10
+navigation_order: 10
 pagination_label: Toetsenbord
 description: Het formulier moet goed werken met alleen een toetsenbord, zonder gebruik te maken van een muis.
 slug: /richtlijnen/formulieren/toetsenbord/

--- a/docs/richtlijnen/formulieren/label/index.mdx
+++ b/docs/richtlijnen/formulieren/label/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Labels in een formulier
+title_sm: Introductie labels
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie labels

--- a/docs/richtlijnen/formulieren/label/index.mdx
+++ b/docs/richtlijnen/formulieren/label/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie labels
 sidebar_position: 6
+navigation_order: 6
 pagination_label: Labels in een formulier
 description: Richtlijnen voor labels in een formulier.
 slug: /richtlijnen/formulieren/labels/

--- a/docs/richtlijnen/formulieren/link/index.mdx
+++ b/docs/richtlijnen/formulieren/link/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Links in een formulier
+title_sm: Introductie links
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie links

--- a/docs/richtlijnen/formulieren/link/index.mdx
+++ b/docs/richtlijnen/formulieren/link/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie links
 sidebar_position: 7
+navigation_order: 7
 pagination_label: Links in een formulier
 description: Richtlijnen voor het plaatsen van links binnen een formulier.
 slug: /richtlijnen/formulieren/links/

--- a/docs/richtlijnen/formulieren/multistep/index.mdx
+++ b/docs/richtlijnen/formulieren/multistep/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie meerdere stappen
 sidebar_position: 8
+navigation_order: 8
 pagination_label: Meerdere stappen
 description: Bestaat een formulier uit veel vragen, dan kan het gebruiksvriendelijk en overzichtelijk zijn om het formulier in meerdere stappen op te delen, of om een vraag per stap te stellen.
 slug: /richtlijnen/formulieren/meerdere-stappen/

--- a/docs/richtlijnen/formulieren/placeholder/index.mdx
+++ b/docs/richtlijnen/formulieren/placeholder/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie placeholders
 sidebar_position: 9
+navigation_order: 9
 pagination_label: Placeholders in een formulier
 description: Richtlijnen voor het ontwerp en de code van placeholders in een formulier.
 slug: /richtlijnen/formulieren/placeholders/

--- a/docs/richtlijnen/formulieren/questions/index.mdx
+++ b/docs/richtlijnen/formulieren/questions/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie uit te vragen informatie
 sidebar_position: 11
+navigation_order: 11
 pagination_label: Uit te vragen informatie in een formulier
 description: Richtlijnen voor uit te vragen informatie in een formulier.
 slug: /richtlijnen/formulieren/vragen/

--- a/docs/richtlijnen/formulieren/status/index.mdx
+++ b/docs/richtlijnen/formulieren/status/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie status
 sidebar_position: 12
+navigation_order: 12
 pagination_label: Status in formulieren
 description: Richtlijnen voor het omgaan met status in formulieren.
 slug: /richtlijnen/formulieren/status/

--- a/docs/richtlijnen/formulieren/status/index.mdx
+++ b/docs/richtlijnen/formulieren/status/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Status in een formulier
+title_sm: Introductie status
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie status

--- a/docs/richtlijnen/formulieren/visual-design/index.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie visueel ontwerp
 sidebar_position: 12
+navigation_order: 12
 pagination_label: Visueel ontwerp van formulieren
 description: Richtlijnen voor het visueel ontwerp van formulieren.
 slug: /richtlijnen/formulieren/visueel-ontwerp/

--- a/docs/richtlijnen/formulieren/when-which/index.mdx
+++ b/docs/richtlijnen/formulieren/when-which/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie wanneer welk element?
 sidebar_position: 14
+navigation_order: 14
 pagination_label: Wanneer gebruik je welk formulierelement
 description: Richtlijnen voor het kiezen van formulierelementen.
 slug: /richtlijnen/formulieren/wanneer-welk-form-element/

--- a/docs/richtlijnen/index.mdx
+++ b/docs/richtlijnen/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Introductie
 description: Introductie richtlijnen NL Design System
 slug: /richtlijnen

--- a/docs/richtlijnen/stijl/colour/index.mdx
+++ b/docs/richtlijnen/stijl/colour/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie kleuren
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Introductie richtlijnen voor kleuren
 description: Kleuren zijn een belangrijk onderdeel van een ontwerp. Ze zorgen voor een visuele toon en helpen bij het overbrengen van functie en betekenis. Kleur wordt echter niet door iedereen op dezelfde manier ervaren. Daarom hebben kleuren een ondersteunende en geen essentiële rol.
 slug: /richtlijnen/stijl/kleuren/

--- a/docs/richtlijnen/stijl/icons/index.mdx
+++ b/docs/richtlijnen/stijl/icons/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie iconen
 sidebar_position: 4
+navigation_order: 4
 pagination_label: Introductie richtlijnen voor iconen
 description: Iconen worden gebruikt om extra betekenis te geven. Ze brengen boodschappen in één oogopslag over en vestigen aandacht op belangrijke informatie. Ook kunnen ze hulp bieden aan iemand met een cognitieve beperking of als iemand moeite heeft met taal.
 slug: /richtlijnen/stijl/iconen/

--- a/docs/richtlijnen/stijl/space/index.mdx
+++ b/docs/richtlijnen/stijl/space/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie ruimte
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Introductie richtlijnen voor ruimte
 description: Ruimte (Spacing in het Engels) helpt bij het organiseren van inhoud. Door ruimte op een voorspelbare manier toe te passen kun je visueel verbanden leggen en orde scheppen.
 slug: /richtlijnen/stijl/ruimte/

--- a/docs/richtlijnen/stijl/typography/4-font/index.mdx
+++ b/docs/richtlijnen/stijl/typography/4-font/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kies een goed lettertype
+title_sm: Goed lettertype
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Goed lettertype

--- a/docs/richtlijnen/stijl/typography/index.mdx
+++ b/docs/richtlijnen/stijl/typography/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie typografie
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Introductie richtlijnen voor typografie
 description: Goede typografie helpt bij het creëren van een duidelijke hiërarchie en het ordenen van informatie. Hierdoor zijn teksten gemakkelijk te lezen en te begrijpen.
 slug: /richtlijnen/stijl/typografie/

--- a/docs/voorbeelden/gebruikersonderzoek.mdx
+++ b/docs/voorbeelden/gebruikersonderzoek.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Gebruikersonderzoek
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Gebruikersonderzoek
 description: Informatie over gebruikersonderzoek.
 slug: /voorbeelden/onderzoek

--- a/docs/voorbeelden/introductie.mdx
+++ b/docs/voorbeelden/introductie.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie
 sidebar_position: 1
+navigation_order: 1
 pagination_label: Index
 description: Voorbeelden van veelvoorkomende pagina's en klantreizen, gemaakt met richtlijnen en componenten uit NL Design System.
 slug: /voorbeelden

--- a/docs/voorbeelden/patronen-en-templates/formulieren.mdx
+++ b/docs/voorbeelden/patronen-en-templates/formulieren.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Formulieren
 sidebar_position: 2
+navigation_order: 2
 pagination_label: Formulieren
 description: Verzameling van patronen en templates rondom formulieren en meerstappenformulieren.
 slug: /voorbeelden/patronen-en-templates/formulieren

--- a/docs/voorbeelden/patronen-en-templates/mijn-omgevingen.mdx
+++ b/docs/voorbeelden/patronen-en-templates/mijn-omgevingen.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: true
 sidebar_label: Mijn omgevingen
 sidebar_position: 3
+navigation_order: 3
 pagination_label: Mijn omgevingen
 description: Verzameling van patronen en templates rondom mijn omgevingen.
 slug: /voorbeelden/patronen-en-templates/mijn-omgevingen

--- a/docs/wcag/index.mdx
+++ b/docs/wcag/index.mdx
@@ -3,6 +3,7 @@ title: Introductie WCAG pagina's
 hide_title: true
 hide_table_of_contents: true
 sidebar_position: 1
+navigation_order: 1
 sidebar_label: Introductie WCAG-pagina's
 pagination_label: Introductie WCAG-pagina's
 description: Introductie van informatie over de WCAG-succescriteria.

--- a/docs/woordenlijst/index.mdx
+++ b/docs/woordenlijst/index.mdx
@@ -4,6 +4,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Woordenlijst
 sidebar_position: 5
+navigation_order: 5
 pagination_label: Woordenlijst
 description: NL Design System Woordenlijst
 slug: /woordenlijst


### PR DESCRIPTION
1. Voor de astro navigatie structuur stappen we over van `sidebar_position` naar `navigation_order` 
2. Daar waar dat automatisch kon, zijn `title_sm` velden toegevoegd
