### PR TITLE
chore: configure prettier to format pnpm-workspace.yaml the same as pnpm CLI does

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 allowBuilds:
-  "@parcel/watcher": true
+  '@parcel/watcher': true
   core-js: false
   core-js-pure: false
   esbuild: true
@@ -16,34 +16,34 @@ engineStrict: true
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
-  - "@amsterdam/*"
-  - "@gemeente-denhaag/*"
-  - "@gemeente-rotterdam/*"
-  - "@nl-design-system/*"
-  - "@nl-design-system-candidate/*"
-  - "@nl-design-system-community/*"
-  - "@nl-design-system-unstable/*"
-  - "@nl-rvo/*"
-  - "@rijkshuisstijl-community/*"
-  - "@utrecht/*"
+  - '@amsterdam/*'
+  - '@gemeente-denhaag/*'
+  - '@gemeente-rotterdam/*'
+  - '@nl-design-system/*'
+  - '@nl-design-system-candidate/*'
+  - '@nl-design-system-community/*'
+  - '@nl-design-system-unstable/*'
+  - '@nl-rvo/*'
+  - '@rijkshuisstijl-community/*'
+  - '@utrecht/*'
   - shell-quote@1.8.4
 
 overrides:
-  "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1"
-  form-data@>=4.0.0 <4.0.4: ">=4.0.4"
+  '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
+  form-data@>=4.0.0 <4.0.4: '>=4.0.4'
   shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
 
 patchedDependencies:
-  "@gemeente-denhaag/iconbutton@3.1.0": patches/@gemeente-denhaag__iconbutton@3.1.0.patch
-  "@gemeente-denhaag/icons@4.0.1": patches/@gemeente-denhaag__icons@4.0.1.patch
-  "@gemeente-denhaag/number-badge@2.1.0": patches/@gemeente-denhaag__number-badge@2.1.0.patch
-  "@gemeente-denhaag/side-navigation@4.1.0": patches/@gemeente-denhaag__side-navigation@4.1.0.patch
-  "@rijkshuisstijl-community/card-react": patches/@rijkshuisstijl-community__card-react.patch
+  '@gemeente-denhaag/iconbutton@3.1.0': patches/@gemeente-denhaag__iconbutton@3.1.0.patch
+  '@gemeente-denhaag/icons@4.0.1': patches/@gemeente-denhaag__icons@4.0.1.patch
+  '@gemeente-denhaag/number-badge@2.1.0': patches/@gemeente-denhaag__number-badge@2.1.0.patch
+  '@gemeente-denhaag/side-navigation@4.1.0': patches/@gemeente-denhaag__side-navigation@4.1.0.patch
+  '@rijkshuisstijl-community/card-react': patches/@rijkshuisstijl-community__card-react.patch
 
 provenance: true
 
 saveExact: true
 
-savePrefix: ""
+savePrefix: ''
 
 strictPeerDependencies: false

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -29,6 +29,13 @@ module.exports = {
         parser: 'astro',
       },
     },
+    {
+      // match pnpm CLI-driven changes behavior
+      files: ['pnpm-workspace.yaml'],
+      options: {
+        singleQuote: true,
+      },
+    },
   ],
   plugins: ['prettier-plugin-astro'],
 };

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,7 +1,7 @@
 /**
  * @type {import('prettier').Config}
  */
-module.exports = {
+export default {
   printWidth: 120,
   singleQuote: true,
   overrides: [


### PR DESCRIPTION
For YAML files, we use double quotes for strings.  We make an exception for the `pnpm-workspace.yaml` file, because the pnpm CLI uses single quotes.
