### PR TITLE
fix: link styling

### DIFF
--- a/docs/handboek/developer/02-aan-de-slag/01-prototypes/01-zonder-front-end-framework.mdx
+++ b/docs/handboek/developer/02-aan-de-slag/01-prototypes/01-zonder-front-end-framework.mdx
@@ -29,7 +29,7 @@ Dit is het ontwerp dat in dit voorbeeld zo goed mogelijk wordt nagebouwd: [Het o
     ></iframe>
   </div>
 </div>
-<a href="/examples/zonder-front-end-framework.html" rel="noopener noreferrer">
+<a class="nl-link" href="/examples/zonder-front-end-framework.html" rel="noopener noreferrer">
   Bovenstaande voorbeeldpagina in volledig scherm bekijken
 </a>
 

--- a/docs/richtlijnen/formulieren/fieldset/1-legend/_guideline.mdx
+++ b/docs/richtlijnen/formulieren/fieldset/1-legend/_guideline.mdx
@@ -17,7 +17,7 @@ VoiceOver leest de legend twee keer voor bij het eerste veld van een groep, dit 
 
 ## Koppen in een legend
 
-Een legend kan ook een kopje bevatten. Zorg er wel voor dat het niveau van deze kopjes klopt in de <a href="https://www.a11yproject.com/posts/how-to-accessible-heading-structure/">hiërarchische koppenstructuur</a> van de hele pagina.
+Een legend kan ook een kopje bevatten. Zorg er wel voor dat het niveau van deze kopjes klopt in de [hiërarchische koppenstructuur](https://www.a11yproject.com/posts/how-to-accessible-heading-structure/) van de hele pagina.
 
 ```html
 <fieldset>

--- a/docs/wcag/2.1.01.mdx
+++ b/docs/wcag/2.1.01.mdx
@@ -94,25 +94,25 @@ Deze tests moeten ook slagen als de website ingezoomd is. Er kunnen dan andere i
   <dt class="dl__term">Gerelateerde successcriteria</dt>
   <dd class="dl__definition">
     Als je test voor bediening met het toetsenbord, test dan meteen gerelateerde successcriteria zoals:
-    <ul>
-      <li><a href="/wcag/1.4.11">WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content</a> voor de focusweergave</li>
-      <li><a href="/wcag/2.1.2">WCAG-succescriterium 2.1.2 Geen toetsenbordval</a></li>
-      <li><a href="/wcag/2.1.3">WCAG-succescriterium 2.1.3 Toetsenbord (geen uitzondering)</a></li>
-      <li><a href="/wcag/2.4.1">WCAG-succescriterium 2.4.1 Blokken omzeilen</a></li>
-      <li><a href="/wcag/2.4.3">WCAG-succescriterium 2.4.3 Focus volgorde</a></li>
-      <li><a href="/wcag/2.4.7">WCAG-succescriterium 2.4.7 Focus zichtbaar</a></li>
-      <li><a href="/wcag/2.4.13">WCAG-succescriterium 2.4.13 Focusweergave</a></li>
-      <li><a href="/wcag/3.2.1">WCAG-succescriterium 3.2.1 Bij focus</a></li>
-    </ul>
+
+    - [WCAG-succescriterium 1.4.11 Contrast van niet-tekstuele content](/wcag/1.4.11) voor de focusweergave
+    - [WCAG-succescriterium 2.1.2 Geen toetsenbordval](/wcag/2.1.2)
+    - [WCAG-succescriterium 2.1.3 Toetsenbord (geen uitzondering)](/wcag/2.1.3)
+    - [WCAG-succescriterium 2.4.1 Blokken omzeilen](/wcag/2.4.1)
+    - [WCAG-succescriterium 2.4.3 Focus volgorde](/wcag/2.4.3)
+    - [WCAG-succescriterium 2.4.7 Focus zichtbaar](/wcag/2.4.7)
+    - [WCAG-succescriterium 2.4.13 Focusweergave](/wcag/2.4.13)
+    - [WCAG-succescriterium 3.2.1 Bij focus](/wcag/3.2.1)
+
   </dd>
   <dt class="dl__term">Volgorde in de code</dt>
   <dd class="dl__definition">Een uitklappend menu en andere overlappende onderdelen zoals chatvensters en cookiemeldingen zijn lastig voor het toetsenbord. Visueel worden ze vaak onderaan een pagina geplaatst. Voor een toetsenbord is het einde van de pagina vaak erg onhandig. De code van een uitklappend menu plaats je het liefst direct na de knop die het opent. Zo zit het voor de navigatie volgorde op een logische plek. De gebruiker opent iets, en met een opvolgende `tab` is het gefocust.</dd>
   <dt class="dl__term">Dialoogvensters</dt>
-  <dd class="dl__definition">Bij het openen van een dialoogvenster moet de focus hierop geplaatst worden. Welk onderdeel de focus krijgt hangt af van de inhoud van het venster. Dit wordt uitgelegd op de Engelstalige pagina <a href="https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboard_interaction"><span lang="en">Dialog (Modal) Pattern</span></a> van de ARIA Authoring Practices Guide (APG). Als een dialoogvenster sluit moet de focus weer terug naar het element dat het opende.</dd>
+  <dd class="dl__definition">Bij het openen van een dialoogvenster moet de focus hierop geplaatst worden. Welk onderdeel de focus krijgt hangt af van de inhoud van het venster. Dit wordt uitgelegd op de Engelstalige pagina [<span lang="en">Dialog (Modal) Pattern</span>](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#keyboard_interaction) van de ARIA Authoring Practices Guide (APG). Als een dialoogvenster sluit moet de focus weer terug naar het element dat het opende.</dd>
   <dt class="dl__term">Hover</dt>
   <dd class="dl__definition">Elementen die reageren op een hover moeten ook werken met het toetsenbord. Denk hierbij bijvoorbeeld aan tooltips en uitklappende menus.</dd>
   <dt class="dl__term">Tabindex</dt>
-  <dd class="dl__definition"><a href="/richtlijnen/formulieren/toetsenbord/tabindex">Gebruik geen positieve tabindex</a>. Voeg ook geen `tabindex="0"` toe aan elementen die niet interactief zijn. Als een element wel interactief moet zijn, voeg ook een naam toe voor <a href="/wcag/4.1.2">WCAG-succescriterium 4.1.2 Naam, rol, waarde</a>.</dd>
+  <dd class="dl__definition">[Gebruik geen positieve tabindex](/richtlijnen/formulieren/toetsenbord/tabindex). Voeg ook geen `tabindex="0"` toe aan elementen die niet interactief zijn. Als een element wel interactief moet zijn, voeg ook een naam toe voor [WCAG-succescriterium 4.1.2 Naam, rol, waarde](/wcag/4.1.2).</dd>
   <dt class="dl__term">Ingewikkelde onderdelen</dt>
   <dd class="dl__definition">Kaarten en visualizaties zijn soms erg lastig toegankelijk te maken voor een toetsenbord. Als er geen andere oplossing mogelijk is kan er een alternatief geboden worden. Zo kan een kaart met markers en adressen aangevuld worden met een lijst met dezelfde adressen. Let wel op dat het alternatief een volwaardige oplossing is.</dd>
 </dl>

--- a/docs/wcag/3.3.07.mdx
+++ b/docs/wcag/3.3.07.mdx
@@ -38,7 +38,7 @@ import Summary from "./summaries/_3.3.7-summary.md";
   <div class="dl__item">
     <dt class="dl__term">Doel</dt>
     <dd class="dl__definition">
-      Maak het gemakkelijker om een <a href="/woordenlijst/#proces">proces</a> van meerdere stappen te doorlopen.
+      Maak het gemakkelijker om een [proces](/woordenlijst/#proces) van meerdere stappen te doorlopen.
     </dd>
   </div>
   <div class="dl__item">

--- a/packages/website/src/components/table-of-content/table-of-content.astro
+++ b/packages/website/src/components/table-of-content/table-of-content.astro
@@ -17,3 +17,12 @@ import '@nl-design-system-candidate/link-css/link.css';
 </ma-table-of-contents>
 
 <script src="./table-of-content.client.ts"></script>
+<script>
+  const toc = document.querySelector('ma-table-of-contents');
+  const codeExampleHeadings = new Set(
+    document.querySelectorAll(
+      '.nlds-guideline h1, .nlds-guideline h2, .nlds-guideline h3, .nlds-guideline h4, .nlds-guideline h5,.nlds-guideline h6',
+    ),
+  );
+  toc.headingsToIgnore = toc.headingsToIgnore.union(codeExampleHeadings);
+</script>

--- a/packages/website/src/components/table-of-content/utils.client.ts
+++ b/packages/website/src/components/table-of-content/utils.client.ts
@@ -86,6 +86,7 @@ export function createListItemsForHeading(heading: HTMLHeadingElement, listItem?
     const link = li.querySelector('a') || document.createElement('a');
     link.href = `#${heading.id}`;
     link.innerText = heading.innerText;
+    link.classList.add('nl-link');
     li.replaceChildren(link);
   } else {
     li.innerText = heading.innerText;

--- a/src/components/Guideline.tsx
+++ b/src/components/Guideline.tsx
@@ -1,5 +1,5 @@
 import { IconMoodHappy, IconMoodSad } from '@tabler/icons-react';
-import { Paragraph } from '@utrecht/component-library-react/dist/css-module';
+import { Paragraph, Link } from '@utrecht/component-library-react/dist/css-module';
 import clsx from 'clsx';
 import type { HTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 import Markdown from 'react-markdown';
@@ -26,7 +26,8 @@ export const Guideline = ({ title, appearance, description, children, figure }: 
   const ContainerElement = figure ? 'figure' : 'div';
   const CaptionElement = figure ? 'figcaption' : 'div';
 
-  const _description = typeof description === 'string' ? <Markdown>{description}</Markdown> : description;
+  const _description =
+    typeof description === 'string' ? <Markdown components={{ a: Link }}>{description}</Markdown> : description;
 
   return (
     <ContainerElement

--- a/src/components/HeartbeatEpisode.tsx
+++ b/src/components/HeartbeatEpisode.tsx
@@ -28,7 +28,9 @@ export const HeartbeatEpisode = ({ id, headingLevel }: HeartbeatEpisodeProps) =>
         </Heading>
       )}
       {episode.description.map((description) => (
-        <Markdown key={description}>{description}</Markdown>
+        <Markdown key={description} components={{ a: Link }}>
+          {description}
+        </Markdown>
       ))}
       {episode.youtubeId ? (
         <VideoPlayer id={episode.youtubeId} title={episode.title} />

--- a/src/components/TermsList.tsx
+++ b/src/components/TermsList.tsx
@@ -33,7 +33,9 @@ const Definition = ({ paragraph }: DefinitionProps) => <Paragraph>{paragraph}</P
 
 const Source = ({ name, url }: SourceProps) => (
   <li>
-    <a href={url}>{name}</a>
+    <a className="nl-link" href={url}>
+      {name}
+    </a>
   </li>
 );
 

--- a/test/docs/markdown-as-children.mdx
+++ b/test/docs/markdown-as-children.mdx
@@ -22,4 +22,6 @@ This is a paragraph
 - this is a list
 - with 2 items
 
+[A link](#)
+
 </SpotlightSection>

--- a/test/docs/markdown-as-children.spec.ts
+++ b/test/docs/markdown-as-children.spec.ts
@@ -10,4 +10,6 @@ test('renders markdown as children of a component', async ({ page }) => {
   await expect(page.locator('p').filter({ hasText: /This is a paragraph/i })).toBeVisible();
 
   await expect(page.locator('li').filter({ hasText: /this is a list/i })).toBeVisible();
+
+  await expect(page.locator('a').filter({ hasText: /A link/i })).toHaveClass('nl-link');
 });


### PR DESCRIPTION
- **fix: Add link styling to unstyled links**
- **fix: table of content ignore headings in code examples**
- **test: add test to check if link class is added in markdown children**

closes: #4488 
closes: #4490 
