### PR TITLE
docs: fix broken github links in community stappenplan

### DIFF
--- a/docs/handboek/definition-of-done/community-stappenplan/voor-kernteam.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-kernteam.mdx
@@ -294,7 +294,7 @@ Door deze 'Component stickers' op screenshots te plakken, kunnen we geïnteresse
 
 ### Actie
 
-Als de component wordt ontwikkeld met de NL Design System infrastructuur op [github.com/nl-design-system](github.com/nl-design-system), dan wordt al automatisch een backup gemaakt van de code met Rewind.
+Als de component wordt ontwikkeld met de NL Design System infrastructuur op [github.com/nl-design-system](https://github.com/nl-design-system), dan wordt al automatisch een backup gemaakt van de code met Rewind.
 
 Als code van de component in eigen infrastructuur wordt ontwikkeld, dan moet handmatig een automatische backup ingesteld worden. Neem contact op met het kernteam, en vraag om een automatisch dagelijks een mirror te maken van jouw Git repository naar een repository bij NL Design System. De backup-repository zal private zijn, zodat geen verwarring ontstaat wat de originele repository is, en voorkom je dat de backup-repository hoger kan eindigen in zoekresultaten.
 

--- a/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
@@ -197,7 +197,7 @@ Is er alleen een React Storybook? Zorg dan dat een codevoorbeeld van CSS beschik
 
 ### Acties
 
-Als de component wordt ontwikkeld met de NL Design System infrastructuur op [github.com/nl-design-system](github.com/nl-design-system), dan heb je automatisch toegang tot visuele regressietest met Chromatic.
+Als de component wordt ontwikkeld met de NL Design System infrastructuur op [github.com/nl-design-system](https://github.com/nl-design-system), dan heb je automatisch toegang tot visuele regressietest met Chromatic.
 
 Controleer dan dat "Storybook Publish" en "UI Tests" bij de Pull Request checks staan.
 


### PR DESCRIPTION
Aangekaart door community!

Preview: 
- https://documentatie-git-docs-fix-broken-github-51ee28-nl-design-system.vercel.app/handboek/estafettemodel/componenten/community/voor-organisaties/#component-heeft-visuele-regressietests
- https://documentatie-git-docs-fix-broken-github-51ee28-nl-design-system.vercel.app/handboek/estafettemodel/componenten/community/voor-kernteam/#backup-van-de-code