### PR TITLE
docs: procedures related to GitHub teams and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# See: https://nldesignsystem.nl/codeowners
 
-# Changes to any file require approval from @nl-design-system/kernteam-committer
 * @nl-design-system/kernteam-committer
-
-# Changes to files in /docs/wcag specifically require approval from @nl-design-system/kernteam-a11y
 /docs/wcag/ @nl-design-system/kernteam-a11y @nl-design-system/kernteam-admin
 
 # Protect this file itself (order matters, keep this line last):

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,9 @@
 
 # Changes to any file require approval from @nl-design-system/kernteam-committer
 * @nl-design-system/kernteam-committer
+
 # Changes to files in /docs/wcag specifically require approval from @nl-design-system/kernteam-a11y
 /docs/wcag/ @nl-design-system/kernteam-a11y @nl-design-system/kernteam-admin
 
-# Changes to this file (.github/CODEOWNERS) require approval from @nl-design-system/kernteam-admin
+# Protect this file itself (order matters, keep this line last):
 .github/CODEOWNERS @nl-design-system/kernteam-admin

--- a/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
+++ b/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
@@ -46,19 +46,22 @@ De admin moet periodiek controleren dat de toegangsrechten van gebruikers nog kl
 Met `CODEOWNERS` leg je vast welke gebruikers of rollen verantwoordelijk zijn voor bepaalde bestanden of mappen.
 Als een pull request die paden wijzigt, voegt GitHub die code owners automatisch toe als reviewer.
 
-Een vereenvoudigd voorbeeld (zet rollen met meer rechten bij voorkeur achteraan op dezelfde regel):
+Een vereenvoudigd voorbeeld:
 
 ```txt
+docs/ @nl-design-system/documentatie
+
 # Infra-bestanden
 .github/ @nl-design-system/kernteam-maintainer
-
-docs/ @nl-design-system/documentatie
 ```
 
 Met dit voorbeeld vraagt GitHub bij een pull request die bestanden onder `docs/` wijzigt automatisch een review aan bij de gebruikers in het team `@nl-design-system/documentatie`.
 
 :::tip[Praktisch advies]
-Het kan zijn dat een team niet 1-op-1 mapt op de mensen die je als eigenaar wil toewijzen.
+De volgorde is belangrijk; als meerdere regels van toepassing zijn op een wijziging, wordt de laatst matchende regel toegepast.
+Over het algemeen zet je daarom de rollen met meer rechten achteraan.
+
+Het kan zijn dat een team niet 1-op-1 mapt op de mensen die je als eigenaar wilt toewijzen.
 Gebruik in `CODEOWNERS` dan bij voorkeur individuele accounts in plaats van teams.
 
 Gebruik verder comments bij paden waar uit de naamgeving niet direct duidelijk wordt wat de scope is van de bestanden.

--- a/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
+++ b/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
@@ -1,0 +1,70 @@
+---
+title: GitHub teams en code owners
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: GitHub teams en code owners
+pagination_label: GitHub teams en code owners
+description: Het werken met GitHub teams en code owners binnen NL Design System
+slug: /handboek/developer/github-teams-en-code-owners/
+keywords:
+  - GitHub
+  - Teams
+  - Codeowners
+  - Code owners
+---
+
+# GitHub teams en code owners
+
+Binnen NL Design System gebruiken we GitHub teams om verantwoordelijkheden duidelijk te organiseren.
+Hiermee organiseren we wie (schrijf)toegang heeft tot repositories, en weet je snel wie je moet betrekken bij een wijziging, code review of toegangsvraag.
+
+We gebruiken het `CODEOWNERS`-bestand om reviewverzoeken automatisch bij de juiste mensen te laten landen.
+
+## Teams in de praktijk
+
+Over het algemeen hanteren we per organisatie een contributor-team, een maintainer-team en een admin-team.
+
+- `<organisatie>-contributor` - heeft schrijftoegang tot de repository en kan daarmee pull requests indienen
+- `<organisatie>-maintainer` - voor het beoordelen en mergen van pull requests en onderhoudstaken op de repository
+- `<organisatie>-admin` - voor toegangsbeheer van de repository
+
+Op verzoek kunnen voor meer granulariteit meer teams worden aangemaakt, maar bovenstaande is in de meeste gevallen voldoende.
+
+## Lid worden van een team
+
+Een maintainer of een lid van het kernteam kan in de `terraform` infrastructuurrepository een pull request aanmaken.
+Hiervoor is een [handleiding](https://github.com/nl-design-system/terraform/blob/main/docs/adding-users.md) beschikbaar.
+
+De admin van de organisatie wordt gevraagd om de aanvraag goed te keuren, en om te kijken of de lijst van gebruikers in de teams up-to-date is.
+
+## CODEOWNERS
+
+Met `CODEOWNERS` leg je vast welke gebruikers/teams eigenaar zijn van bepaalde bestanden of mappen.
+Deze gebruikers worden automatisch toegevoegd als reviewer als een pull request deze bestanden of mappen wijzigt.
+
+Een vereenvoudigd voorbeeld:
+
+```txt
+# Infra-bestanden
+.github/ @nl-design-system/kernteam-maintainer
+
+docs/ @nl-design-system/documentatie
+```
+
+Met dit voorbeeld, bij een pull request dat bestanden onder `docs/` wijzigt, vraagt GitHub automatisch een review aan bij `@nl-design-system/documentatie`.
+
+:::tip[Praktisch advies]
+Het kan zijn dat een team niet 1-op-1 mapt op de mensen die je als eigenaar wil toewijzen.
+Gebruik in `CODEOWNERS` dan bij voorkeur individuele accounts in plaats van teams.
+
+Gebruik verder comments bij paden waar uit de naamgeving niet direct duidelijk wordt wat de scope is van de bestanden.
+:::
+
+### Review van code owners verplichten
+
+Code owners worden altijd aan pull requests toegevoegd als reviewer.
+Middels een _branch protection rule_ kun je verplichten dat een goedkeuring van één (of meer) code owners nodig is.
+
+Standaard staat deze verplichting uit.
+We raden sterk aan om hier wel gebruik van te maken.
+In de `terraform` infrastructuurrepository is deze functie aan te zetten door in de betreffende `github_repository_ruleset` de regel `rules.pull_requests.require_code_owner_review` op `true` te zetten.

--- a/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
+++ b/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
@@ -45,6 +45,8 @@ De admin moet periodiek controleren dat de toegangsrechten van gebruikers nog kl
 
 Met `CODEOWNERS` leg je vast welke gebruikers of rollen verantwoordelijk zijn voor bepaalde bestanden of mappen.
 Als een pull request die paden wijzigt, voegt GitHub die code owners automatisch toe als reviewer.
+Hiermee worden de juiste mensen gelijk geïnformeerd.
+Als beveiligingslaag kan een accordering van een code owner ook verplicht worden.
 
 Een vereenvoudigd voorbeeld:
 

--- a/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
+++ b/docs/handboek/developer/05-infrastructuur/03-github-teams-en-codeowners.md
@@ -15,34 +15,38 @@ keywords:
 
 # GitHub teams en code owners
 
-Binnen NL Design System gebruiken we GitHub teams om verantwoordelijkheden duidelijk te organiseren.
-Hiermee organiseren we wie (schrijf)toegang heeft tot repositories, en weet je snel wie je moet betrekken bij een wijziging, code review of toegangsvraag.
+Binnen NL Design System gebruiken we rollen om verantwoordelijkheden duidelijk te organiseren.
+In GitHub zijn er teams per organisatie en per rol.
 
-We gebruiken het `CODEOWNERS`-bestand om reviewverzoeken automatisch bij de juiste mensen te laten landen.
+Hiermee organiseren we wie toegang heeft tot repositories, en weet je snel wie toestemming moet geven voor een aanpassing van code of voor een wijziging in toegangsrechten.
 
-## Teams in de praktijk
+We gebruiken het `CODEOWNERS`-bestand om te garanderen dat een code review wordt gevraagd aan de juiste personen, voor wijzigingen aan belangrijke bestanden.
 
-Over het algemeen hanteren we per organisatie een contributor-team, een maintainer-team en een admin-team.
+## Rollen
+
+Over het algemeen is er per organisatie een contributor-team, een maintainer-team en een admin-team.
 
 - `<organisatie>-contributor` - heeft schrijftoegang tot de repository en kan daarmee pull requests indienen
 - `<organisatie>-maintainer` - voor het beoordelen en mergen van pull requests en onderhoudstaken op de repository
 - `<organisatie>-admin` - voor toegangsbeheer van de repository
 
-Op verzoek kunnen voor meer granulariteit meer teams worden aangemaakt, maar bovenstaande is in de meeste gevallen voldoende.
+Op verzoek kunnen extra rollen gebruikt worden, maar de standaard-rollen zijn in de meeste gevallen voldoende.
 
 ## Lid worden van een team
 
-Een maintainer of een lid van het kernteam kan in de `terraform` infrastructuurrepository een pull request aanmaken.
+Wanneer iemand aan een team toegevoegd moet worden, dan moet een maintainer of een admin die wijziging doorvoeren door een pull request aan te maken in de `terraform`-repository.
 Hiervoor is een [handleiding](https://github.com/nl-design-system/terraform/blob/main/docs/adding-users.md) beschikbaar.
 
-De admin van de organisatie wordt gevraagd om de aanvraag goed te keuren, en om te kijken of de lijst van gebruikers in de teams up-to-date is.
+De admin van de organisatie moet de wijzigingen indienen of goedkeuren.
+
+De admin moet periodiek controleren dat de toegangsrechten van gebruikers nog kloppen.
 
 ## CODEOWNERS
 
-Met `CODEOWNERS` leg je vast welke gebruikers/teams eigenaar zijn van bepaalde bestanden of mappen.
-Deze gebruikers worden automatisch toegevoegd als reviewer als een pull request deze bestanden of mappen wijzigt.
+Met `CODEOWNERS` leg je vast welke gebruikers of rollen verantwoordelijk zijn voor bepaalde bestanden of mappen.
+Als een pull request die paden wijzigt, voegt GitHub die code owners automatisch toe als reviewer.
 
-Een vereenvoudigd voorbeeld:
+Een vereenvoudigd voorbeeld (zet rollen met meer rechten bij voorkeur achteraan op dezelfde regel):
 
 ```txt
 # Infra-bestanden
@@ -51,7 +55,7 @@ Een vereenvoudigd voorbeeld:
 docs/ @nl-design-system/documentatie
 ```
 
-Met dit voorbeeld, bij een pull request dat bestanden onder `docs/` wijzigt, vraagt GitHub automatisch een review aan bij `@nl-design-system/documentatie`.
+Met dit voorbeeld vraagt GitHub bij een pull request die bestanden onder `docs/` wijzigt automatisch een review aan bij de gebruikers in het team `@nl-design-system/documentatie`.
 
 :::tip[Praktisch advies]
 Het kan zijn dat een team niet 1-op-1 mapt op de mensen die je als eigenaar wil toewijzen.
@@ -63,7 +67,7 @@ Gebruik verder comments bij paden waar uit de naamgeving niet direct duidelijk w
 ### Review van code owners verplichten
 
 Code owners worden altijd aan pull requests toegevoegd als reviewer.
-Middels een _branch protection rule_ kun je verplichten dat een goedkeuring van één (of meer) code owners nodig is.
+Middels een _branch protection rule_ kun je verplichten dat een goedkeuring van één of meer code owners nodig is.
 
 Standaard staat deze verplichting uit.
 We raden sterk aan om hier wel gebruik van te maken.

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -176,6 +176,7 @@ Redirect 301 "/belangenorganisatie" "/community/belangenorganisaties/aanmelden/"
 
 # Convenience redirects for use in code
 Redirect 301 "/lint-staged" "/linting-en-code-formatting#lint-staged"
+Redirect 301 "/codeowners" "/handboek/developer/github-teams-en-code-owners/#codeowners"
 
 # Convenience redirects because pages have been deleted,  but we have some idea what a helpfull alternative could be
 Redirect 301 "/handboek/developer/architectuur/" "/handboek/developer/introductie/"


### PR DESCRIPTION
[Preview](https://documentatie-git-docs-teams-and-codeowners-nl-design-system.vercel.app/handboek/developer/github-teams-en-code-owners/)