### PR TITLE
docs: splits alle basis token definities in losse secties

### DIFF
--- a/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
@@ -26,10 +26,12 @@ export const colorSection = (...keys) => ({
 
 # Alle basis-tokens
 
-Op deze pagina vind je een overzicht van alle beschikbare basis-tokens, inclusief de mogelijkheid om deze te kopiëren als JSON of CSS.
+Op deze pagina vind je een overzicht van alle beschikbare basis-tokens.
 
-- [Meer informatie over basis-tokens](/handboek/huisstijl/basis-tokens)
-- [Changelog van basis tokens](https://github.com/nl-design-system/themes/blob/main/packages/basis-design-tokens/CHANGELOG.md)
+Elk onderdeel heeft de mogelijkheid om deze te kopiëren als JSON of CSS. Gebruik dit om de tokens te definiëren in Tokens Studio of in CSS.
+
+- [Introductie van basis-tokens](/handboek/huisstijl/basis-tokens)
+- [Changelog van basis tokens (op GitHub)](https://github.com/nl-design-system/themes/blob/main/packages/basis-design-tokens/CHANGELOG.md)
 
 ## Kleuren
 

--- a/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
@@ -18,11 +18,155 @@ keywords:
 import tokens from "@nl-design-system-unstable/basis-design-tokens/src/tokens.json";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 
+TODO: link naar changelog
+
 # Alle basis-tokens
 
 Op deze pagina vind je een overzicht van alle beschikbare basis-tokens, inclusief de mogelijkheid om deze te kopiëren als JSON of CSS.
 
-[Meer informatie over basis-tokens](/handboek/huisstijl/basis-tokens)
+- [Meer informatie over basis-tokens](/handboek/huisstijl/basis-tokens)
+- [Changelog van basis tokens](https://github.com/nl-design-system/themes/blob/main/packages/basis-design-tokens/CHANGELOG.md)
+
+## Kleuren
+
+### Transparant
+
+<DesignTokens tokens={{ basis: { color: { transparent: tokens.basis.color.transparent } } }} />
+
+### Default
+
+<DesignTokens tokens={{ basis: { color: { default: tokens.basis.color["default"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "default-inverse": tokens.basis.color["default-inverse"] } } }} />
+
+### Accent 1
+
+<DesignTokens tokens={{ basis: { color: { "accent-1": tokens.basis.color["accent-1"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "accent-1-inverse": tokens.basis.color["accent-1-inverse"] } } }} />
+
+### Accent 2
+
+<DesignTokens tokens={{ basis: { color: { "accent-2": tokens.basis.color["accent-2"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "accent-2-inverse": tokens.basis.color["accent-2-inverse"] } } }} />
+
+### Accent 3
+
+<DesignTokens tokens={{ basis: { color: { "accent-3": tokens.basis.color["accent-3"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "accent-3-inverse": tokens.basis.color["accent-3-inverse"] } } }} />
+
+### Action 1
+
+<DesignTokens tokens={{ basis: { color: { "action-1": tokens.basis.color["action-1"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "action-1-inverse": tokens.basis.color["action-1-inverse"] } } }} />
+
+### Action 2
+
+<DesignTokens tokens={{ basis: { color: { "action-2": tokens.basis.color["action-2"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "action-2-inverse": tokens.basis.color["action-2-inverse"] } } }} />
+
+### Disabled
+
+<DesignTokens tokens={{ basis: { color: { disabled: tokens.basis.color["disabled"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "disabled-inverse": tokens.basis.color["disabled-inverse"] } } }} />
+
+### Highlight
+
+<DesignTokens tokens={{ basis: { color: { highlight: tokens.basis.color["highlight"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "highlight-inverse": tokens.basis.color["highlight-inverse"] } } }} />
+
+### Info
+
+<DesignTokens tokens={{ basis: { color: { info: tokens.basis.color["info"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "info-inverse": tokens.basis.color["info-inverse"] } } }} />
+
+### Negative
+
+<DesignTokens tokens={{ basis: { color: { negative: tokens.basis.color["negative"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "negative-inverse": tokens.basis.color["negative-inverse"] } } }} />
+
+### Positive
+
+<DesignTokens tokens={{ basis: { color: { positive: tokens.basis.color["positive"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "positive-inverse": tokens.basis.color["positive-inverse"] } } }} />
+
+### Warning
+
+<DesignTokens tokens={{ basis: { color: { warning: tokens.basis.color["warning"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "warning-inverse": tokens.basis.color["warning-inverse"] } } }} />
+
+### Selected
+
+<DesignTokens tokens={{ basis: { color: { selected: tokens.basis.color["selected"] } } }} />
+<DesignTokens tokens={{ basis: { color: { "selected-inverse": tokens.basis.color["selected-inverse"] } } }} />
+
+## Text
+
+<DesignTokens tokens={{ basis: { text: tokens.basis.text } }} />
+
+### Heading
+
+<DesignTokens tokens={{ basis: { heading: tokens.basis.heading } }} />
+
+## Space
+
+### None
+
+<DesignTokens tokens={{ basis: { space: { none: tokens.basis.space.none } } }} />
+
+### Block
+
+<DesignTokens tokens={{ basis: { space: { block: tokens.basis.space.block } } }} />
+
+### Inline
+
+<DesignTokens tokens={{ basis: { space: { inline: tokens.basis.space.inline } } }} />
+
+### Row
+
+<DesignTokens tokens={{ basis: { space: { row: tokens.basis.space.row } } }} />
+
+### Column
+
+<DesignTokens tokens={{ basis: { space: { column: tokens.basis.space.column } } }} />
+
+## Size
+
+<DesignTokens tokens={{ basis: { size: tokens.basis.size } }} />
+
+## Page
+
+<DesignTokens tokens={{ basis: { page: tokens.basis.page } }} />
+
+## Border
+
+### Border breedte
+
+<DesignTokens tokens={{ basis: { "border-width": tokens.basis["border-width"] } }} />
+
+### Border radius
+
+<DesignTokens tokens={{ basis: { "border-radius": tokens.basis["border-radius"] } }} />
+
+## Shadow
+
+<DesignTokens tokens={{ basis: { "box-shadow": tokens.basis["box-shadow"] } }} />
+
+## Form control
+
+<DesignTokens tokens={{ basis: { "form-control": tokens.basis["form-control"] } }} />
+
+## Focus
+
+<DesignTokens tokens={{ basis: { focus: tokens.basis["focus"] } }} />
+
+## Pointer target
+
+<DesignTokens tokens={{ basis: { "pointer-target": tokens.basis["pointer-target"] } }} />
+
+## Action
+
+<DesignTokens tokens={{ basis: { action: tokens.basis["action"] } }} />
+
+## Alle tokens
 
 <DesignTokens tokens={tokens} />
 

--- a/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/basis-tokens/alle-basis-tokens.mdx
@@ -18,7 +18,11 @@ keywords:
 import tokens from "@nl-design-system-unstable/basis-design-tokens/src/tokens.json";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 
-TODO: link naar changelog
+export const colorSection = (...keys) => ({
+  basis: {
+    color: Object.fromEntries(keys.map((k) => [k, tokens.basis.color[k]])),
+  },
+});
 
 # Alle basis-tokens
 
@@ -31,72 +35,59 @@ Op deze pagina vind je een overzicht van alle beschikbare basis-tokens, inclusie
 
 ### Transparant
 
-<DesignTokens tokens={{ basis: { color: { transparent: tokens.basis.color.transparent } } }} />
+<DesignTokens tokens={colorSection("transparent")} />
 
 ### Default
 
-<DesignTokens tokens={{ basis: { color: { default: tokens.basis.color["default"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "default-inverse": tokens.basis.color["default-inverse"] } } }} />
+<DesignTokens tokens={colorSection("default", "default-inverse")} />
 
 ### Accent 1
 
-<DesignTokens tokens={{ basis: { color: { "accent-1": tokens.basis.color["accent-1"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "accent-1-inverse": tokens.basis.color["accent-1-inverse"] } } }} />
+<DesignTokens tokens={colorSection("accent-1", "accent-1-inverse")} />
 
 ### Accent 2
 
-<DesignTokens tokens={{ basis: { color: { "accent-2": tokens.basis.color["accent-2"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "accent-2-inverse": tokens.basis.color["accent-2-inverse"] } } }} />
+<DesignTokens tokens={colorSection("accent-2", "accent-2-inverse")} />
 
 ### Accent 3
 
-<DesignTokens tokens={{ basis: { color: { "accent-3": tokens.basis.color["accent-3"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "accent-3-inverse": tokens.basis.color["accent-3-inverse"] } } }} />
+<DesignTokens tokens={colorSection("accent-3", "accent-3-inverse")} />
 
 ### Action 1
 
-<DesignTokens tokens={{ basis: { color: { "action-1": tokens.basis.color["action-1"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "action-1-inverse": tokens.basis.color["action-1-inverse"] } } }} />
+<DesignTokens tokens={colorSection("action-1", "action-1-inverse")} />
 
 ### Action 2
 
-<DesignTokens tokens={{ basis: { color: { "action-2": tokens.basis.color["action-2"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "action-2-inverse": tokens.basis.color["action-2-inverse"] } } }} />
+<DesignTokens tokens={colorSection("action-2", "action-2-inverse")} />
 
 ### Disabled
 
-<DesignTokens tokens={{ basis: { color: { disabled: tokens.basis.color["disabled"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "disabled-inverse": tokens.basis.color["disabled-inverse"] } } }} />
+<DesignTokens tokens={colorSection("disabled", "disabled-inverse")} />
 
 ### Highlight
 
-<DesignTokens tokens={{ basis: { color: { highlight: tokens.basis.color["highlight"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "highlight-inverse": tokens.basis.color["highlight-inverse"] } } }} />
+<DesignTokens tokens={colorSection("highlight", "highlight-inverse")} />
 
 ### Info
 
-<DesignTokens tokens={{ basis: { color: { info: tokens.basis.color["info"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "info-inverse": tokens.basis.color["info-inverse"] } } }} />
+<DesignTokens tokens={colorSection("info", "info-inverse")} />
 
 ### Negative
 
-<DesignTokens tokens={{ basis: { color: { negative: tokens.basis.color["negative"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "negative-inverse": tokens.basis.color["negative-inverse"] } } }} />
+<DesignTokens tokens={colorSection("negative", "negative-inverse")} />
 
 ### Positive
 
-<DesignTokens tokens={{ basis: { color: { positive: tokens.basis.color["positive"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "positive-inverse": tokens.basis.color["positive-inverse"] } } }} />
+<DesignTokens tokens={colorSection("positive", "positive-inverse")} />
 
 ### Warning
 
-<DesignTokens tokens={{ basis: { color: { warning: tokens.basis.color["warning"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "warning-inverse": tokens.basis.color["warning-inverse"] } } }} />
+<DesignTokens tokens={colorSection("warning", "warning-inverse")} />
 
 ### Selected
 
-<DesignTokens tokens={{ basis: { color: { selected: tokens.basis.color["selected"] } } }} />
-<DesignTokens tokens={{ basis: { color: { "selected-inverse": tokens.basis.color["selected-inverse"] } } }} />
+<DesignTokens tokens={colorSection("selected", "selected-inverse")} />
 
 ## Text
 

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -5,7 +5,6 @@ import prettier from 'prettier/standalone';
 import type { ButtonHTMLAttributes } from 'react';
 import { IconCopy } from '@tabler/icons-react';
 import { Button } from '@utrecht/component-library-react/dist/css-module';
-import { Icon } from '@utrecht/component-library-react';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   language: 'json' | 'css';
@@ -28,11 +27,8 @@ export function CopyButton({ children, content, language }: Props) {
   if (!('clipboard' in navigator)) return null;
 
   return (
-    <Button type="button" appearance="secondary-action-button" onClick={onClick}>
+    <Button type="button" appearance="secondary-action-button" onClick={onClick} icon={<IconCopy />}>
       {children}
-      <Icon>
-        <IconCopy />
-      </Icon>
     </Button>
   );
 }

--- a/src/components/DesignTokens.tsx
+++ b/src/components/DesignTokens.tsx
@@ -59,6 +59,15 @@ export function DesignTokens({ tokens }: Props) {
 
   return (
     <>
+      <ActionGroup>
+        <CopyButton content={jsonString} language="json">
+          Kopieer als JSON
+        </CopyButton>
+        <CopyButton content={cssCustomPropertiesString} language="css">
+          Kopieer als CSS
+        </CopyButton>
+      </ActionGroup>
+
       <Table>
         <TableHeader>
           <TableRow>
@@ -88,15 +97,6 @@ export function DesignTokens({ tokens }: Props) {
           })}
         </TableBody>
       </Table>
-
-      <ActionGroup>
-        <CopyButton content={jsonString} language="json">
-          Kopieer als JSON
-        </CopyButton>
-        <CopyButton content={cssCustomPropertiesString} language="css">
-          Kopieer als CSS
-        </CopyButton>
-      </ActionGroup>
     </>
   );
 }


### PR DESCRIPTION
test url: https://documentatie-git-docs-split-basis-tokens-nl-design-system.vercel.app/handboek/huisstijl/basis-tokens/alle-basis-tokens/

- 1 sectie per token type, subsecties voor kleuren
- kopieer-buttons bovenaan de tabellen geplaatst op verzoek van Jeffrey
- kopieer-icoon verplaatst naar 'officiele' utrecht-button slot voor `icon` ipv hand-rolled, fixt icon alignment


voor:
<img width="200" height="67" alt="Screenshot 2026-06-23 at 14 36 26" src="https://github.com/user-attachments/assets/b12916b4-baf2-4bd8-8d64-66d21f482b14" />

na:
<img width="212" height="75" alt="Screenshot 2026-06-23 at 14 36 10" src="https://github.com/user-attachments/assets/0487e612-82cf-40c2-bab5-49a93b2d7b12" />
