### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm run build:docusaurus",
-  "framework": "docusaurus",
-  "outputDirectory": "build",
+  "buildCommand": "cd ../.. && pnpm --filter @nl-design-system/website-astro run build",
+  "framework": "astro",
+  "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {
       "dependabot/*": false,


### PR DESCRIPTION
This PR moves the vercel configuration to `vercel.json`.

It is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.

I removed `github.autoCancellation` because `true` seems to be the default.
