### PR TITLE
docs: show tags in component overview based on relay step filter

### DIFF
--- a/src/components/ComponentOverview.tsx
+++ b/src/components/ComponentOverview.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from 'react';
 import {
   COMPONENT_STATES,
   getAllFrameworkNames,
-  getComponentFrameworkNames,
+  getComponentFrameworkNamesForFilteredStatus,
   hasFramework,
   normalizeName,
   type Component,
@@ -165,7 +165,7 @@ export const ComponentOverview = () => {
           });
 
           const relayStep = component && COMPONENT_STATES[component.relayStep];
-          const frameworkNames = getComponentFrameworkNames(component);
+          const frameworkNames = getComponentFrameworkNamesForFilteredStatus(component, showStatuses);
 
           return (
             <ComponentCard

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,6 +134,57 @@ export const getProjectFrameworkNames = (project: ComponentProject): string[] =>
 export const getComponentFrameworkNames = (component: Component): string[] =>
   sortFrameworkNames(removeDuplicates(component.projects.flatMap((project) => getProjectFrameworkNames(project))));
 
+export const getComponentFrameworkNamesForFilteredStatus = (component: Component, relayFilters: string[]): string[] => {
+  // No extra logic needed if no filters are selected
+  if (relayFilters.length < 1) return getComponentFrameworkNames(component);
+
+  // Only get the framework names for the projects that match the selected relay filters,
+  // so that for example if Candidate is selected, which only has CSS, HTML and React implementations,
+  // it doesn't show the Angular framework which comes from one of the community implementations.
+  const frameworkNames = component.projects.flatMap((project) => {
+    // 1a. Determine the project's relay step (HELP_WANTED, COMMUNITY, CANDIDATE, HALL_OF_FAME) based on its id
+    // Usually relayStep is one of RELAY_STEP,
+    // in case of community projects, the id is something like DEN_HAAG.
+    const projectRelayStep = project.id as RELAY_STEP;
+    // 1b. Determine if this project is a community project by checking if the projectRelayStep is
+    // not in the known relayProjectIds (HELP_WANTED, COMMUNITY, CANDIDATE, HALL_OF_FAME)
+    const isCommunityProject = !relayProjectIds.includes(projectRelayStep);
+
+    // 2a. Determine if this relay step is included in the relayFilters
+    // Which we only depend on for non-community projects, since community projects have ids like DEN_HAAG
+    const isInRelayFilters = relayFilters.includes(projectRelayStep);
+    // 2b. Determine if the HELP_WANTED or COMMUNITY relay step is included in the relayFilters,
+    // because if it is, then we want to include all community projects.
+    // We include for HELP_WANTED, because HELP_WANTED might already have community implementations.
+    const communityProjectsAreAllowed = relayFilters.includes('HELP_WANTED') || relayFilters.includes('COMMUNITY');
+
+    // Project CANDIDATE exists and is done.
+    const isCompletedCandidate = project.id === 'CANDIDATE' && project.done;
+    // Project HALL_OF_FAME exists and is done.
+    const isCompletedHallOfFame = project.id === 'HALL_OF_FAME' && project.done;
+
+    // In case of HELP_WANTED or COMMUNITY
+    if (communityProjectsAreAllowed && isCommunityProject) {
+      return getProjectFrameworkNames(project);
+    }
+    // In case of any other relay step, only include the framework names if this project's relay step is included in the relayFilters
+    // For example: when filtering CANDIDATE or HALL_OF_FAME, DEN_HAAG would end up here.
+    else if (!isInRelayFilters) {
+      return [];
+    }
+    // In case of CANDIDATE, we can't get the frameworks from the projectboard,
+    // but we know we support (and require at least implementations of) CSS, HTML and React, so we can just return those.
+    // In case of HALL_OF_FAME, we don't have those components yet,
+    // but those too would be expected to support (and have a CANDIDATE implementation of) CSS, HTML and React, so we can just return those as well.
+    else if (isCompletedCandidate || isCompletedHallOfFame) {
+      return ['CSS', 'HTML', 'React'];
+    }
+    // Anything else, just get the framework names for this project without extra logic
+    return getProjectFrameworkNames(project);
+  });
+  return sortFrameworkNames(removeDuplicates(frameworkNames));
+};
+
 export const getComponentAlias = (project: ComponentProject): string => {
   const task = project.tasks.find(({ name }) => name === 'Naam');
   return task?.value || '';


### PR DESCRIPTION
Based on community feedback: when filtering on Candidate, it's confusing to see the tags state there's Angular implementations, when there are no Candidate Angular implementations, just Community Angular implementations for the Candidate component.

Preview: https://documentatie-git-docs-show-tags-in-comp-700f8d-nl-design-system.vercel.app/componenten/

UPDATE:

Ik heb een [issue aangemaakt](https://github.com/nl-design-system/documentatie/issues/4164) hiervoor en we sluiten deze PR:

> Community feedback ([Slack](https://codefornl.slack.com/archives/C01DAT4TRPF/p1778164049188419)): wanneer ik filter in de Component Overview op Candidate, zie ik in de Component Cards dat bijvoorbeeld een Button de tag Angular heeft. Dan verwacht ik dat de Candidate Button dus geimplementeerd is in Angular. Maar dat is niet zo: de Candidate Button heeft HTML/CSS/React implementatie, de Angular tag komt van de Community Implementaties.
> 
> Aan de hand van deze feedback is deze PR gemaakt: [#4158](https://github.com/nl-design-system/documentatie/pull/4158) en besproken in het kernteam ([Slack](https://codefornl.slack.com/archives/C02CWGL2M18/p1778175977241309)). Hier komt meer bij kijken dan een kleine wijziging: verschillende test cases, de vraag of dit het probleem oplost, de vraag of dit andere verwarringen kan veroorzaken, etc. Daarom hebben we de pull request gesloten en een issue aangemaakt voor op de backlog.
> 
> Designers zijn op de hoogte gebracht ([Slack](https://codefornl.slack.com/archives/C02CWGL2M18/p1778164489883619)) om hier ook over na te denken in de redesign van de website.
