### PR TITLE
ci: use "Other" as framework preset (on Vercel)

### DIFF
--- a/packages/website/vercel.json
+++ b/packages/website/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm --filter @nl-design-system/website-astro run build",
-  "framework": "astro",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm run build:docusaurus",
-  "framework": "docusaurus",
+  "framework": null,
   "outputDirectory": "build",
   "git": {
     "deploymentEnabled": {


### PR DESCRIPTION
Rationale: avoid relying on Vercel magic.
