### PR TITLE
fix: playwright add exclusion for .nlds-guideline h1

### DIFF
--- a/docs/richtlijnen/content/tekstopmaak/headings.mdx
+++ b/docs/richtlijnen/content/tekstopmaak/headings.mdx
@@ -92,7 +92,7 @@ Gebruik koppen in volgorde. Begin bijvoorbeeld met een kopniveau 2 onder de hoof
 Van boven naar beneden mag je geen niveaus overslaan. Van beneden naar boven wel. Het is prima om na een kopniveau 4 weer een nieuwe sectie te beginnen met een kopniveau 2.
 
 <Guideline appearance="do" title="Gebruik kopniveaus in de de goede volgorde.">
-  <Canvas language="html">
+  <Canvas language="html" className="nlds-not-accessible">
     {() => (
       <>
         <h1>Kop met niveau 1</h1>
@@ -127,7 +127,7 @@ Van boven naar beneden mag je geen niveaus overslaan. Van beneden naar boven wel
 </Guideline>
 
 <Guideline appearance="dont" title="Van boven naar beneden een kopniveau overslaan.">
-  <Canvas language="html">
+  <Canvas language="html" className="nlds-not-accessible">
     {() => (
       <>
         <h1>Dit is een kop met niveau 1</h1>

--- a/docs/richtlijnen/content/video/beschrijving.mdx
+++ b/docs/richtlijnen/content/video/beschrijving.mdx
@@ -31,7 +31,7 @@ Geef iedere video een duidelijke beschrijving, zodat bezoekers weten wat ze kunn
 Beschrijf bóven de videospeler op de pagina waar de video over gaat. Dit kan bijvoorbeeld in een beschrijvende paragraaf, of met een kopje. Zo begrijpen alle bezoekers wat zij kunnen verwachten van de video en bepalen of ze de video willen bekijken.
 
 <Guideline appearance="do" title="Video's op de pagina een beschrijving geven">
-  <Canvas language="html">
+  <Canvas language="html" className="nlds-not-accessible">
     {() => (
       <>
         <h1>Heartbeat terugkijken</h1>

--- a/docs/richtlijnen/content/video/transcript.mdx
+++ b/docs/richtlijnen/content/video/transcript.mdx
@@ -71,7 +71,7 @@ Maak daarom ook in een transcript gebruik van [kopjes, paragrafen, leestekens en
   appearance="do"
   title="Breng structuur aan in je transcript en maak onderscheid tussen gesproken dialoog en beschrijvingen"
 >
-  <Canvas language="html">
+  <Canvas language="html" className="nlds-not-accessible">
     {() => (
       <>
         <h1>Je verhuizing doorgeven</h1>

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -48,6 +48,7 @@ export interface CanvasProps {
   copy?: boolean;
   container?: string | CanvasContainerType;
   designTokens?: CSSProperties;
+  className?: string;
 }
 
 export const Canvas = globalThis.isAstro

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -1,11 +1,12 @@
 import type { CanvasProps } from './Canvas';
 import Prism from 'prismjs';
+import clsx from 'clsx';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Accordion, AccordionSection } from '../../../packages/website/src/components/accordion/accordion';
 import './CanvasAstro.css';
 import '@utrecht/component-library-css/dist/html.css';
 
-export const CanvasAstro = ({ children, language }: CanvasProps) => {
+export const CanvasAstro = ({ children, language, className }: CanvasProps) => {
   const _children = typeof children === 'function' ? children() : children;
   const code = renderToStaticMarkup(_children);
   const formattedCode = code
@@ -23,7 +24,7 @@ export const CanvasAstro = ({ children, language }: CanvasProps) => {
   const highlighed = Prism.highlight(formattedCode, Prism.languages[language], language);
 
   return (
-    <div className="ma-canvas-astro">
+    <div className={clsx('ma-canvas-astro', className)}>
       <div
         className="ma-canvas-astro__example utrecht-html ma-flow"
         dangerouslySetInnerHTML={{ __html: formattedCode }}

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -95,7 +95,7 @@ test.describe('SEO values', async () => {
             .getAttribute('content')
             .then((twitterCard) => ({ twitterCard })),
           page
-            .locator('body h1:not(.nlds-guideline h1)') // exclude h1's that are used in guideline do/don't blocks
+            .locator('body h1:not(.nlds-not-accessible h1)')
             .innerText()
             .then((h1) => ({ h1 })),
         ]).then((values) => Object.assign({}, ...values));

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -95,7 +95,7 @@ test.describe('SEO values', async () => {
             .getAttribute('content')
             .then((twitterCard) => ({ twitterCard })),
           page
-            .locator('body h1')
+            .locator('body h1:not(.nlds-guideline h1)') // exclude h1's that are used in guideline do/don't blocks
             .innerText()
             .then((h1) => ({ h1 })),
         ]).then((values) => Object.assign({}, ...values));


### PR DESCRIPTION
2 weken terug is een test toegevoegd om te controleren of er op elke pagina een h1 staat. Echter op een paar pagina's staan meerdere h1's omdat ze in Do/Don't blokken gebruikt worden en hier struikelt ie nu over.

Bijvoorbeeld: https://nldesignsystem.nl/richtlijnen/content/video/beschrijving/
"Video beschrijving" en onder doen "Heartbeat terugkijken" zijn beide een h1.

Dat er meerdere h1's op de pagina staan is in dit geval oke. 

Fix: Aan de h1 locator toegevoegd dat ie de h1's onder de div met .nlds-guideline moet negeren.