### PR TITLE
build: update component progress 1.0.16

### DIFF
--- a/docs/componenten/switch/index.mdx
+++ b/docs/componenten/switch/index.mdx
@@ -41,18 +41,11 @@ import { ComponentIllustration } from "@site/src/components/ComponentIllustratio
 export const title = "Switch";
 export const description = "Invoerveld om een optie aan of uit te zetten, waarbij de actie direct wordt doorgevoerd.";
 export const issueNumber = 33;
-export const relayStep = "help wanted";
 export const componentName = "switch";
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
-
-<ComponentIllustration
-  relayStep={relayStep}
-  description={`Schets van de ${componentName} component`}
-  name={componentName}
-/>
 
 ## Definition of Done
 

--- a/docs/componenten/tabs/index.mdx
+++ b/docs/componenten/tabs/index.mdx
@@ -43,18 +43,11 @@ import { ComponentIllustration } from "@site/src/components/ComponentIllustratio
 export const title = "Tabs";
 export const description = "Paneel om onderwerpen te groeperen, waarbij er maar één per keer zichtbaar is, met buttons om te kiezen welk onderwerp wordt weergegeven.";
 export const issueNumber = 51;
-export const relayStep = "help wanted";
 export const componentName = "tabs";
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
-
-<ComponentIllustration
-  relayStep={relayStep}
-  description={`Schets van de ${componentName} component`}
-  name={componentName}
-/>
 
 ## Definition of Done
 

--- a/docs/componenten/task-navigation/index.mdx
+++ b/docs/componenten/task-navigation/index.mdx
@@ -36,18 +36,11 @@ import { ComponentIllustration } from "@site/src/components/ComponentIllustratio
 export const title = "Task Navigation";
 export const description = "Overzicht van één of meerdere taken die aandacht nodig hebben, met een link om de taak uit te voeren.";
 export const issueNumber = 350;
-export const relayStep = "help wanted";
 export const componentName = "task-navigation";
 
 export const component = componentProgress.find((item) => item.number === issueNumber);
 
 <Introduction component={component} headingLevel={1} description={description} />
-
-<ComponentIllustration
-  relayStep={relayStep}
-  description={`Schets van de ${componentName} component`}
-  name={componentName}
-/>
 
 ## Definition of Done
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@nl-design-system-unstable/documentation": "workspace:*",
     "@nl-design-system-unstable/nlds-design-tokens": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "3.4.0",
-    "@nl-design-system/component-progress": "1.0.15",
+    "@nl-design-system/component-progress": "1.0.16",
     "@nl-design-system/eslint-config": "1.0.0",
     "@persoonlijke-regelingen-assistent/components-react": "1.0.0-alpha.152",
     "@playwright/test": "1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         specifier: 3.4.0
         version: 3.4.0
       '@nl-design-system/component-progress':
-        specifier: 1.0.15
-        version: 1.0.15
+        specifier: 1.0.16
+        version: 1.0.16
       '@nl-design-system/eslint-config':
         specifier: 1.0.0
         version: 1.0.0(eslint@9.39.2(jiti@1.21.0))(typescript@5.9.3)
@@ -3585,8 +3585,8 @@ packages:
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.4.0':
     resolution: {integrity: sha512-Ax1JW5KSUJUnfkFVDwzPHvpD61HMirn6Kp2Gu5QkHIEqwLjkD6P3/dtwKMJZq8dUGzoP/9XwMNcugLhB7Z0Qlg==}
 
-  '@nl-design-system/component-progress@1.0.15':
-    resolution: {integrity: sha512-lUDd6HIJUGrU9/mS1/iXe4aikP4jZ/B0IIV0Rm3bOoEuyLAnw+B+tPESSvLg/WAyBuqTR8xDJ5N1DEyHuLrGxA==}
+  '@nl-design-system/component-progress@1.0.16':
+    resolution: {integrity: sha512-KngVOlfY6Puvk6+lFdSMsUrLNt00aoaHD92o/MBk5kShp/hmfR/+u6PMZcgWU3lJKE/vcpy0jKi1/kLh99u18A==}
 
   '@nl-design-system/component-progress@1.0.7':
     resolution: {integrity: sha512-yhJVnQPcrEJcOWTq06eSVx7AsimvJj6OilVfC9mQXKH8X31MuWzIg5cyQBlTZ6u8f4QtXu2jKGeb738nNE+kEw==}
@@ -15952,7 +15952,7 @@ snapshots:
 
   '@nl-design-system-unstable/voorbeeld-design-tokens@3.4.0': {}
 
-  '@nl-design-system/component-progress@1.0.15': {}
+  '@nl-design-system/component-progress@1.0.16': {}
 
   '@nl-design-system/component-progress@1.0.7': {}
 


### PR DESCRIPTION
This PR will update the component progress to version 1.0.16.

Removes ComponentIllustration from Help Wanted Components that are now Community Components. (Only Switch, Tabs and Task Navigation had them). Since those are only for Help Wanted.

Switch https://documentatie-git-build-update-component-de5b64-nl-design-system.vercel.app/switch/
Task Navigation https://documentatie-git-build-update-component-de5b64-nl-design-system.vercel.app/task-navigation/
Page Layout https://documentatie-git-build-update-component-de5b64-nl-design-system.vercel.app/page-layout/
Page Body https://documentatie-git-build-update-component-de5b64-nl-design-system.vercel.app/page-body/
Tabs https://documentatie-git-build-update-component-de5b64-nl-design-system.vercel.app/tabs/