### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,13 +30,6 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -88,13 +81,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -133,13 +119,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,13 +31,6 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/docs/handboek/developer/05-infrastructuur/06-pnpm.mdx
+++ b/docs/handboek/developer/05-infrastructuur/06-pnpm.mdx
@@ -13,9 +13,9 @@ keywords:
 
 import { getMinimumPnpmVersion } from "@site/src/utils";
 
-{/* De volgende user stories vormen de richtlijnen waarop deze pagina is gebaseerd: */}  
-{/* - Als developer wil ik weten welke package manager ik moet gebruiken, zodat mijn code compatible is met NL Design System */}  
-{/* - Als Developer Relations engineer wil ik een link naar documentatie kunnen sturen, zodat mensen de juiste package manager gebruiken */}  
+{/* De volgende user stories vormen de richtlijnen waarop deze pagina is gebaseerd: */}
+{/* - Als developer wil ik weten welke package manager ik moet gebruiken, zodat mijn code compatible is met NL Design System */}
+{/* - Als Developer Relations engineer wil ik een link naar documentatie kunnen sturen, zodat mensen de juiste package manager gebruiken */}
 {/* - Als Vers & Veilig Engineer wil ik dat de community de pnpm versie in hun hele codebase in sync houdt, en dit zoveel mogelijk zelf kan doen */}
 
 # Werken met pnpm
@@ -53,9 +53,9 @@ Gebruik altijd de `corepack` CLI om de versie in `package.json` te upgraden zoda
 Dit is een beveiligingsmaatregel om te verifiëren dat exact dezelfde pnpm-binary wordt gebruikt op elke machine.
 
 ```sh
-# upgraden naar laatste versie in major range
+# upgraden naar laatste versie in de huidige major version range
 corepack up
 
 # of: upgraden naar specifieke versie
-corepack use pnpm@10
+corepack use pnpm@11
 ```

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   ],
   "private": true,
   "license": "EUPL-1.2",
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a",
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "repository": {
     "type": "git+ssh",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -7,12 +7,6 @@
   ],
   "private": true,
   "license": "EUPL-1.2",
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
-  "engines": {
-    "//": "Update @types/node to match the highest node version here",
-    "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
-  },
   "repository": {
     "type": "git+ssh",
     "url": "git@github.com:nl-design-system/documentatie.git",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,13 @@ packages:
   - docs/
   - packages/*
 
+allowBuilds:
+  "@parcel/watcher": true
+  core-js: false
+  core-js-pure: false
+  esbuild: true
+  sharp: true
+
 autoInstallPeers: false
 
 engineStrict: true
@@ -26,6 +33,8 @@ overrides:
 
 patchedDependencies:
   "@rijkshuisstijl-community/card-react": patches/@rijkshuisstijl-community__card-react.patch
+
+provenance: true
 
 saveExact: true
 


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
