### PR TITLE
feat: breadcrumbs

### DIFF
--- a/packages/website/src/layouts/detail.astro
+++ b/packages/website/src/layouts/detail.astro
@@ -5,11 +5,13 @@ import { IconChevronRight } from '@tabler/icons-react';
 import TableOfContents from '@components/table-of-content/table-of-content.astro';
 import { SideNav } from '@components/side-nav/side-nav.tsx';
 import { navigation } from '../navigation.config.ts';
+import { getBreadcrumbsForElement } from '../navigation';
 import './detail.css';
 
 export type Props = DocumentProps;
 
 const nav = await navigation;
+const breadcrumbPath = await getBreadcrumbsForElement(Astro.url.pathname);
 const { ...props } = Astro.props;
 ---
 
@@ -20,16 +22,29 @@ const { ...props } = Astro.props;
         <SideNav data={nav} />
       </div>
 
-      <nav class="ma-layout-detail__breadcrumb-nav" aria-labelledby="breadcrumb-label">
-        <h2 hidden id="breadcrumb-label">Kruimelpad</h2>
-        <BreadcrumbNav>
-          <BreadcrumbNavLink href="/">Home</BreadcrumbNavLink>
-          <BreadcrumbNavSeparator>
-            <IconChevronRight />
-          </BreadcrumbNavSeparator>
-          <BreadcrumbNavLink href="#">{props.title}</BreadcrumbNavLink>
-        </BreadcrumbNav>
-      </nav>
+      {
+        breadcrumbPath.length > 0 && (
+          <nav class="ma-layout-detail__breadcrumb-nav" aria-labelledby="breadcrumb-label">
+            <h2 hidden id="breadcrumb-label">
+              Kruimelpad
+            </h2>
+            <BreadcrumbNav>
+              {breadcrumbPath.map((item, index, list) => (
+                <>
+                  <BreadcrumbNavLink href={item.href || ''} disabled={!item.href}>
+                    {item.label}
+                  </BreadcrumbNavLink>
+                  {index < list.length - 1 ? (
+                    <BreadcrumbNavSeparator>
+                      <IconChevronRight />
+                    </BreadcrumbNavSeparator>
+                  ) : null}
+                </>
+              ))}
+            </BreadcrumbNav>
+          </nav>
+        )
+      }
 
       <main id="main" class="ma-layout-detail__main">
         <header class="ma-layout-detail__header"><slot name="header" /></header>

--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -11,6 +11,7 @@ import { NavListLink } from '@components/nav-list/nav-list';
 import { Logo } from '@components/logo/logo';
 import { LinkList, LinkListLink } from '@components/link-list/link-list';
 import { IconChevronRight } from '@tabler/icons-react';
+import { getMainNavigation } from '../navigation';
 
 import '@fontsource/fira-code';
 import '@fontsource/fira-sans/700';
@@ -42,15 +43,7 @@ const _keywords = new Set([...siteKeywords, ...(keywords || [])]);
 const _follow = follow === undefined ? index : follow;
 const _robots = `${index ? 'index' : 'noindex'} ${_follow ? 'follow' : 'nofollow'}`;
 
-const mainNavigationItems = [
-  { href: '/', label: 'Home' },
-  { href: '/handboek/', label: 'Handboek' },
-  { href: '/richtlijnen/', label: 'Richtlijnen' },
-  { href: '/componenten/', label: 'Componenten' },
-  { href: '/voorbeelden/', label: 'Voorbeelden' },
-  { href: '/community/', label: 'Community' },
-  { href: '/project/', label: 'Project' },
-];
+const mainNavigationItems = await getMainNavigation();
 
 const footerNavigationItems = [
   { href: '/blog/', label: 'Blog' },

--- a/packages/website/src/layouts/overview.astro
+++ b/packages/website/src/layouts/overview.astro
@@ -4,11 +4,13 @@ import { BreadcrumbNav, BreadcrumbNavLink, BreadcrumbNavSeparator } from '@compo
 import { IconChevronRight } from '@tabler/icons-react';
 import { SideNav } from '@components/side-nav/side-nav.tsx';
 import { navigation } from '../navigation.config.ts';
+import { getBreadcrumbsForElement } from '../navigation';
 import './overview.css';
 
 export type Props = DocumentProps;
 
 const nav = await navigation;
+const breadcrumbPath = await getBreadcrumbsForElement(Astro.url.pathname);
 const { ...props } = Astro.props;
 ---
 
@@ -19,16 +21,29 @@ const { ...props } = Astro.props;
         <SideNav data={nav} />
       </div>
 
-      <nav class="ma-layout-overview__breadcrumb-nav" aria-labelledby="breadcrumb-label">
-        <h2 hidden id="breadcrumb-label">Kruimelpad</h2>
-        <BreadcrumbNav>
-          <BreadcrumbNavLink href="/">Home</BreadcrumbNavLink>
-          <BreadcrumbNavSeparator>
-            <IconChevronRight />
-          </BreadcrumbNavSeparator>
-          <BreadcrumbNavLink href="#">{props.title}</BreadcrumbNavLink>
-        </BreadcrumbNav>
-      </nav>
+      {
+        breadcrumbPath.length > 0 && (
+          <nav class="ma-layout-overview__breadcrumb-nav" aria-labelledby="breadcrumb-label">
+            <h2 hidden id="breadcrumb-label">
+              Kruimelpad
+            </h2>
+            <BreadcrumbNav>
+              {breadcrumbPath.map((item, index, list) => (
+                <>
+                  <BreadcrumbNavLink href={item.href || ''} disabled={!item.href}>
+                    {item.label}
+                  </BreadcrumbNavLink>
+                  {index < list.length - 1 ? (
+                    <BreadcrumbNavSeparator>
+                      <IconChevronRight />
+                    </BreadcrumbNavSeparator>
+                  ) : null}
+                </>
+              ))}
+            </BreadcrumbNav>
+          </nav>
+        )
+      }
 
       <main id="main" class="ma-layout-overview__main">
         <div class="ma-layout-overview__main-body">

--- a/packages/website/src/navigation.config.ts
+++ b/packages/website/src/navigation.config.ts
@@ -1,8 +1,7 @@
 import { navigationItem, navigationGroup } from './navigation';
 
 export const navigation = navigationGroup({
-  label: 'Home',
-  index: navigationItem({ label: 'Home', href: '/' }),
+  index: navigationItem({ href: '/', label: 'Home' }),
   items: [
     navigationGroup({
       label: 'Handboek',

--- a/packages/website/src/navigation/get-breadcrumbs-for-element.ts
+++ b/packages/website/src/navigation/get-breadcrumbs-for-element.ts
@@ -1,0 +1,57 @@
+import { navigationElements, type NavigationElement, type NavigationGroup } from './index';
+import { navigation } from '../navigation.config';
+import type { NavigationItem } from './index.ts';
+
+/**
+ * Based on the navigation config, get the breadcrumb path of
+ * NavigationElements for a specific route. The `input` can be either an
+ * `href` or `NavigationElement`.
+ */
+export async function getBreadcrumbsForElement(input: string | NavigationElement): Promise<NavigationElement[]> {
+  await navigation;
+
+  const parents: NavigationGroup[] = [];
+  const child: NavigationElement | undefined = typeof input === 'string' ? findNavigationElement(input) : input;
+
+  if (!child) return [];
+
+  findNavigationElementParents(child, parents);
+  parents.reverse();
+
+  if (child !== parents.at(-1)?.index) {
+    return [...parents, child];
+  }
+
+  return parents;
+}
+
+/**
+ * Find an element in the navigation tree based on a href.
+ */
+function findNavigationElement(href: string) {
+  return navigationElements.find((element: NavigationElement) => {
+    const _href = (element as NavigationItem)?.href || (element as NavigationGroup)?.index?.href;
+    return trimSlashes(_href) === trimSlashes(href);
+  });
+}
+
+/**
+ * Find all parents for a given `NavigationElement`.
+ */
+function findNavigationElementParents(element: NavigationElement, list: NavigationElement[]) {
+  if (element.parent) {
+    list.push(element.parent);
+    findNavigationElementParents(element.parent, list);
+  }
+}
+
+/**
+ * Trim the slashes of a string (usually an `href`) to use in a comparison.
+ * Since the `href` of an `NavigationItem` can be based on an
+ * Astro Content Collection Id's, a Docusaurus ID, the existance of a leading
+ * or trailing slash is not guaranteed. Stripping them results in a more stable
+ * comparison
+ */
+function trimSlashes(string?: string) {
+  return string ? string.replace(/\/$/, '').replace(/^\//, '') : undefined;
+}

--- a/packages/website/src/navigation/get-main-navigation.ts
+++ b/packages/website/src/navigation/get-main-navigation.ts
@@ -1,0 +1,11 @@
+import { navigation } from '../navigation.config';
+
+/**
+ * Get the main navigation items (level 1) of the navigation structure.
+ * This consists of the root `NavigationGroup` from the navigation config
+ * alongside its children.
+ */
+export async function getMainNavigation() {
+  const nav = await navigation;
+  return [nav, ...nav.items].filter(Boolean);
+}

--- a/packages/website/src/navigation/index.ts
+++ b/packages/website/src/navigation/index.ts
@@ -4,13 +4,14 @@ import { getAllCollections } from '../content.config';
 import type { Dirent } from 'node:fs';
 import { sortItems } from './sort-items';
 export { getBreadcrumbsForElement } from './get-breadcrumbs-for-element';
+export { getMainNavigation } from './get-main-navigation';
 
 /**
  * An item in a navigation tree. The item references an Content Collection ID.
  */
 export interface NavigationItem {
   /** The label of the item to display to the user */
-  label: string;
+  label?: string;
 
   /** The Astro Content Collection ID of the item */
   id?: string;
@@ -35,7 +36,7 @@ export interface NavigationItem {
  */
 export interface NavigationGroup {
   /** The label of the group to display to the user */
-  label: string;
+  label?: string;
 
   /** The items in the group */
   items: (NavigationItem | NavigationGroup | Promise<NavigationItem> | Promise<NavigationGroup>)[];

--- a/packages/website/src/navigation/index.ts
+++ b/packages/website/src/navigation/index.ts
@@ -3,6 +3,7 @@ import { readdir } from 'node:fs/promises';
 import { getAllCollections } from '../content.config';
 import type { Dirent } from 'node:fs';
 import { sortItems } from './sort-items';
+export { getBreadcrumbsForElement } from './get-breadcrumbs-for-element';
 
 /**
  * An item in a navigation tree. The item references an Content Collection ID.
@@ -63,9 +64,6 @@ export interface NavigationGroup {
 export type NavigationElement = NavigationItem | NavigationGroup;
 export type NavigationElementOrdered = NavigationElement & { order: NonNullable<NavigationElement['order']> };
 
-/** All available entries from each Content Collection */
-const collections = getAllCollections();
-
 /**
  * A flat list of all navigation elements, filled when the `navigation` promise
  * is resolved
@@ -97,7 +95,7 @@ export async function navigationItem(input: NavigationItemInput): Promise<Naviga
   const _filePath = typeof input === 'string' ? input : input.filePath;
   const options = typeof input === 'string' ? undefined : input;
 
-  const entries = await collections;
+  const entries = await getAllCollections();
   const entry = entries.find(
     (entry) =>
       (_filePath && entry.filePath?.endsWith(_filePath)) || // relative file path

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -18,7 +18,7 @@
     },
     "plugins": [{ "name": "@astrojs/ts-plugin" }],
     "checkJs": true,
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
closes: #4051

Zolang #4162 nog niet gemerged is, zijn nog niet alle pagina's opgenomen in de navigatie structuur. De breadcrumbs halen de data uit deze structuur, dus enkel de pagina's in de navigatie structuur krijgen breadcrumbs.

Zie de breadcrumb in actie:
[Help wanted pagina](https://documentatie-next-git-feat-breadcrumbs-nl-design-system.vercel.app/handboek/estafettemodel/componenten/help-wanted/)
