### PR TITLE
test: add img.youtube.com to allowed hosts

### DIFF
--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -25,6 +25,7 @@ const cspConnectSrcSources = ['https://*.algolia.net', 'https://*.algolianet.com
 const cspImgSrcSources = [
   'https://raw.githubusercontent.com',
   'https://i.ytimg.com',
+  'https://img.youtube.com',
   'https://www.toegankelijkheidsverklaring.nl',
   'https://github.com',
   'https://www.gebruikercentraal.nl',


### PR DESCRIPTION
There is a flaky CSP test that sometimes fails on this host; perhaps it is because of a timing issue that it sometimes passes.  It should be added to allowed hosts.
