### PR TITLE
ci: retrieve vercel deployment logs for failed vercel builds

### DIFF
--- a/.github/workflows/vercel-deployment-logs.yml
+++ b/.github/workflows/vercel-deployment-logs.yml
@@ -1,0 +1,72 @@
+name: Vercel deployment failure logs
+
+on:
+  deployment_status:
+
+permissions: {}
+
+jobs:
+  fetch-vercel-deployment-logs:
+    if: >-
+      (github.event.deployment_status.state == 'failure' ||
+      github.event.deployment_status.state == 'error') &&
+      github.event.deployment.creator.login == 'vercel[bot]'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: vercel-deployment-logs-${{ github.event.deployment_status.id }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Resolve Vercel deployment URL
+        id: vercel
+        env:
+          LOG_URL: ${{ github.event.deployment_status.log_url }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${LOG_URL}" ]]; then
+            echo "::error::deployment_status.log_url is empty; cannot resolve Vercel deployment URL"
+            exit 1
+          fi
+
+          DEPLOYMENT_URL="${LOG_URL##*/}"
+          DEPLOYMENT_URL="${DEPLOYMENT_URL%%\?*}"
+
+          if [[ -z "${DEPLOYMENT_URL}" ]]; then
+            echo "::error::Could not parse Vercel deployment URL from log_url: ${LOG_URL}"
+            exit 1
+          fi
+
+          echo "deployment_url=${DEPLOYMENT_URL}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved Vercel deployment URL: ${DEPLOYMENT_URL}"
+
+      - name: Fetch Vercel deployment logs
+        id: fetch_logs
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          LOG_BASENAME="vercel-deployment-logs-${{ steps.vercel.outputs.deployment_url }}"
+          FILENAME="${LOG_BASENAME//.vercel.app/}.json"
+          echo "filename=${FILENAME}" >> "${GITHUB_OUTPUT}"
+          curl --fail --show-error --silent \
+            --header "Authorization: Bearer ${VERCEL_TOKEN}" \
+            --header "Accept: application/json" \
+            "https://api.vercel.com/v3/deployments/${{ steps.vercel.outputs.deployment_url }}/events?follow=0&limit=-1" \
+            --output "${FILENAME}"
+
+      - name: Convert Vercel deployment logs to text
+        run: |
+          FILENAME="${{ steps.fetch_logs.outputs.filename }}"
+          TXT_FILENAME="${FILENAME%.json}.txt"
+          jq -r '
+            .[]
+            | select((.text // "") != "")
+            | "[\((.created / 1000 | strftime("%Y-%m-%d %H:%M:%S")))] [\(.type // "log")] \(.text)"
+          ' "${FILENAME}" > "${TXT_FILENAME}"
+
+      - name: Upload Vercel deployment logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vercel-deployment-logs-${{ steps.vercel.outputs.deployment_url }}
+          path: vercel-deployment-logs-*.{json,txt}
+          if-no-files-found: error


### PR DESCRIPTION
Since contributors don't have access to Vercel, but Vercel build failures still block pipelines, it can be hard to debug when something only occurs on Vercel but not in GH or local.  There should be a way to get the logs without having access to Vercel so contributors can debug without 

This workflow detects Vercel deployment failures, retrieves the logs using an API token, and then attaches the logs as an artifact.

It was tested on a hobby project so as to not pollute actions history, so it went through some iterations already:
- Instead of installing `vercel` CLI (requiring either addition to package.json or pinning version in the workflow), calling the API directly
- Since the raw JSON is pretty hard to read, a prettify step was added.  Timestamps and whether it's stdout/stderr is kept.
- Removed "vercel.app" from the resulting logs zip otherwise macOS thinks it's an app

Permissions are minimized but the secret should probably be added in a new, separate "Vercel" environment.

