### PR TITLE
docs: add tip

### DIFF
--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -45,6 +45,8 @@ Community componenten Icon Button en Side Navigation van Den Haag zijn toegevoeg
 
 [Bekijk de video 'Changelog: Icon Button en Side Navigation'](https://youtu.be/2dPkYxAUjlQ) waarin wordt uitgelegd hoe je deze componenten overneemt.
 
+Tip: Heb je een Figma-bestand waarin je deze componenten gebruikt? Zorg er dan voor dat je de huidige versie van dat bestand opslaat voordat je de update met wijzigingen vanuit de bibliotheek accepteert. Dit doe je door de huidige versie toe te voegen aan de Version History en deze een duidelijke naam te geven, bijvoorbeeld: 'Vooraf aan release 15.0.0’. Daarna kun je zonder zorgen de update accepteren en je bestand up-to-date brengen met de nieuwe versie.
+
 ```json
 {
   "denhaag": {

--- a/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
+++ b/docs/handboek/designer/werken-met-nl-design-system/figma-changelog.mdx
@@ -45,7 +45,7 @@ Community componenten Icon Button en Side Navigation van Den Haag zijn toegevoeg
 
 [Bekijk de video 'Changelog: Icon Button en Side Navigation'](https://youtu.be/2dPkYxAUjlQ) waarin wordt uitgelegd hoe je deze componenten overneemt.
 
-Tip: Heb je een Figma-bestand waarin je deze componenten gebruikt? Zorg er dan voor dat je de huidige versie van dat bestand opslaat voordat je de update met wijzigingen vanuit de bibliotheek accepteert. Dit doe je door de huidige versie toe te voegen aan de Version History en deze een duidelijke naam te geven, bijvoorbeeld: 'Vooraf aan release 15.0.0’. Daarna kun je zonder zorgen de update accepteren en je bestand up-to-date brengen met de nieuwe versie.
+Tip: Heb je een Figma-bestand waarin je deze componenten gebruikt? Zorg er dan voor dat je de huidige versie van dat bestand opslaat voordat je de update met wijzigingen vanuit de bibliotheek accepteert. Dit doe je door de huidige versie toe te voegen aan de Version History en deze een duidelijke naam te geven, bijvoorbeeld: 'Vooraf aan release 15.0.0'. Daarna kun je zonder zorgen de update accepteren en je bestand up-to-date brengen met de nieuwe versie.
 
 ```json
 {


### PR DESCRIPTION
Added a tip for updating Figma files before accepting library changes.

Preview: https://documentatie-git-docs-add-tip-to-v1500-nl-design-system.vercel.app/handboek/designer/figma-changelog/