### PR TITLE
fix: convenience redirect mijn services community

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -178,7 +178,7 @@ Redirect 301 "/4.1.3" "/wcag/4.1.3/"
 # Convenience redirect, because this URL is simple enough to share in audio tracks during presentations
 Redirect 301 "/belangenorganisaties" "/community/belangenorganisaties/aanmelden/"
 Redirect 301 "/belangenorganisatie" "/community/belangenorganisaties/aanmelden/"
-Redirect 301 "/mijn-services-community" "/community/community-sprints/mijn-services-community/"
+RedirectMatch 301 "^/mijn-services-community/?$" "/community/community-sprints/mijn-services-community/"
 
 # Convenience redirects for use in code
 Redirect 301 "/lint-staged" "/linting-en-code-formatting#lint-staged"


### PR DESCRIPTION
Deze redirect vorige maand ingesteld `Redirect 301 "/mijn-services-community" "/community/community-sprints/mijn-services-community/"` zorgt ervoor dat deze link `nldesignsystem.nl/mijn-services-community/mijn-services-community-check-in.ics` redirect naar `nldesignsystem.nl/community/community-sprints/mijn-services-community/mijn-services-community-check-in.ics`.

Aangepast zodat het enkel redirect vanaf `nldesignsystem.nl/mijn-services-community` en `nldesignsystem.nl/mijn-services-community/`