### PR TITLE
fix: automatic trailing slash breaks links to files

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,6 +1,6 @@
 import type { Props } from '@docusaurus/Link';
 import { clsx } from 'clsx';
-
+import { hasFileExtension } from '../utils';
 import type { PropsWithChildren } from 'react';
 
 /**
@@ -15,8 +15,11 @@ export const BareLink = ({ children, ...props }: PropsWithChildren<Props>) => {
 
   // Internal link
   if (url.origin === 'https://nldesignsystem.nl') {
-    // add trailing slash
-    url.pathname = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
+    // guarantee trailing slash if it is a pathname without file extension
+    // (e.g. /docs/index/ or /docs/index vs /docs/index.html or /docs/file.ics)
+    if (!url.pathname.endsWith('/') && !hasFileExtension(url.pathname)) {
+      url.pathname = `${url.pathname}/`;
+    }
 
     // keep internal links relative
     dest = url.toString().replace('https://nldesignsystem.nl', '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,7 +246,7 @@ export const getMinimumNodeVersion = () => {
   return version.replace(/^[\^~>=<]+/, '');
 };
 
-const FILE_EXTENSIONS = new Set(['html', 'htm', 'ics', 'json', 'pdf']);
+const FILE_EXTENSIONS = new Set(['ics', 'json', 'pdf']);
 
 export const hasFileExtension = (pathname: string): boolean => {
   const lastSegment = pathname.split('/').pop() ?? '';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,3 +245,12 @@ export const getMinimumNodeVersion = () => {
   // Handle simple prefixes like "^18.0.0", "~18.0.0", ">=18.0.0"
   return version.replace(/^[\^~>=<]+/, '');
 };
+
+const FILE_EXTENSIONS = new Set(['html', 'htm', 'ics', 'json', 'pdf']);
+
+export const hasFileExtension = (pathname: string): boolean => {
+  const lastSegment = pathname.split('/').pop() ?? '';
+  const extension = lastSegment.split('.').pop()?.toLowerCase();
+
+  return extension !== undefined && FILE_EXTENSIONS.has(extension);
+};


### PR DESCRIPTION
Originally occured when switching Docusaurus Link to our own Link in https://github.com/nl-design-system/documentatie/commit/8a37c1dbe2c718b5b2fe09535c3adc23ee795a82

Fixed allowed FILE_EXTENSIONS are more secure than a regex that checks for a period, since those might be possible in routing

Preview: https://documentatie-git-fix-automatic-trailing-1fc39e-nl-design-system.vercel.app/
Bedanktpagina met ICS bestand: https://documentatie-git-fix-automatic-trailing-1fc39e-nl-design-system.vercel.app/community/community-sprints/mijn-services-community/aanmelden/bedankt