### PR TITLE
refactor: simplify component sample colors

### DIFF
--- a/src/components/ComponentIllustration/ComponentIllustration.css
+++ b/src/components/ComponentIllustration/ComponentIllustration.css
@@ -1,4 +1,7 @@
 .ma-component-illustration {
+  --ma-component-illustration-background-color: var(--basis-color-default-bg-subtle);
+  --ma-component-illustration-grid-color: var(--basis-color-default-border-subtle);
+
   block-size: auto;
   display: inline;
   inline-size: auto;
@@ -10,26 +13,18 @@
 }
 
 .ma-component-illustration--help-wanted {
-  --ma-component-illustration-background-color: var(--ma-color-help-wanted-bg-default);
-  --ma-component-illustration-grid-color: var(--ma-color-help-wanted-border-default);
   --ma-component-illustration-color: var(--ma-color-help-wanted-color-default);
 }
 
 .ma-component-illustration--community {
-  --ma-component-illustration-background-color: var(--ma-color-community-bg-default);
-  --ma-component-illustration-grid-color: var(--ma-color-help-community-border-color-default);
   --ma-component-illustration-color: var(--ma-color-community-color-default);
 }
 
 .ma-component-illustration--candidate {
-  --ma-component-illustration-background-color: var(--ma-color-candidate-bg-default);
-  --ma-component-illustration-grid-color: var(--ma-color-candidate-border-color-default);
   --ma-component-illustration-color: var(--ma-color-candidate-border-default);
 }
 
 .ma-component-illustration--hall-of-fame {
-  --ma-component-illustration-background-color: var(--ma-color-hall-of-fame-bg-default);
-  --ma-component-illustration-grid-color: var(--ma-color-hall-of-fame-border-color-default);
   --ma-component-illustration-color: var(--ma-color-hall-of-fame-color-default);
 }
 


### PR DESCRIPTION
Er was iets mis gegaan met de grids van Candidate en Community componenten in het overzicht
<img width="995" height="939" alt="Screenshot 2026-07-31 at 16 26 37" src="https://github.com/user-attachments/assets/cf520cd4-e748-4566-8e01-b98e3dde35fe" />

Toen ik dat ging fixen bedacht ik me dat voor componenten zoals Grid het veel duidelijker is om gewoon de subtle achtergrond en border color te gebruiken. Mijn voorstel is dan dus ook om dat door te voeren

<img width="961" height="934" alt="Screenshot 2026-07-31 at 16 27 10" src="https://github.com/user-attachments/assets/d464cd62-7f13-4581-8081-39a60b7c1fb2" />
