### PR TITLE
fix: create patches to remove style elements from denhaag packages

### DIFF
--- a/patches/@gemeente-denhaag__iconbutton@3.1.0.patch
+++ b/patches/@gemeente-denhaag__iconbutton@3.1.0.patch
@@ -1,0 +1,56 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 3babfb3c363c8bbead51685b4533ab99d3adf425..6f5cab5c3779049456d07497d757a0f12f83f76d 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -42,22 +42,8 @@ typeof SuppressedError === "function" ? SuppressedError : function (error, suppr
+     var e = new Error(message);
+     return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+ };var css_248z = ".denhaag-icon-button{appearance:none;background-color:transparent;border:0;border-radius:0;color:var(--denhaag-icon-button-color);cursor:pointer;display:inline-flex;outline:0;padding-block-end:var(--denhaag-icon-button-padding-block-end);padding-block-start:var(--denhaag-icon-button-padding-block-start);padding-inline-end:var(--denhaag-icon-button-padding-inline-end);padding-inline-start:var(--denhaag-icon-button-padding-inline-start)}.denhaag-icon-button--hover,.denhaag-icon-button:hover{color:var(--denhaag-icon-button-hover-color)}.denhaag-icon-button--focus,.denhaag-icon-button:focus-visible{color:var(--denhaag-icon-button-focus-color);outline-color:var(--denhaag-icon-button-focus-outline-color);outline-offset:var(--denhaag-icon-button-focus-outline-offset);outline-style:var(--denhaag-icon-button-focus-outline-style);outline-width:var(--denhaag-icon-button-focus-outline-width)}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }/**
+  * Displays a Button with an Icon as content.
+  * @param props The properties of an IconButton component.
+diff --git a/dist/mjs/index.js b/dist/mjs/index.js
+index 2f9191a27370d23148da8eceb5c45740295b43b2..7d5481e5403419a215fc59ef293497e0b7e7ddec 100644
+--- a/dist/mjs/index.js
++++ b/dist/mjs/index.js
+@@ -42,22 +42,8 @@ typeof SuppressedError === "function" ? SuppressedError : function (error, suppr
+     var e = new Error(message);
+     return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+ };var css_248z = ".denhaag-icon-button{appearance:none;background-color:transparent;border:0;border-radius:0;color:var(--denhaag-icon-button-color);cursor:pointer;display:inline-flex;outline:0;padding-block-end:var(--denhaag-icon-button-padding-block-end);padding-block-start:var(--denhaag-icon-button-padding-block-start);padding-inline-end:var(--denhaag-icon-button-padding-inline-end);padding-inline-start:var(--denhaag-icon-button-padding-inline-start)}.denhaag-icon-button--hover,.denhaag-icon-button:hover{color:var(--denhaag-icon-button-hover-color)}.denhaag-icon-button--focus,.denhaag-icon-button:focus-visible{color:var(--denhaag-icon-button-focus-color);outline-color:var(--denhaag-icon-button-focus-outline-color);outline-offset:var(--denhaag-icon-button-focus-outline-offset);outline-style:var(--denhaag-icon-button-focus-outline-style);outline-width:var(--denhaag-icon-button-focus-outline-width)}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }/**
+  * Displays a Button with an Icon as content.
+  * @param props The properties of an IconButton component.

--- a/patches/@gemeente-denhaag__icons@4.0.1.patch
+++ b/patches/@gemeente-denhaag__icons@4.0.1.patch
@@ -1,0 +1,56 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index e7eebf4f4e06c6a15b75da64bcf26cc200739d5e..036ab7670769a74ca09b923d38ced234eb987c22 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -48,22 +48,8 @@ typeof SuppressedError === "function" ? SuppressedError : function (error, suppr
+     var Component = component;
+     return (React.createElement(Component, __assign({ className: iconClassName, focusable: focusable, "aria-hidden": (_b = props['aria-hidden']) !== null && _b !== void 0 ? _b : true, shapeRendering: shapeRendering }, props), props.children));
+ };var css_248z = ".denhaag-icon{fill:currentColor;display:inline-block;flex-shrink:0;font-size:1.5rem;height:1em;transition:fill .2s cubic-bezier(.4,0,.2,1) 0ms;width:1em}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }var _path$$;
+ function _extends$12() { return _extends$12 = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends$12.apply(null, arguments); }
+ var SvgArrowLeft = function SvgArrowLeft(props) {
+diff --git a/dist/mjs/index.js b/dist/mjs/index.js
+index b8085bb733b9c2f6e8ee8dafbe13862cf41ca5d3..4efbd21b8bd8ab58b8e35f15b2b7f872921fd0a0 100644
+--- a/dist/mjs/index.js
++++ b/dist/mjs/index.js
+@@ -48,22 +48,8 @@ typeof SuppressedError === "function" ? SuppressedError : function (error, suppr
+     var Component = component;
+     return (React__default.createElement(Component, __assign({ className: iconClassName, focusable: focusable, "aria-hidden": (_b = props['aria-hidden']) !== null && _b !== void 0 ? _b : true, shapeRendering: shapeRendering }, props), props.children));
+ };var css_248z = ".denhaag-icon{fill:currentColor;display:inline-block;flex-shrink:0;font-size:1.5rem;height:1em;transition:fill .2s cubic-bezier(.4,0,.2,1) 0ms;width:1em}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }var _path$$;
+ function _extends$12() { return _extends$12 = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends$12.apply(null, arguments); }
+ var SvgArrowLeft = function SvgArrowLeft(props) {

--- a/patches/@gemeente-denhaag__number-badge@2.1.0.patch
+++ b/patches/@gemeente-denhaag__number-badge@2.1.0.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 6ca5f45cfb0490dd362ab56ee099b7cd132fb717..ac0d4ac5f465a13caecdc3d20784352bda064512 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -95,20 +95,6 @@ var NumberBadge = /*#__PURE__*/react.forwardRef(function NumberBadge(props, ref)
+   }));
+ });
+ NumberBadge.displayName = 'NumberBadge';var css_248z = ".nl-number-badge{align-items:center;background-color:var(--nl-number-badge-background-color);border-color:var(--nl-number-badge-border-color);border-radius:var(--nl-number-badge-border-radius);border-style:solid;border-width:var(--nl-number-badge-border-width,1px);box-sizing:border-box;color:var(--nl-number-badge-color);display:inline-flex;font-family:var(--nl-number-badge-font-family);font-size:max(var(--nl-number-badge-font-size),1rem);font-style:normal;font-variant-numeric:lining-nums tabular-nums;font-weight:var(--nl-number-badge-font-weight);justify-content:center;line-height:1;max-block-size:max-content;max-inline-size:max-content;min-block-size:var(--nl-number-badge-min-block-size);min-inline-size:var(--nl-number-badge-min-inline-size);padding-block:var(--nl-number-badge-padding-block);padding-inline:var(--nl-number-badge-padding-inline);white-space:nowrap}.nl-number-badge__hidden-label{block-size:1px!important;border:0!important;clip-path:inset(50%)!important;inline-size:1px!important;margin:-1px!important;overflow:hidden!important;padding:0!important;position:absolute!important;white-space:nowrap!important}.nl-number-badge__visible-label{display:inline}@media screen and (forced-colors:active){.nl-number-badge{border-color:currentColor!important;border-width:max(var(--nl-number-badge-min-border-width,0),1px)!important;color:currentColor!important}}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }exports.NumberBadge=NumberBadge;//# sourceMappingURL=index.js.map
+diff --git a/dist/mjs/index.js b/dist/mjs/index.js
+index 80ececfb137c7746d99b845bfa74183e341e1241..78d0285857427db3016458c3231a911708564ac1 100644
+--- a/dist/mjs/index.js
++++ b/dist/mjs/index.js
+@@ -95,20 +95,6 @@ var NumberBadge = /*#__PURE__*/forwardRef(function NumberBadge(props, ref) {
+   }));
+ });
+ NumberBadge.displayName = 'NumberBadge';var css_248z = ".nl-number-badge{align-items:center;background-color:var(--nl-number-badge-background-color);border-color:var(--nl-number-badge-border-color);border-radius:var(--nl-number-badge-border-radius);border-style:solid;border-width:var(--nl-number-badge-border-width,1px);box-sizing:border-box;color:var(--nl-number-badge-color);display:inline-flex;font-family:var(--nl-number-badge-font-family);font-size:max(var(--nl-number-badge-font-size),1rem);font-style:normal;font-variant-numeric:lining-nums tabular-nums;font-weight:var(--nl-number-badge-font-weight);justify-content:center;line-height:1;max-block-size:max-content;max-inline-size:max-content;min-block-size:var(--nl-number-badge-min-block-size);min-inline-size:var(--nl-number-badge-min-inline-size);padding-block:var(--nl-number-badge-padding-block);padding-inline:var(--nl-number-badge-padding-inline);white-space:nowrap}.nl-number-badge__hidden-label{block-size:1px!important;border:0!important;clip-path:inset(50%)!important;inline-size:1px!important;margin:-1px!important;overflow:hidden!important;padding:0!important;position:absolute!important;white-space:nowrap!important}.nl-number-badge__visible-label{display:inline}@media screen and (forced-colors:active){.nl-number-badge{border-color:currentColor!important;border-width:max(var(--nl-number-badge-min-border-width,0),1px)!important;color:currentColor!important}}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }export{NumberBadge};//# sourceMappingURL=index.js.map

--- a/patches/@gemeente-denhaag__side-navigation@4.1.0.patch
+++ b/patches/@gemeente-denhaag__side-navigation@4.1.0.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index fe502fcbc43ace133c9d99297dd8dfcf38a3bc09..f02167b7378deb7ab2c54159db57d6d85ea093f7 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -1,20 +1,6 @@
+ 'use strict';var React=require('react'),clsx=require('clsx'),iconbutton=require('@gemeente-denhaag/iconbutton'),icons=require('@gemeente-denhaag/icons'),numberBadge=require('@gemeente-denhaag/number-badge');var css_248z = ".denhaag-side-navigation{display:var(--denhaag-side-navigation-display);flex-direction:var(--denhaag-side-navigation-flex-direction);min-width:var(--denhaag-side-navigation-min-width);row-gap:var(--denhaag-side-navigation-row-gap)}@media (width <= 1023px){.denhaag-side-navigation{display:var(--denhaag-side-navigation-mobile-display)}}.denhaag-side-navigation__list{list-style:none;margin-block-end:0;margin-block-start:0;padding-block-end:0;padding-block-start:0;padding-inline-start:0}.denhaag-side-navigation__item{align-items:center;display:flex;flex-direction:row;font-family:var(--denhaag-side-navigation-item-font-family,sans-serif);font-size:var(--denhaag-side-navigation-item-font-size);font-weight:var(--denhaag-side-navigation-item-font-weight,normal);line-height:1.5}.denhaag-side-navigation__item:has(>.denhaag-side-navigation__list){flex-wrap:wrap}.denhaag-side-navigation__item>.denhaag-side-navigation__list{flex-basis:100%;margin-inline-start:var(--denhaag-side-navigation-list-margin-inline-start)}.denhaag-side-navigation__tree-item-label-wrapper{align-items:center;display:flex;flex-basis:100%;flex-direction:row}.denhaag-side-navigation__link{align-items:center;color:var(--denhaag-side-navigation-link-color);column-gap:16px;display:flex;flex-direction:row;flex-grow:1;padding-block-end:var(--denhaag-side-navigation-link-padding-block-end);padding-block-start:var(--denhaag-side-navigation-link-padding-block-start);text-decoration:none}.denhaag-side-navigation__link-label{align-items:center;display:flex;gap:var(--denhaag-side-navigation-link-label-gap)}.denhaag-side-navigation__link--hover,.denhaag-side-navigation__link:hover{color:var(--denhaag-side-navigation-link-hover-color);cursor:pointer}.denhaag-side-navigation__link--focus,.denhaag-side-navigation__link:focus-visible{outline:var(--denhaag-focus-border)}.denhaag-side-navigation__link--current{color:var(--denhaag-side-navigation-link-active-color);font-weight:var(--denhaag-side-navigation-link-active-font-weight)}.denhaag-side-navigation__expand-button{align-items:center;block-size:var(--denhaag-side-navigation-expand-button-inline-size);display:inline-flex;inline-size:var(--denhaag-side-navigation-expand-button-inline-size);justify-content:center;transform:var(--denhaag-side-navigation-expand-button-transform,rotate(0deg));transition:var(--denhaag-side-navigation-expand-button-transition,\"transform 200ms ease-in-out\")}@media (prefers-reduced-motion){.denhaag-side-navigation__expand-button{transition:none}}.denhaag-side-navigation__expand-button--expanded,.denhaag-side-navigation__expand-button[aria-expanded=true]{transform:var(--denhaag-side-navigation-expand-button-expanded-transform,rotate(180deg))}.denhaag-side-navigation__expand-separator{background-color:currentColor;color:var(--denhaag-side-navigation-expand-separator-color);display:inline-block;flex-shrink:0;inline-size:var(--denhaag-side-navigation-expand-separator-inline-size,1px);margin-inline-end:var(--denhaag-side-navigation-expand-separator-margin-block-end,8px);margin-inline-start:var(--denhaag-side-navigation-expand-separator-margin-block-start,8px);padding-block-end:var(--denhaag-side-navigation-expand-separator-padding-block-end,8px);padding-block-start:var(--denhaag-side-navigation-expand-separator-padding-block-start,8px)}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }/******************************************************************************
+ Copyright (c) Microsoft Corporation.
+ 
+diff --git a/dist/mjs/index.js b/dist/mjs/index.js
+index 12607aa888987a5d93dc1cf1a2ee835f49347f0d..e145f62d60530722c7f9d6d5259117ab6cc80a50 100644
+--- a/dist/mjs/index.js
++++ b/dist/mjs/index.js
+@@ -1,20 +1,6 @@
+ import React,{useId,useRef,useState}from'react';import clsx from'clsx';import {IconButton}from'@gemeente-denhaag/iconbutton';import {ChevronDownIcon}from'@gemeente-denhaag/icons';import {NumberBadge}from'@gemeente-denhaag/number-badge';var css_248z = ".denhaag-side-navigation{display:var(--denhaag-side-navigation-display);flex-direction:var(--denhaag-side-navigation-flex-direction);min-width:var(--denhaag-side-navigation-min-width);row-gap:var(--denhaag-side-navigation-row-gap)}@media (width <= 1023px){.denhaag-side-navigation{display:var(--denhaag-side-navigation-mobile-display)}}.denhaag-side-navigation__list{list-style:none;margin-block-end:0;margin-block-start:0;padding-block-end:0;padding-block-start:0;padding-inline-start:0}.denhaag-side-navigation__item{align-items:center;display:flex;flex-direction:row;font-family:var(--denhaag-side-navigation-item-font-family,sans-serif);font-size:var(--denhaag-side-navigation-item-font-size);font-weight:var(--denhaag-side-navigation-item-font-weight,normal);line-height:1.5}.denhaag-side-navigation__item:has(>.denhaag-side-navigation__list){flex-wrap:wrap}.denhaag-side-navigation__item>.denhaag-side-navigation__list{flex-basis:100%;margin-inline-start:var(--denhaag-side-navigation-list-margin-inline-start)}.denhaag-side-navigation__tree-item-label-wrapper{align-items:center;display:flex;flex-basis:100%;flex-direction:row}.denhaag-side-navigation__link{align-items:center;color:var(--denhaag-side-navigation-link-color);column-gap:16px;display:flex;flex-direction:row;flex-grow:1;padding-block-end:var(--denhaag-side-navigation-link-padding-block-end);padding-block-start:var(--denhaag-side-navigation-link-padding-block-start);text-decoration:none}.denhaag-side-navigation__link-label{align-items:center;display:flex;gap:var(--denhaag-side-navigation-link-label-gap)}.denhaag-side-navigation__link--hover,.denhaag-side-navigation__link:hover{color:var(--denhaag-side-navigation-link-hover-color);cursor:pointer}.denhaag-side-navigation__link--focus,.denhaag-side-navigation__link:focus-visible{outline:var(--denhaag-focus-border)}.denhaag-side-navigation__link--current{color:var(--denhaag-side-navigation-link-active-color);font-weight:var(--denhaag-side-navigation-link-active-font-weight)}.denhaag-side-navigation__expand-button{align-items:center;block-size:var(--denhaag-side-navigation-expand-button-inline-size);display:inline-flex;inline-size:var(--denhaag-side-navigation-expand-button-inline-size);justify-content:center;transform:var(--denhaag-side-navigation-expand-button-transform,rotate(0deg));transition:var(--denhaag-side-navigation-expand-button-transition,\"transform 200ms ease-in-out\")}@media (prefers-reduced-motion){.denhaag-side-navigation__expand-button{transition:none}}.denhaag-side-navigation__expand-button--expanded,.denhaag-side-navigation__expand-button[aria-expanded=true]{transform:var(--denhaag-side-navigation-expand-button-expanded-transform,rotate(180deg))}.denhaag-side-navigation__expand-separator{background-color:currentColor;color:var(--denhaag-side-navigation-expand-separator-color);display:inline-block;flex-shrink:0;inline-size:var(--denhaag-side-navigation-expand-separator-inline-size,1px);margin-inline-end:var(--denhaag-side-navigation-expand-separator-margin-block-end,8px);margin-inline-start:var(--denhaag-side-navigation-expand-separator-margin-block-start,8px);padding-block-end:var(--denhaag-side-navigation-expand-separator-padding-block-end,8px);padding-block-start:var(--denhaag-side-navigation-expand-separator-padding-block-start,8px)}";
+-        if (typeof document !== 'undefined') { 
++        if (typeof document !== 'undefined') {
+ 
+-          const head = document.head || document.getElementsByTagName('head')[0];
+-          const style = document.createElement('style');
+-          style.type = 'text/css';
+-          style.nonce = window.NONCE;
+-        
+-          {
+-            head.appendChild(style);
+-          }
+-        
+-          if (style.styleSheet) {
+-            style.styleSheet.cssText = css_248z;
+-          } else {
+-            style.appendChild(document.createTextNode(css_248z));
+-          }
+         }/******************************************************************************
+ Copyright (c) Microsoft Corporation.
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
   shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
 
 patchedDependencies:
+  '@gemeente-denhaag/iconbutton@3.1.0': da0c7ecd733b2ae3ddf6302d79a2a23ac35ac3678ce602d97406281ba2b6bb8d
+  '@gemeente-denhaag/icons@4.0.1': cc14f2ecdeabcc85e8c3394c30d1de582cfbeac741d17297e4abd43fbe161240
+  '@gemeente-denhaag/number-badge@2.1.0': b675fd2f28efbeba50e82b29b6716822e040042eb2452174f3d2c70f8c3658c1
+  '@gemeente-denhaag/side-navigation@4.1.0': 3295b6f74778642baea0e502b3c3603eec54678bb51dc3218d44a96db7b95ff7
   '@rijkshuisstijl-community/card-react': c81451f5b5c55b13c5034472ed2735eaa7ee7b7ee0969f9c8ae9b845ad991247
 
 importers:
@@ -462,7 +466,7 @@ importers:
         version: 3.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@gemeente-denhaag/side-navigation':
         specifier: 4.1.0
-        version: 4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.1.0(patch_hash=3295b6f74778642baea0e502b3c3603eec54678bb51dc3218d44a96db7b95ff7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nl-design-system-candidate/button-css':
         specifier: 1.1.0
         version: 1.1.0
@@ -15587,9 +15591,9 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@gemeente-denhaag/iconbutton@3.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@gemeente-denhaag/iconbutton@3.1.0(patch_hash=da0c7ecd733b2ae3ddf6302d79a2a23ac35ac3678ce602d97406281ba2b6bb8d)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@gemeente-denhaag/icons': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@gemeente-denhaag/icons': 4.0.1(patch_hash=cc14f2ecdeabcc85e8c3394c30d1de582cfbeac741d17297e4abd43fbe161240)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15605,7 +15609,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@gemeente-denhaag/icons@4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@gemeente-denhaag/icons@4.0.1(patch_hash=cc14f2ecdeabcc85e8c3394c30d1de582cfbeac741d17297e4abd43fbe161240)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       clsx: 2.1.1
       react: 18.3.1
@@ -15658,7 +15662,7 @@ snapshots:
       - react-vega
       - vega
 
-  '@gemeente-denhaag/number-badge@2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@gemeente-denhaag/number-badge@2.1.0(patch_hash=b675fd2f28efbeba50e82b29b6716822e040042eb2452174f3d2c70f8c3658c1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -15694,11 +15698,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@gemeente-denhaag/side-navigation@4.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@gemeente-denhaag/side-navigation@4.1.0(patch_hash=3295b6f74778642baea0e502b3c3603eec54678bb51dc3218d44a96db7b95ff7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@gemeente-denhaag/iconbutton': 3.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@gemeente-denhaag/icons': 4.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@gemeente-denhaag/number-badge': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@gemeente-denhaag/iconbutton': 3.1.0(patch_hash=da0c7ecd733b2ae3ddf6302d79a2a23ac35ac3678ce602d97406281ba2b6bb8d)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@gemeente-denhaag/icons': 4.0.1(patch_hash=cc14f2ecdeabcc85e8c3394c30d1de582cfbeac741d17297e4abd43fbe161240)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@gemeente-denhaag/number-badge': 2.1.0(patch_hash=b675fd2f28efbeba50e82b29b6716822e040042eb2452174f3d2c70f8c3658c1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,10 @@ overrides:
   shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
 
 patchedDependencies:
+  "@gemeente-denhaag/iconbutton@3.1.0": patches/@gemeente-denhaag__iconbutton@3.1.0.patch
+  "@gemeente-denhaag/icons@4.0.1": patches/@gemeente-denhaag__icons@4.0.1.patch
+  "@gemeente-denhaag/number-badge@2.1.0": patches/@gemeente-denhaag__number-badge@2.1.0.patch
+  "@gemeente-denhaag/side-navigation@4.1.0": patches/@gemeente-denhaag__side-navigation@4.1.0.patch
   "@rijkshuisstijl-community/card-react": patches/@rijkshuisstijl-community__card-react.patch
 
 provenance: true


### PR DESCRIPTION
De Den Haag componenten injecteren client side CSS. Dat matched niet met de CSP settings. Deze PR patched de componenten van Den Haag zodat er geen css meer geinjecteerd wordt