### PR TITLE
ci: fix upload step in Vercel log pipeline

### DIFF
--- a/.github/workflows/vercel-deployment-logs.yml
+++ b/.github/workflows/vercel-deployment-logs.yml
@@ -19,11 +19,10 @@ jobs:
     steps:
       - name: Resolve Vercel deployment URL
         id: vercel
+        shell: bash
         env:
           LOG_URL: ${{ github.event.deployment_status.log_url }}
         run: |
-          set -euo pipefail
-
           if [[ -z "${LOG_URL}" ]]; then
             echo "::error::deployment_status.log_url is empty; cannot resolve Vercel deployment URL"
             exit 1
@@ -42,6 +41,7 @@ jobs:
 
       - name: Fetch Vercel deployment logs
         id: fetch_logs
+        shell: bash
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
@@ -56,6 +56,7 @@ jobs:
 
       - name: Convert Vercel deployment logs to text
         id: convert_logs
+        shell: bash
         run: |
           JSON_FILENAME="${{ steps.fetch_logs.outputs.filename }}"
           FILENAME="${JSON_FILENAME%.json}.txt"

--- a/.github/workflows/vercel-deployment-logs.yml
+++ b/.github/workflows/vercel-deployment-logs.yml
@@ -55,18 +55,22 @@ jobs:
             --output "${FILENAME}"
 
       - name: Convert Vercel deployment logs to text
+        id: convert_logs
         run: |
-          FILENAME="${{ steps.fetch_logs.outputs.filename }}"
-          TXT_FILENAME="${FILENAME%.json}.txt"
+          JSON_FILENAME="${{ steps.fetch_logs.outputs.filename }}"
+          FILENAME="${JSON_FILENAME%.json}.txt"
+          echo "filename=${FILENAME}" >> "${GITHUB_OUTPUT}"
           jq -r '
             .[]
             | select((.text // "") != "")
             | "[\((.created / 1000 | strftime("%Y-%m-%d %H:%M:%S")))] [\(.type // "log")] \(.text)"
-          ' "${FILENAME}" > "${TXT_FILENAME}"
+          ' "${JSON_FILENAME}" > "${FILENAME}"
 
       - name: Upload Vercel deployment logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vercel-deployment-logs-${{ steps.vercel.outputs.deployment_url }}
-          path: vercel-deployment-logs-*.{json,txt}
+          path: |
+            ${{ steps.fetch_logs.outputs.filename }}
+            ${{ steps.convert_logs.outputs.filename }}
           if-no-files-found: error


### PR DESCRIPTION
Fixes the following error:
https://github.com/nl-design-system/documentatie/actions/runs/26942226407/job/79486249313#step:5:11

- **ci: fix glob when uploading Vercel logs (brace expansion is not supported)**
- **refactor: specify shell (this has "set -eo pipefail" as default)**
