### PR TITLE
refactor: simplify component sample colors

### DIFF
--- a/src/components/ComponentIllustration/ComponentIllustration.css
+++ b/src/components/ComponentIllustration/ComponentIllustration.css
@@ -1,5 +1,5 @@
 .ma-component-illustration {
-  --ma-component-illustration-background-color: var(--basis-color-default-bg-subtle);
+  --ma-component-illustration-grid-background-color: var(--basis-color-default-bg-subtle);
   --ma-component-illustration-grid-color: var(--basis-color-default-border-subtle);
 
   block-size: auto;
@@ -13,18 +13,22 @@
 }
 
 .ma-component-illustration--help-wanted {
+  --ma-component-illustration-background-color: var(--ma-color-help-wanted-bg-default);
   --ma-component-illustration-color: var(--ma-color-help-wanted-color-default);
 }
 
 .ma-component-illustration--community {
+  --ma-component-illustration-background-color: var(--ma-color-community-bg-default);
   --ma-component-illustration-color: var(--ma-color-community-color-default);
 }
 
 .ma-component-illustration--candidate {
+  --ma-component-illustration-background-color: var(--ma-color-candidate-bg-default);
   --ma-component-illustration-color: var(--ma-color-candidate-border-default);
 }
 
 .ma-component-illustration--hall-of-fame {
+  --ma-component-illustration-background-color: var(--ma-color-hall-of-fame-bg-default);
   --ma-component-illustration-color: var(--ma-color-hall-of-fame-color-default);
 }
 

--- a/static/svg/_template-icon.svg
+++ b/static/svg/_template-icon.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
     <!-- SVG paths here -->
-
-    <!-- Use var(--ma-component-illustration-background-color, white) for fill and stroke in background color -->
+    <!-- Use var(--ma-component-illustration-grid-background-color, white) for grid background color -->
     <!-- Use var(--ma-component-illustration-grid-color, #eee) for grid color -->
+    <!-- Use var(--ma-component-illustration-background-color, white) for fill and stroke in background color -->
     <!-- Use var(--ma-component-illustration-color, #666) for component color -->
 
     <!-- Optional: remove unnecessary `def` and `g` elements -->

--- a/static/svg/componenten_overzicht_accordion.svg
+++ b/static/svg/componenten_overzicht_accordion.svg
@@ -3,7 +3,7 @@
   <symbol id="component-illustration" viewBox="0 0 960 540">
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
-    <g fill="var(--ma-component-illustration-background-color, white)">
+    <g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
       <rect width="960" height="540" />
       <rect width="960" height="540" />
     </g>

--- a/static/svg/componenten_overzicht_action-group.svg
+++ b/static/svg/componenten_overzicht_action-group.svg
@@ -2,7 +2,7 @@
     <!-- This ensures the component can be found in the ComponentIllustration component -->
     <symbol id="component-illustration" viewBox="0 0 960 540">
         <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
-        <g fill="var(--ma-component-illustration-background-color, white)">
+        <g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
           <rect width="960" height="540"/>
           <rect width="960" height="540"/>
         </g>

--- a/static/svg/componenten_overzicht_alert-dialog.svg
+++ b/static/svg/componenten_overzicht_alert-dialog.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_608_1182)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_608_1182)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>

--- a/static/svg/componenten_overzicht_alert.svg
+++ b/static/svg/componenten_overzicht_alert.svg
@@ -3,7 +3,7 @@
     <symbol id="component-illustration" viewBox="0 0 960 540">
 
         <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
-        <g fill="var(--ma-component-illustration-background-color, white)">
+        <g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
             <rect width="960" height="540"/>
             <rect width="960" height="540"/>
         </g>

--- a/static/svg/componenten_overzicht_avatar.svg
+++ b/static/svg/componenten_overzicht_avatar.svg
@@ -4,9 +4,9 @@
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
         <g clip-path="url(#clip0_632_1855)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <g clip-path="url(#clip1_632_1855)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_blockquote.svg
+++ b/static/svg/componenten_overzicht_blockquote.svg
@@ -4,9 +4,9 @@
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
         <g clip-path="url(#clip0_632_1892)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <g clip-path="url(#clip1_632_1892)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_breadcrumb-navigation.svg
+++ b/static/svg/componenten_overzicht_breadcrumb-navigation.svg
@@ -4,9 +4,9 @@
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
         <g clip-path="url(#clip0_633_1932)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <g clip-path="url(#clip1_633_1932)">
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_button.svg
+++ b/static/svg/componenten_overzicht_button.svg
@@ -3,8 +3,8 @@
   <symbol id="component-illustration" viewBox="0 0 960 540">
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file -->
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
         <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_calendar.svg
+++ b/static/svg/componenten_overzicht_calendar.svg
@@ -3,8 +3,8 @@
   <symbol id="component-illustration">
 
     <!-- Use variables to set backgroundcolors so they can change with the status of the component without modififying this file --> -->
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 
         <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
         <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_card-as-link.svg
+++ b/static/svg/componenten_overzicht_card-as-link.svg
@@ -1,7 +1,7 @@
 <svg viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
     <symbol id="component-illustration" viewBox="0 0 960 540">
-    <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-    <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+    <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+    <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
     <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_case-card.svg
+++ b/static/svg/componenten_overzicht_case-card.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
     <symbol id="component-illustration">
-        <g fill="var(--ma-component-illustration-background-color, white)">
+        <g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
             <rect width="960" height="540"/>
             <rect width="960" height="540"/>
         </g>

--- a/static/svg/componenten_overzicht_checkbox-group.svg
+++ b/static/svg/componenten_overzicht_checkbox-group.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_checkbox.svg
+++ b/static/svg/componenten_overzicht_checkbox.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_code-block.svg
+++ b/static/svg/componenten_overzicht_code-block.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
 <g clip-path="url(#clip0_1318_2811)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1318_2811)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_code.svg
+++ b/static/svg/componenten_overzicht_code.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
 <g clip-path="url(#clip0_641_3321)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_641_3321)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_color-sample.svg
+++ b/static/svg/componenten_overzicht_color-sample.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_contact-timeline.svg
+++ b/static/svg/componenten_overzicht_contact-timeline.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1788_2888)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1788_2888)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>

--- a/static/svg/componenten_overzicht_counter-badge.svg
+++ b/static/svg/componenten_overzicht_counter-badge.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_data-badge-2.svg
+++ b/static/svg/componenten_overzicht_data-badge-2.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_data-badge.svg
+++ b/static/svg/componenten_overzicht_data-badge.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_data-summary.svg
+++ b/static/svg/componenten_overzicht_data-summary.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_634_2098)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_634_2098)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_date-input-group.svg
+++ b/static/svg/componenten_overzicht_date-input-group.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_634_2137)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_634_2137)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_date-input.svg
+++ b/static/svg/componenten_overzicht_date-input.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-    <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-    <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+    <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+    <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
     <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_date-picker.svg
+++ b/static/svg/componenten_overzicht_date-picker.svg
@@ -1,8 +1,8 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_description-list.svg
+++ b/static/svg/componenten_overzicht_description-list.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg" >
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1120_2564)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1120_2564)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_dialog.svg
+++ b/static/svg/componenten_overzicht_dialog.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g fill="var(--ma-component-illustration-grid-color, #eee)">
     <rect width="2" height="540" transform="translate(69)"/>
     <rect width="2" height="540" transform="translate(151)"/>

--- a/static/svg/componenten_overzicht_dot-badge.svg
+++ b/static/svg/componenten_overzicht_dot-badge.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg" >
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_637_1943)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, #AAA)"/>
 <g clip-path="url(#clip1_637_1943)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_drawer.svg
+++ b/static/svg/componenten_overzicht_drawer.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg" >
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1107_2400)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1107_2400)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_fieldset.svg
+++ b/static/svg/componenten_overzicht_fieldset.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_637_2145)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_637_2145)">
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_figure.svg
+++ b/static/svg/componenten_overzicht_figure.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_file-input.svg
+++ b/static/svg/componenten_overzicht_file-input.svg
@@ -1,8 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_638_2230)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_638_2230)">
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_file.svg
+++ b/static/svg/componenten_overzicht_file.svg
@@ -1,8 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1866_2945)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1866_2945)">
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -20,13 +18,11 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="153" y="211" width="654" height="118" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M191.334 251.333C190.045 251.333 189.001 252.378 189.001 253.667V286.333C189.001 287.622 190.045 288.667 191.334 288.667H214.667C215.956 288.667 217.001 287.622 217.001 286.333V263H210.001C207.423 263 205.334 260.911 205.334 258.333V251.333H191.334ZM210.001 254.633L213.701 258.333H210.001V254.633ZM184.334 253.667C184.334 249.801 187.468 246.667 191.334 246.667H207.667C208.286 246.667 208.88 246.912 209.317 247.35L220.984 259.017C221.421 259.454 221.667 260.048 221.667 260.667V286.333C221.667 290.199 218.533 293.333 214.667 293.333H191.334C187.468 293.333 184.334 290.199 184.334 286.333V253.667Z" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="247" y="243" width="362" height="24" rx="12" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="247" y="281" width="158" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M745 252C746.105 252 747 252.895 747 254V273.172L753.586 266.586C754.367 265.805 755.633 265.805 756.414 266.586C757.195 267.367 757.195 268.633 756.414 269.414L746.414 279.414C745.633 280.195 744.367 280.195 743.586 279.414L733.586 269.414C732.805 268.633 732.805 267.367 733.586 266.586C734.367 265.805 735.633 265.805 736.414 266.586L743 273.172V254C743 252.895 743.895 252 745 252ZM729 278C730.105 278 731 278.895 731 280V284C731 285.105 731.895 286 733 286H757C758.105 286 759 285.105 759 284V280C759 278.895 759.895 278 761 278C762.105 278 763 278.895 763 280V284C763 287.314 760.314 290 757 290H733C729.686 290 727 287.314 727 284V280C727 278.895 727.895 278 729 278Z" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_1866_2945">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_form-field-checkbox-option.svg
+++ b/static/svg/componenten_overzicht_form-field-checkbox-option.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-description.svg
+++ b/static/svg/componenten_overzicht_form-field-description.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-error-message.svg
+++ b/static/svg/componenten_overzicht_form-field-error-message.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-label-suffix.svg
+++ b/static/svg/componenten_overzicht_form-field-label-suffix.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1796_2918)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1796_2918)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,18 +19,14 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="235" y="277" width="490" height="80" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="233" y="227" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="181" width="248" height="24" rx="12" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="509" y="181" width="123" height="24" rx="12" fill="var(--ma-component-illustration-color, #666)"/>
-<g clip-path="url(#clip2_1796_2918)">
 <path d="M259 297L259 337" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
-</g>
 <path d="M570 82L570 159.449M571 160C572.657 153.403 577 147.769 577 141M570.057 159.343C569.256 154.95 566.905 151.408 565.544 147.295C564.831 145.139 563.999 142.956 562.565 141.27" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M506.44 179.176C504.925 181.352 503.827 183.528 503.144 185.704C502.461 187.859 502.12 190.387 502.12 193.288C502.12 196.189 502.461 198.728 503.144 200.904C503.827 203.059 504.925 205.224 506.44 207.4L503.208 209.576C501.821 207.656 500.712 205.992 499.88 204.584C499.048 203.197 498.355 201.565 497.8 199.688C497.267 197.811 497 195.677 497 193.288C497 190.899 497.267 188.765 497.8 186.888C498.355 185.011 499.048 183.379 499.88 181.992C500.712 180.584 501.821 178.92 503.208 177L506.44 179.176Z" fill="var(--ma-component-illustration-color, #666)"/>
 <path d="M638.232 177C639.619 178.941 640.717 180.605 641.528 181.992C642.36 183.379 643.043 185.011 643.576 186.888C644.131 188.765 644.408 190.899 644.408 193.288C644.408 195.677 644.131 197.811 643.576 199.688C643.043 201.565 642.36 203.197 641.528 204.584C640.717 205.971 639.619 207.635 638.232 209.576L635 207.4C636.515 205.203 637.613 203.027 638.296 200.872C638.979 198.696 639.32 196.168 639.32 193.288C639.32 190.408 638.979 187.891 638.296 185.736C637.613 183.56 636.515 181.373 635 179.176L638.232 177Z" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_1796_2918">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_form-field-label.svg
+++ b/static/svg/componenten_overzicht_form-field-label.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-option-label.svg
+++ b/static/svg/componenten_overzicht_form-field-option-label.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-partial-label.svg
+++ b/static/svg/componenten_overzicht_form-field-partial-label.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-partial.svg
+++ b/static/svg/componenten_overzicht_form-field-partial.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-radio-option.svg
+++ b/static/svg/componenten_overzicht_form-field-radio-option.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-field-status.svg
+++ b/static/svg/componenten_overzicht_form-field-status.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1919_3537)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1919_3537)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,20 +19,16 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="235" y="174" width="490" height="162" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="233" y="132" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="92" width="248" height="24" rx="12" fill="var(--ma-component-illustration-color, #666)"/>
 <path d="M125 410L202.449 410M203 409C196.403 407.343 190.769 403 184 403M202.343 409.943C197.95 410.744 194.408 413.095 190.295 414.456C188.139 415.169 185.956 416.001 184.27 417.435" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M267.513 360.488C268.164 361.139 268.164 362.194 267.513 362.845L250.846 379.512C250.196 380.163 249.14 380.163 248.489 379.512L240.156 371.179C239.505 370.528 239.505 369.472 240.156 368.821C240.807 368.171 241.862 368.171 242.513 368.821L249.668 375.976L265.156 360.488C265.807 359.837 266.862 359.837 267.513 360.488Z" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="281" y="362" width="336" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-<g clip-path="url(#clip2_1919_3537)">
 <circle cx="253" cy="410" r="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <rect x="281" y="402" width="160" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M267.513 440.488C268.164 441.139 268.164 442.194 267.513 442.845L250.846 459.512C250.196 460.163 249.14 460.163 248.489 459.512L240.156 451.179C239.505 450.528 239.505 449.472 240.156 448.821C240.807 448.171 241.862 448.171 242.513 448.821L249.668 455.976L265.156 440.488C265.807 439.837 266.862 439.837 267.513 440.488Z" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="281" y="442" width="242" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_1919_3537">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_form-field.svg
+++ b/static/svg/componenten_overzicht_form-field.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_form-navigation.svg
+++ b/static/svg/componenten_overzicht_form-navigation.svg
@@ -1,9 +1,8 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1446_2957)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1446_2957)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -49,7 +48,6 @@
 </g>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M356.608 139.391C357.129 139.911 357.129 140.755 356.608 141.276L343.275 154.609C342.754 155.13 341.91 155.13 341.389 154.609L334.723 147.943C334.202 147.422 334.202 146.578 334.723 146.057C335.243 145.536 336.087 145.536 336.608 146.057L342.332 151.781L354.723 139.391C355.243 138.87 356.087 138.87 356.608 139.391Z" fill="var(--ma-component-illustration-background-color, white)"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M356.608 222.391C357.129 222.911 357.129 223.755 356.608 224.276L343.275 237.609C342.754 238.13 341.91 238.13 341.389 237.609L334.723 230.943C334.202 230.422 334.202 229.578 334.723 229.057C335.243 228.536 336.087 228.536 336.608 229.057L342.332 234.781L354.723 222.391C355.243 221.87 356.087 221.87 356.608 222.391Z" fill="var(--ma-component-illustration-background-color, white)"/>
-</g>
 <defs>
 <clipPath id="clip0_1446_2957">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_form-summary.svg
+++ b/static/svg/componenten_overzicht_form-summary.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_634_2098)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_634_2098)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <mask id="path-1-inside-1_634_2098" fill="var(--ma-component-illustration-background-color, white)">
 <path d="M151 146H809V230H151V146Z"/>
 </mask>
@@ -40,7 +37,6 @@
 <path d="M809 391H151V399H809V391Z" fill="var(--ma-component-illustration-color, #666)" mask="url(#path-9-inside-3_634_2098)"/>
 <rect x="151" y="345" width="240" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="479" y="345" width="102" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </symbol>
 <use href='#component-illustration'/>
 </svg>

--- a/static/svg/componenten_overzicht_grid.svg
+++ b/static/svg/componenten_overzicht_grid.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
     <symbol id="component-illustration">
-        <g clip-path="url(#clip0_1450_2976)">
-            <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)" />
-            <g clip-path="url(#clip1_1450_2976)">
-                <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)" />
+            <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)" />
+                <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)" />
                 <rect width="2" height="540" transform="translate(69)"
                     fill="var(--ma-component-illustration-grid-color, #EEE)" />
                 <rect width="2" height="540" transform="translate(151)"
@@ -38,7 +36,6 @@
                     fill="var(--ma-component-illustration-grid-color, #EEE)" />
                 <rect width="960" height="2" transform="translate(0 474)"
                     fill="var(--ma-component-illustration-grid-color, #EEE)" />
-            </g>
             <path d="M70 65L70 475" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"
                 stroke-linecap="round" />
             <path d="M152 65L152 475" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"
@@ -61,7 +58,6 @@
                 stroke-linecap="round" />
             <path d="M890 65L890 475" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"
                 stroke-linecap="round" />
-        </g>
         <defs>
             <clipPath id="clip0_1450_2976">
                 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)" />

--- a/static/svg/componenten_overzicht_heading-group.svg
+++ b/static/svg/componenten_overzicht_heading-group.svg
@@ -1,8 +1,8 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
     <g>
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-        <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+        <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
     </g>
     <g fill="var(--ma-component-illustration-grid-color, #eee)">
         <rect width="2" height="540" transform="translate(69)"/>

--- a/static/svg/componenten_overzicht_heading.svg
+++ b/static/svg/componenten_overzicht_heading.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_icon-only-button.svg
+++ b/static/svg/componenten_overzicht_icon-only-button.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_icon.svg
+++ b/static/svg/componenten_overzicht_icon.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g fill="var(--ma-component-illustration-background-color, white)">
+<g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
 <rect width="960" height="540"/>
 <rect width="960" height="540"/>
 </g>

--- a/static/svg/componenten_overzicht_image.svg
+++ b/static/svg/componenten_overzicht_image.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-    <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+    <rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
     <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
     <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_input-group.svg
+++ b/static/svg/componenten_overzicht_input-group.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_642_3473)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_642_3473)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,14 +19,10 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="194" y="230" width="162" height="80" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="376" y="230" width="162" height="80" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="558" y="230" width="208" height="80" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-<g clip-path="url(#clip2_642_3473)">
 <path d="M218 250L218 290" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
-</g>
-</g>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_invalid-form-alert.svg
+++ b/static/svg/componenten_overzicht_invalid-form-alert.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_language-navigation.svg
+++ b/static/svg/componenten_overzicht_language-navigation.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g fill="var(--ma-component-illustration-background-color, white)">
+<g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
 <rect width="960" height="540"/>
 <rect width="960" height="540"/>
 </g>

--- a/static/svg/componenten_overzicht_legend.svg
+++ b/static/svg/componenten_overzicht_legend.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g fill="var(--ma-component-illustration-background-color, white)">
+<g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
     <rect width="960" height="540"/>
     <rect width="2" height="540" transform="translate(69)"/>
 </g>

--- a/static/svg/componenten_overzicht_link-list.svg
+++ b/static/svg/componenten_overzicht_link-list.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g fill="var(--ma-component-illustration-background-color, white)">
+<g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
 <rect width="960" height="540"/>
 <rect width="960" height="540"/>
 </g>

--- a/static/svg/componenten_overzicht_link.svg
+++ b/static/svg/componenten_overzicht_link.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_login-link.svg
+++ b/static/svg/componenten_overzicht_login-link.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_logo.svg
+++ b/static/svg/componenten_overzicht_logo.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1606_2760)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1606_2760)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,14 +19,12 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <g clip-path="url(#clip2_1606_2760)">
 <line x1="2" y1="-2" x2="231.287" y2="-2" transform="matrix(0.713689 0.700463 -0.297665 0.95467 233 190.591)" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 <line x1="2" y1="-2" x2="231.287" y2="-2" transform="matrix(0.713689 -0.700463 0.297665 0.95467 233.508 354)" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 </g>
 <path d="M237 189H396C397.105 189 398 189.895 398 191V352H235V191C235 189.895 235.895 189 237 189Z" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="442" y="250" width="240" height="40" rx="20" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_1606_2760">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_mark.svg
+++ b/static/svg/componenten_overzicht_mark.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_modal-dialog.svg
+++ b/static/svg/componenten_overzicht_modal-dialog.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -70,7 +70,6 @@
 <path d="M857.199 64L857.199 476" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 <path d="M873.602 64L873.602 476" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 <path d="M890 64L890 476" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
-<g filter="url(#filter0_d_640_2876)">
 <rect x="233" y="161" width="494" height="218" fill="var(--ma-component-illustration-background-color, white)"/>
 <rect x="273" y="209" width="346" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="273" y="241" width="240" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>

--- a/static/svg/componenten_overzicht_navigation-bar.svg
+++ b/static/svg/componenten_overzicht_navigation-bar.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g fill="var(--ma-component-illustration-background-color, white)">
+<g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
 <rect width="960" height="540"/>
 <rect width="960" height="540"/>
 </g>

--- a/static/svg/componenten_overzicht_note.svg
+++ b/static/svg/componenten_overzicht_note.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_2442)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_2442)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="153" y="192" width="654" height="156" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="191" y="246" width="480" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="191" y="278" width="240" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
@@ -31,7 +28,6 @@
 <rect x="149" y="99" width="494" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="149" y="466" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="149" y="140" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_641_2442">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_notification-banner.svg
+++ b/static/svg/componenten_overzicht_notification-banner.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_number-badge.svg
+++ b/static/svg/componenten_overzicht_number-badge.svg
@@ -1,6 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-    <g fill="var(--ma-component-illustration-background-color, white)">
+    <g fill="var(--ma-component-illustration-grid-background-color, #AAA)">
         <rect width="960" height="540"/>
     </g>
     <g fill="var(--ma-component-illustration-grid-color, #eee)">

--- a/static/svg/componenten_overzicht_number-input.svg
+++ b/static/svg/componenten_overzicht_number-input.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_ordered-list.svg
+++ b/static/svg/componenten_overzicht_ordered-list.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_page-body.svg
+++ b/static/svg/componenten_overzicht_page-body.svg
@@ -1,8 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1978_3282)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1978_3282)">
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -20,7 +18,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="112" y="197" width="736" height="147" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-dasharray="8 8"/>
 <path d="M65 58H895C896.105 58 897 58.8954 897 60V480C897 481.105 896.105 482 895 482H65C63.8954 482 63 481.105 63 480V60L63.0107 59.7959C63.113 58.7872 63.9643 58 65 58Z" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <path d="M73 66H887C888.105 66 889 66.8954 889 68V472C889 473.105 888.105 474 887 474H73C71.8954 474 71 473.105 71 472V68C71 66.8954 71.8954 66 73 66Z" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
@@ -38,7 +35,6 @@
 <line x1="2" y1="-2" x2="91.2858" y2="-2" transform="matrix(0.89773 -0.440547 0.529143 0.848533 151.258 169)" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 </g>
 <rect x="153" y="129" width="80" height="38" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-</g>
 <defs>
 <clipPath id="clip0_1978_3282">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_page-footer.svg
+++ b/static/svg/componenten_overzicht_page-footer.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_page-header.svg
+++ b/static/svg/componenten_overzicht_page-header.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_page-layout.svg
+++ b/static/svg/componenten_overzicht_page-layout.svg
@@ -1,8 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1978_3364)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1978_3364)">
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -20,7 +18,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <path d="M65 58H895C896.105 58 897 58.8954 897 60V480C897 481.105 896.105 482 895 482H65C63.8954 482 63 481.105 63 480V60L63.0107 59.7959C63.113 58.7872 63.9643 58 65 58Z" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <path d="M73 66H887C888.105 66 889 66.8954 889 68V472C889 473.105 888.105 474 887 474H73C71.8954 474 71 473.105 71 472V68C71 66.8954 71.8954 66 73 66Z" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="112" y="107" width="736" height="326" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
@@ -38,7 +35,6 @@
 <line x1="2" y1="-2" x2="91.2858" y2="-2" transform="matrix(0.89773 -0.440547 0.529143 0.848533 151.258 169)" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 </g>
 <rect x="153" y="129" width="80" height="38" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-</g>
 <defs>
 <clipPath id="clip0_1978_3364">
 <rect width="960" height="540" fill="white"/>

--- a/static/svg/componenten_overzicht_page-number-navigation.svg
+++ b/static/svg/componenten_overzicht_page-number-navigation.svg
@@ -1,8 +1,8 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_paragraph.svg
+++ b/static/svg/componenten_overzicht_paragraph.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_password-input.svg
+++ b/static/svg/componenten_overzicht_password-input.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_pre-heading.svg
+++ b/static/svg/componenten_overzicht_pre-heading.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_progress-bar.svg
+++ b/static/svg/componenten_overzicht_progress-bar.svg
@@ -1,8 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_2818)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -20,9 +19,7 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="235" y="260" width="490" height="20" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-<g clip-path="url(#clip2_641_2818)">
 <rect x="235" y="258" width="288" height="24" fill="var(--ma-component-illustration-color, #666)"/>
 </symbol>
 <use href='#component-illustration'/>

--- a/static/svg/componenten_overzicht_progress-circle.svg
+++ b/static/svg/componenten_overzicht_progress-circle.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1611_2781)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1611_2781)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <mask id="path-1-outside-1_1611_2781" maskUnits="userSpaceOnUse" x="389" y="179" width="182" height="182" fill="black">
 <rect fill="var(--ma-component-illustration-background-color, white)" x="389" y="179" width="182" height="182"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M563 270C563 224.16 525.84 187 480 187C434.16 187 397 224.16 397 270C397 315.84 434.16 353 480 353C525.84 353 563 315.84 563 270ZM547.007 270C547.007 232.997 517.01 203 480.007 203C443.004 203 413.007 232.997 413.007 270C413.007 307.003 443.004 337 480.007 337C517.01 337 547.007 307.003 547.007 270Z"/>
@@ -29,7 +26,6 @@
 <path d="M480 195C521.421 195 555 228.579 555 270L571 270C571 219.742 530.258 179 480 179L480 195ZM405 270C405 228.579 438.579 195 480 195L480 179C429.742 179 389 219.742 389 270L405 270ZM480 345C438.579 345 405 311.421 405 270L389 270C389 320.258 429.742 361 480 361L480 345ZM555 270C555 311.421 521.421 345 480 345L480 361C530.258 361 571 320.258 571 270L555 270ZM480.007 211C512.592 211 539.007 237.415 539.007 270L555.007 270C555.007 228.578 521.428 195 480.007 195L480.007 211ZM421.007 270C421.007 237.415 447.422 211 480.007 211L480.007 195C438.586 195 405.007 228.578 405.007 270L421.007 270ZM480.007 329C447.422 329 421.007 302.585 421.007 270L405.007 270C405.007 311.421 438.586 345 480.007 345L480.007 329ZM539.007 270C539.007 302.585 512.592 329 480.007 329L480.007 345C521.428 345 555.007 311.421 555.007 270L539.007 270Z" fill="var(--ma-component-illustration-color, #666)" mask="url(#path-1-outside-1_1611_2781)"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M480 187C525.84 187 563 224.16 563 270C563 315.84 525.84 353 480 353C434.16 353 397 315.84 397 270L412.993 270C412.993 307.003 442.99 337 479.993 337C516.996 337 546.993 307.003 546.993 270C546.993 232.999 517 203.004 480 203L480 187Z" fill="var(--ma-component-illustration-color, #666)"/>
 <path d="M480 187L479 187V186L480 186V187ZM563 270H564H563ZM397 270H396V269H397V270ZM412.993 270V269H413.993V270H412.993ZM546.993 270H547.993H546.993ZM480 203L480 204L479 204V203L480 203ZM480 186C526.392 186 564 223.608 564 270H562C562 224.713 525.287 188 480 188V186ZM564 270C564 316.392 526.392 354 480 354V352C525.287 352 562 315.287 562 270H564ZM480 354C433.608 354 396 316.392 396 270H398C398 315.287 434.713 352 480 352V354ZM397 269L412.993 269V271L397 271V269ZM479.993 338C442.438 338 411.993 307.555 411.993 270H413.993C413.993 306.451 443.542 336 479.993 336V338ZM547.993 270C547.993 307.555 517.548 338 479.993 338V336C516.444 336 545.993 306.451 545.993 270H547.993ZM480 202C517.552 202.004 547.993 232.447 547.993 270H545.993C545.993 233.551 516.447 204.004 480 204L480 202ZM479 203L479 187L481 187L481 203L479 203Z" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_1611_2781">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_progress-list.svg
+++ b/static/svg/componenten_overzicht_progress-list.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_2858)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_2858)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <g clip-path="url(#clip2_641_2858)">
 <circle cx="275" cy="188" r="21" fill="var(--ma-component-illustration-color, #666)"/>
 </g>
@@ -55,7 +52,6 @@
 <path d="M275 354L275 432" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-dasharray="6 8"/>
 </g>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M286.608 98.3905C287.129 98.9112 287.129 99.7554 286.608 100.276L273.275 113.609C272.754 114.13 271.91 114.13 271.389 113.609L264.723 106.943C264.202 106.422 264.202 105.578 264.723 105.057C265.243 104.536 266.087 104.536 266.608 105.057L272.332 110.781L284.723 98.3905C285.243 97.8698 286.087 97.8698 286.608 98.3905Z" fill="var(--ma-component-illustration-background-color, white)"/>
-</g>
 <defs>
 <clipPath id="clip0_641_2858">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_progress-steps.svg
+++ b/static/svg/componenten_overzicht_progress-steps.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_2858)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
-<g clip-path="url(#clip1_641_2858)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <g clip-path="url(#clip2_641_2858)">
 <circle cx="275" cy="188" r="21" fill="var(--ma-component-illustration-color, #666)"/>
 </g>
@@ -55,7 +52,6 @@
 <path d="M275 354L275 432" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-dasharray="6 8"/>
 </g>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M286.608 98.3905C287.129 98.9112 287.129 99.7554 286.608 100.276L273.275 113.609C272.754 114.13 271.91 114.13 271.389 113.609L264.723 106.943C264.202 106.422 264.202 105.578 264.723 105.057C265.243 104.536 266.087 104.536 266.608 105.057L272.332 110.781L284.723 98.3905C285.243 97.8698 286.087 97.8698 286.608 98.3905Z" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
-</g>
 <defs>
 <clipPath id="clip0_641_2858">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_pull-quote.svg
+++ b/static/svg/componenten_overzicht_pull-quote.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_2076_3569)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
-<g clip-path="url(#clip1_2076_3569)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, var(--ma-component-illustration-background-color, white))"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="234" y="401" width="494" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="234" y="442" width="411" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="264" y="275" width="463" height="24" rx="12" fill="var(--ma-component-illustration-color, #666)"/>
@@ -36,7 +33,6 @@
 <path d="M200 106C193.403 104.343 187.769 100 181 100M199.343 106.943C194.95 107.744 191.408 110.095 187.295 111.456C185.139 112.169 182.956 113.001 181.27 114.435" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M200 311C193.403 309.343 187.769 305 181 305M199.343 311.943C194.95 312.744 191.408 315.095 187.295 316.456C185.139 317.169 182.956 318.001 181.27 319.435" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M98 211.55C98 168.377 114.768 141.316 135.91 125.141C156.958 109.038 182.168 103.849 199.019 104.003L198.981 108.003C182.832 107.856 158.542 112.861 138.34 128.317C118.233 143.701 102 169.564 102 211.55C102 253.533 118.226 278.307 138.273 292.365C158.435 306.504 182.697 309.965 198.854 308.787L199.146 312.776C182.303 314.004 157.065 310.428 135.977 295.64C114.774 280.77 98 254.725 98 211.55Z" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 <defs>
 <clipPath id="clip0_2076_3569">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_radio-button.svg
+++ b/static/svg/componenten_overzicht_radio-button.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_2903)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_2903)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,13 +19,11 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <g clip-path="url(#clip2_641_2903)">
 <circle cx="480" cy="270" r="79" stroke="var(--ma-component-illustration-color, #666)" stroke-width="8"/>
 </g>
 <g clip-path="url(#clip3_641_2903)">
 <circle cx="480" cy="270" r="42" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </g>
 <defs>
 <clipPath id="clip0_641_2903">

--- a/static/svg/componenten_overzicht_radio-group.svg
+++ b/static/svg/componenten_overzicht_radio-group.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_612_1270)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_612_1270)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <g clip-path="url(#clip2_612_1270)">
 <circle cx="275" cy="270" r="19" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 </g>
@@ -36,7 +33,6 @@
 <rect x="317" y="344" width="246" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <g clip-path="url(#clip5_612_1270)">
 <circle cx="9" cy="9" r="9" transform="matrix(-1 0 0 1 284 179)" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </g>
 <defs>
 <clipPath id="clip0_612_1270">

--- a/static/svg/componenten_overzicht_range.svg
+++ b/static/svg/componenten_overzicht_range.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3012)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3012)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="235" y="260" width="490" height="20" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <g clip-path="url(#clip2_641_3012)">
 <rect x="235" y="258" width="120" height="24" fill="var(--ma-component-illustration-color, #666)"/>
@@ -29,7 +26,6 @@
 <g clip-path="url(#clip3_641_3012)">
 <rect x="334" y="249" width="42" height="42" rx="21" fill="var(--ma-component-illustration-background-color, white)"/>
 <circle cx="355" cy="270" r="19" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-</g>
 </g>
 </symbol>
 <use href='#component-illustration'/>

--- a/static/svg/componenten_overzicht_rich-text-content.svg
+++ b/static/svg/componenten_overzicht_rich-text-content.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3038)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3038)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="233" y="262" width="494" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="303" width="494" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="344" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
@@ -35,7 +32,6 @@
 <circle cx="241" cy="494" r="8" fill="var(--ma-component-illustration-color, #666)"/>
 </g>
 <rect x="265" y="486" width="462" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_root.svg
+++ b/static/svg/componenten_overzicht_root.svg
@@ -1,8 +1,6 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1978_3021)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1978_3021)">
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -20,7 +18,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="63" y="58" width="834" height="424" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-dasharray="8 8"/>
 <rect x="71" y="66" width="818" height="408" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="104" y="100" width="752" height="340" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
@@ -38,7 +35,6 @@
 <line x1="2" y1="-2" x2="91.2858" y2="-2" transform="matrix(0.89773 -0.440547 0.529143 0.848533 151.258 169)" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 </g>
 <rect x="153" y="129" width="80" height="38" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-</g>
 <defs>
 <clipPath id="clip0_1978_3021">
 <rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>

--- a/static/svg/componenten_overzicht_select-combobox.svg
+++ b/static/svg/componenten_overzicht_select-combobox.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_1338_2890)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_1338_2890)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
-</g>
 <rect x="235" y="165" width="490" height="309" rx="2" fill="var(--ma-component-illustration-background-color, white)"/>
 <rect x="235" y="165" width="490" height="309" rx="2" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <rect x="273" y="211" width="349" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
@@ -33,7 +30,6 @@
 <rect x="257" y="98" width="81" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <g clip-path="url(#clip2_1338_2890)">
 <path d="M348 86L348 126" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
-</g>
 </g>
 <defs>
 <clipPath id="clip0_1338_2890">

--- a/static/svg/componenten_overzicht_select.svg
+++ b/static/svg/componenten_overzicht_select.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3080)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3080)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,11 +19,9 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="235" y="230" width="490" height="80" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M671.586 262.586C672.367 261.805 673.633 261.805 674.414 262.586L685 273.172L695.586 262.586C696.367 261.805 697.633 261.805 698.414 262.586C699.195 263.367 699.195 264.633 698.414 265.414L686.414 277.414C685.633 278.195 684.367 278.195 683.586 277.414L671.586 265.414C670.805 264.633 670.805 263.367 671.586 262.586Z" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="257" y="262" width="246" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_separator.svg
+++ b/static/svg/componenten_overzicht_separator.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3110)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3110)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,7 +19,6 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <g clip-path="url(#clip2_641_3110)">
 <path d="M151 270L809 270" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4" stroke-linecap="round"/>
 </g>
@@ -31,7 +28,6 @@
 <rect x="233" y="140" width="494" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="427" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="233" y="181" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_side-navigation.svg
+++ b/static/svg/componenten_overzicht_side-navigation.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3152)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3152)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,13 +19,11 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
 <rect x="315" y="262" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="315" y="98" width="330" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="315" y="180" width="248" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="315" y="344" width="166" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="315" y="426" width="246" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_skip-link.svg
+++ b/static/svg/componenten_overzicht_skip-link.svg
@@ -1,9 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<g clip-path="url(#clip0_641_3227)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<g clip-path="url(#clip1_641_3227)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
@@ -21,25 +19,11 @@
 <rect width="960" height="2" transform="translate(0 310)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 392)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="960" height="2" transform="translate(0 474)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
-</g>
-<g filter="url(#filter0_d_641_3227)">
+<rect x="323" y="236" width="330" height="84" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="315" y="228" width="330" height="84" fill="var(--ma-component-illustration-background-color, white)"/>
 <rect x="317" y="230" width="326" height="80" stroke="var(--ma-component-illustration-color, #666)" stroke-width="4"/>
-</g>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M345 256C346.105 256 347 256.895 347 258V270C347 272.209 348.791 274 351 274H366.172L361.586 269.414C360.805 268.633 360.805 267.367 361.586 266.586C362.367 265.805 363.633 265.805 364.414 266.586L372.414 274.586C373.195 275.367 373.195 276.633 372.414 277.414L364.414 285.414C363.633 286.195 362.367 286.195 361.586 285.414C360.805 284.633 360.805 283.367 361.586 282.586L366.172 278H351C346.582 278 343 274.418 343 270V258C343 256.895 343.895 256 345 256Z" fill="var(--ma-component-illustration-color, #666)"/>
 <rect x="397" y="262" width="206" height="16" rx="8" fill="var(--ma-component-illustration-color, #666)"/>
-</g>
-<defs>
-<filter id="filter0_d_641_3227" x="315" y="228" width="338" height="92" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dx="8" dy="8"/>
-<feComposite in2="hardAlpha" operator="out"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.254902 0 0 0 0 0.321569 0 0 0 1 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_641_3227"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_641_3227" result="shape"/>
-</filter>
-</defs>
 </symbol>
 <use href="#component-illustration"/>
 </svg>

--- a/static/svg/componenten_overzicht_spinner.svg
+++ b/static/svg/componenten_overzicht_spinner.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_641_3256)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_641_3256)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_status-badge.svg
+++ b/static/svg/componenten_overzicht_status-badge.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_strong.svg
+++ b/static/svg/componenten_overzicht_strong.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_641_3321)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_641_3321)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_sub-heading.svg
+++ b/static/svg/componenten_overzicht_sub-heading.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1223_2600)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1223_2600)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_subscript.svg
+++ b/static/svg/componenten_overzicht_subscript.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_superscript.svg
+++ b/static/svg/componenten_overzicht_superscript.svg
@@ -1,7 +1,7 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration" viewBox="0 0 960 540">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_switch.svg
+++ b/static/svg/componenten_overzicht_switch.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_641_3352)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_641_3352)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_table.svg
+++ b/static/svg/componenten_overzicht_table.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3379)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3379)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_tabs.svg
+++ b/static/svg/componenten_overzicht_tabs.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3423)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3423)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_task-list.svg
+++ b/static/svg/componenten_overzicht_task-list.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1223_2661)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1223_2661)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_task-navigation.svg
+++ b/static/svg/componenten_overzicht_task-navigation.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1866_2999)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1866_2999)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -33,10 +33,10 @@
 </g>
 <defs>
 <clipPath id="clip0_1866_2999">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 </clipPath>
 <clipPath id="clip1_1866_2999">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 </clipPath>
 </defs>
 </symbol>

--- a/static/svg/componenten_overzicht_text-area.svg
+++ b/static/svg/componenten_overzicht_text-area.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3506)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3506)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_text-input.svg
+++ b/static/svg/componenten_overzicht_text-input.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_621_1274)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_621_1274)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_toggletip.svg
+++ b/static/svg/componenten_overzicht_toggletip.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3535)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3535)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_unordered-list.svg
+++ b/static/svg/componenten_overzicht_unordered-list.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3575)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3575)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_variable-heading.svg
+++ b/static/svg/componenten_overzicht_variable-heading.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3621)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3621)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_video.svg
+++ b/static/svg/componenten_overzicht_video.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_642_3651)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_642_3651)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #eee)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #eee)"/>

--- a/static/svg/componenten_overzicht_youtube-video.svg
+++ b/static/svg/componenten_overzicht_youtube-video.svg
@@ -1,9 +1,9 @@
 <svg width="960" height="540" viewBox="0 0 960 540" fill="none" xmlns="http://www.w3.org/2000/svg">
 <symbol id="component-illustration">
 <g clip-path="url(#clip0_1450_3049)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <g clip-path="url(#clip1_1450_3049)">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 <rect width="2" height="540" transform="translate(69)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(151)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
 <rect width="2" height="540" transform="translate(233)" fill="var(--ma-component-illustration-grid-color, #EEE)"/>
@@ -34,10 +34,10 @@
 </g>
 <defs>
 <clipPath id="clip0_1450_3049">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 </clipPath>
 <clipPath id="clip1_1450_3049">
-<rect width="960" height="540" fill="var(--ma-component-illustration-background-color, white)"/>
+<rect width="960" height="540" fill="var(--ma-component-illustration-grid-background-color, #AAA)"/>
 </clipPath>
 <clipPath id="clip2_1450_3049">
 <rect width="96" height="64" fill="var(--ma-component-illustration-background-color, white)" transform="translate(432 238)"/>


### PR DESCRIPTION
Na de versimpeling van de achtergrond kleur op de component overzichtspagina waren er een paar componenten waar de achtergrond van de geschetste component nu niet goed naar voren kwam. Daarom introduceert deze PR de --component-illustration-grid-background-color variable die voor alle statussen gelijk is en de --component-illustration-background-color voor de background van eventuele componenten in de schets.

<img width="882" height="290" alt="Screenshot 2026-08-07 at 16 21 40" src="https://github.com/user-attachments/assets/768d7295-f305-4e00-9e5b-f2c52bf2979a" />
