### PR TITLE
chore: remove uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
     "unist-util-visit": "5.1.0",
-    "uuid": "11.1.0",
     "yaml-loader": "0.9.0"
   },
   "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,9 +384,6 @@ importers:
       unist-util-visit:
         specifier: 5.1.0
         version: 5.1.0
-      uuid:
-        specifier: 11.1.0
-        version: 11.1.0
       yaml-loader:
         specifier: 0.9.0
         version: 0.9.0
@@ -11042,10 +11039,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -24680,8 +24673,6 @@ snapshots:
   utility-types@3.10.0: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
This dependency is outdated and it seems not to be used anywhere.

If anyone uses this to generate uuid's locally, you can also run:
`pnpm dlx uuid`

Tagging @RenateRoke @Yolijn since I saw you mentioned uuid once.