### PR TITLE
fix: duplicate titles

### DIFF
--- a/docs/community/belangenorganisaties/aanmelden-bedankt.mdx
+++ b/docs/community/belangenorganisaties/aanmelden-bedankt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de mailinglist voor belangenorganisaties
 hide_title: true
 hide_table_of_contents: false
 slug: /community/belangenorganisaties/aanmelden-bedankt

--- a/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de MijnServices community
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Bedankt voor je aanmelding

--- a/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Rijkshuisstijl Community
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Bedankt voor je aanmelding

--- a/docs/community/events/community-bijeenkomst-2-success.mdx
+++ b/docs/community/events/community-bijeenkomst-2-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Communitybijeenkomst
 hide_title: true
 hide_table_of_contents: false
 description: Je bent nu aangemeld voor de communitybijeenkomst.

--- a/docs/community/events/design-open-dag-success.mdx
+++ b/docs/community/events/design-open-dag-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Design Open Dag
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Design Open Dag

--- a/docs/community/events/design-open-hour/aanmelden-success.mdx
+++ b/docs/community/events/design-open-hour/aanmelden-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Design Open Hour
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/community/events/design-systems-week/aanmelden-bedankt.mdx
+++ b/docs/community/events/design-systems-week/aanmelden-bedankt.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Design Systems Week
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Design Systems Week
+title: Design Systems Week - English
 description: Design Systems Week is an online event organized by NL Design System with several short sessions about the ins and outs of design systems
 lang: en
 hide_title: true

--- a/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
@@ -1,5 +1,5 @@
 ---
-title: Videos
+title: Videos van Design Systems Week 2023
 title_sm: "2023"
 description: Recordings of the English talks for the Design Systems Week 2023
 lang: en

--- a/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
@@ -1,5 +1,5 @@
 ---
-title: Videos
+title: Videos van Design Systems Week 2024
 title_sm: "2024"
 description: Recordings of talks that are in English for Design Systems Week 2024.
 lang: en

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -1,5 +1,5 @@
 ---
-title: Videos
+title: Videos van Design Systems Week 2025
 title_sm: "2025"
 description: Recordings of talks that are in English for Design Systems Week 2025.
 lang: en

--- a/docs/community/events/design-systems-week/en/sign-up-thanks.mdx
+++ b/docs/community/events/design-systems-week/en/sign-up-thanks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Thanks for signing up!
+title: Thanks for signing up for the Design Systems Week!
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Signing up

--- a/docs/community/events/developer-open-hour/aanmelden-success.mdx
+++ b/docs/community/events/developer-open-hour/aanmelden-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Developer Open Hour
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/community/events/estafettemodeldag-success.mdx
+++ b/docs/community/events/estafettemodeldag-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Estafettemodeldag
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Sluit je aan

--- a/docs/community/events/heartbeat/aanmelden-success.mdx
+++ b/docs/community/events/heartbeat/aanmelden-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de Heartbeat
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/community/events/introduction-european-design-systems-success.mdx
+++ b/docs/community/events/introduction-european-design-systems-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Thanks for signing up!
+title: Thanks for signing up for the Introduction into European Design Systems 2025!
 hide_title: true
 hide_table_of_contents: false
 lang: en

--- a/docs/community/expertteam-digitale-toegankelijkheid/_meedenken-succes.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/_meedenken-succes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor meedenken met het Expertteam Digitale Toegankelijkheid
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Sluit je aan

--- a/docs/community/sluit-je-aan-success.mdx
+++ b/docs/community/sluit-je-aan-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor de NL Design System community
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Sluit je aan
@@ -13,7 +13,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-# Bedankt voor je aanmelding voor de NL Design System Community
+# Bedankt voor je aanmelding voor de NL Design System community
 
 Welkom, fijn dat je erbij bent. We hopen je snel (weer) eens te zien bij een Heartbeat, samenwerkdag of bijeenkomst.
 

--- a/docs/footer/coc-en.md
+++ b/docs/footer/coc-en.md
@@ -1,5 +1,5 @@
 ---
-title: Code of Conduct
+title: Code of Conduct - English
 hide_title: true
 hide_table_of_contents: true
 pagination_label: Code of Conduct

--- a/docs/footer/coc.md
+++ b/docs/footer/coc.md
@@ -1,5 +1,5 @@
 ---
-title: Code of Conduct
+title: Code of Conduct - Nederlands
 hide_title: true
 hide_table_of_contents: true
 pagination_label: Code of Conduct

--- a/docs/handboek/definition-of-done/candidate-stappenplan/index.md
+++ b/docs/handboek/definition-of-done/candidate-stappenplan/index.md
@@ -1,5 +1,5 @@
 ---
-title: Overzicht
+title: Overzicht van de Candidate Definition of Done voor componenten
 title_sm: Candidate
 hide_title: true
 hide_table_of_contents: false

--- a/docs/handboek/definition-of-done/hall-of-fame-stappenplan/index.md
+++ b/docs/handboek/definition-of-done/hall-of-fame-stappenplan/index.md
@@ -1,5 +1,5 @@
 ---
-title: Overzicht
+title: Overzicht van de Hall of Fame Definition of Done voor componenten
 title_sm: Hall of Fame
 hide_title: true
 hide_table_of_contents: false

--- a/docs/handboek/designer/index.mdx
+++ b/docs/handboek/designer/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introductie
+title: NL Design System introductie voor designers
 hide_title: true
 hide_table_of_contents: true
 sidebar_label: Introductie

--- a/docs/handboek/developer/01-index.mdx
+++ b/docs/handboek/developer/01-index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introductie
+title: NL Design System introductie voor developers
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie

--- a/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
+++ b/docs/handboek/huisstijl-vastleggen/design-tokens.mdx
@@ -1,6 +1,5 @@
 ---
-title: Design tokens
-hide_title: true
+title: Design tokens - Introductie
 hide_table_of_contents: false
 sidebar_label: Design tokens
 sidebar_position: 1

--- a/docs/handboek/introductie.md
+++ b/docs/handboek/introductie.md
@@ -1,5 +1,5 @@
 ---
-title: Introductie
+title: NL Design System introductie
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie

--- a/docs/project/newsletter-success.mdx
+++ b/docs/project/newsletter-success.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bedankt voor je aanmelding
+title: Bedankt voor je aanmelding voor onze nieuwsbrief
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Aanmelden

--- a/docs/richtlijnen/formulieren/help/8-avoid-input-mask/index.mdx
+++ b/docs/richtlijnen/formulieren/help/8-avoid-input-mask/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Maak het mogelijk een inzending te controleren, te wijzigen of ongedaan te maken
+title: Maak het makkelijk om flexibel een veld in te voeren
 title_sm: Vermijd invoerpatronen
 hide_title: true
 hide_table_of_contents: false


### PR DESCRIPTION
In de nieuwe Astro website hadden we een mooie waarschuwing op de tijdelijk homepage met duplicate titles. Die heb ik hierbij opgelost.

<img width="721" height="934" alt="Screenshot 2026-07-10 at 11 17 40" src="https://github.com/user-attachments/assets/e58c0bcd-28b0-4d98-8cc8-a1d2d625754f" />
