### PR TITLE
ci: harden Vercel logs workflow

### DIFF
--- a/.github/workflows/vercel-deployment-logs.yml
+++ b/.github/workflows/vercel-deployment-logs.yml
@@ -10,7 +10,8 @@ jobs:
     if: >-
       (github.event.deployment_status.state == 'failure' ||
       github.event.deployment_status.state == 'error') &&
-      github.event.deployment.creator.login == 'vercel[bot]'
+      github.event.deployment.creator.login == 'vercel[bot]' &&
+      github.event.deployment_status.creator.login == 'vercel[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: vercel-deployment-logs-${{ github.event.deployment_status.id }}

--- a/.github/workflows/vercel-deployment-logs.yml
+++ b/.github/workflows/vercel-deployment-logs.yml
@@ -36,7 +36,12 @@ jobs:
             exit 1
           fi
 
-          DEPLOYMENT_NAME="${DEPLOYMENT_URL//.vercel.app/}"
+          if [[ ! "${DEPLOYMENT_URL}" =~ ^[a-z0-9-]+[a-z0-9.-]*$ ]]; then
+            echo "::error::Invalid Vercel deployment URL: ${DEPLOYMENT_URL}"
+            exit 1
+          fi
+
+          DEPLOYMENT_NAME="${DEPLOYMENT_URL%.vercel.app}"
           echo "deployment_url=${DEPLOYMENT_URL}" >> "${GITHUB_OUTPUT}"
           echo "deployment_name=${DEPLOYMENT_NAME}" >> "${GITHUB_OUTPUT}"
           echo "Resolved Vercel deployment URL: ${DEPLOYMENT_URL}"


### PR DESCRIPTION
- **ci: only run when both deployment and status were created by `vercel[bot]`**
- **ci: ensure deployment url does not contain slashes or unsafe characters**
