### PR TITLE
feat: styling acceptatie criteria component

### DIFF
--- a/docs/componenten/alert/index.mdx
+++ b/docs/componenten/alert/index.mdx
@@ -43,7 +43,6 @@ keywords:
 ---
 
 {/* @license CC0-1.0 */}
-
 import componentProgress from "@nl-design-system/component-progress/dist/index.json";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
@@ -56,6 +55,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import * as Acceptatiecriteria from "./\_acceptatiecriteria.tsx";
 
 {/* Add name and description for the component */}

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -60,6 +60,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import * as Acceptatiecriteria from "./\_acceptatiecriteria.tsx";
 
 import { Markdown } from "@site/src/components/Markdown";

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -59,6 +59,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -56,6 +56,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -63,6 +63,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -67,6 +67,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/form-field-description/index.mdx
+++ b/docs/componenten/form-field-description/index.mdx
@@ -39,6 +39,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Form Field Description";

--- a/docs/componenten/form-field-error-message/index.mdx
+++ b/docs/componenten/form-field-error-message/index.mdx
@@ -42,6 +42,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Form Field Error Message";

--- a/docs/componenten/form-field-label/index.mdx
+++ b/docs/componenten/form-field-label/index.mdx
@@ -37,6 +37,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Form Field Label";

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -91,6 +91,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import * as Acceptatiecriteria from "./\_acceptatiecriteria.tsx";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";

--- a/docs/componenten/icon/index.mdx
+++ b/docs/componenten/icon/index.mdx
@@ -41,6 +41,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Markdown } from "@site/src/components/Markdown";
 import Guidelines from "./\_guidelines.md";

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -62,6 +62,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -53,6 +53,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/note/index.mdx
+++ b/docs/componenten/note/index.mdx
@@ -22,6 +22,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_component.md";
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -48,6 +48,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/ordered-list/index.mdx
+++ b/docs/componenten/ordered-list/index.mdx
@@ -49,6 +49,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Ordered List";

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -88,6 +88,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -65,6 +65,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 import { DesignTokens } from "@site/src/components/DesignTokens";
 import { Markdown } from "@site/src/components/Markdown";
 import Usage from "./_usage.md";

--- a/docs/componenten/text-input/index.mdx
+++ b/docs/componenten/text-input/index.mdx
@@ -48,6 +48,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Text Input";

--- a/docs/componenten/unordered-list/index.mdx
+++ b/docs/componenten/unordered-list/index.mdx
@@ -53,6 +53,7 @@ import {
   Introduction,
   Related,
 } from "@site/src/components/ComponentPage";
+import { Checklist, ChecklistItem } from "@site/src/components/Checklist";
 
 {/* Add name and description for the component */}
 export const title = "Unordered List";

--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -12,7 +12,7 @@ import { removeH1FromMarkdown } from './markdown-plugins/remark-remove-h1';
 import { remarkUnwrapDiv } from './markdown-plugins/remark-unwrap-div';
 import { remarkCanvasFix } from './markdown-plugins/remark-canvas-fix';
 import { remarkUndoInlineDirectives } from './markdown-plugins/remark-undo-inline-directives';
-import { videoplayerClientLoadPlugin } from './markdown-plugins/remark-videoplayer-client-load';
+import { clientLoadPlugin } from './markdown-plugins/remark-client-load';
 const siteUrl = 'https://nldesignsystem.nl';
 
 const cspDevConfig: AstroUserConfig = {
@@ -132,7 +132,7 @@ export default defineConfig({
         remarkDirective,
         remarkUndoInlineDirectives,
         remarkAdmonitions,
-        videoplayerClientLoadPlugin,
+        clientLoadPlugin(['Videoplayer', 'VideoPlayer', 'Checklist']),
         removeH1FromMarkdown(),
       ],
       rehypePlugins: [

--- a/packages/website/markdown-plugins/remark-client-load/index.ts
+++ b/packages/website/markdown-plugins/remark-client-load/index.ts
@@ -2,15 +2,19 @@ import type { Root } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxAttribute } from 'mdast-util-mdx-jsx';
 import { visit } from 'unist-util-visit';
 
-/* The <VideoPlayer /> component needs client side logic to function. In Astro
-it (thus) needs the `client:load` prop. Instead of placing this burden on the
-author, lets add it automatically for each instance */
-export function videoplayerClientLoadPlugin() {
-  return (tree: Root) => {
-    visit(tree, 'mdxJsxFlowElement', (node: MdxJsxFlowElement) => {
-      if (!node.name || !node.attributes) return;
+/* Some components need client side logic to function. In Astro they need the
+`client:load` prop. Instead of placing this burden on the author, add it
+automatically for each instance. Pass the list of component names that need
+hydration. */
+export function clientLoadPlugin(componentNames: string[]) {
+  const nameSet = new Set(componentNames);
+  return function plugin() {
+    return (tree: Root) => {
+      visit(tree, 'mdxJsxFlowElement', (node: MdxJsxFlowElement) => {
+        if (!node.name || !node.attributes) return;
 
-      if (node.name === 'Videoplayer' || node.name === 'VideoPlayer') {
+        if (!nameSet.has(node.name)) return;
+
         // Check if client:load attribute already exists
         const hasClientLoad = node.attributes.some(
           (attr): attr is MdxJsxAttribute => attr.type === 'mdxJsxAttribute' && attr.name === 'client:load',
@@ -25,7 +29,7 @@ export function videoplayerClientLoadPlugin() {
           };
           node.attributes.push(newAttr);
         }
-      }
-    });
+      });
+    };
   };
 }

--- a/packages/website/src/components/accordion/accordion.tsx
+++ b/packages/website/src/components/accordion/accordion.tsx
@@ -1,15 +1,15 @@
 import '@utrecht/accordion-css/dist/index.css';
 import '@nl-design-system-candidate/button-css/button.css';
 import clsx from 'clsx';
-import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import type { HTMLAttributes, ReactNode, ElementType } from 'react';
 import { IconChevronDown } from '@tabler/icons-react';
 import { Heading, type HeadingProps } from '@nl-design-system-candidate/heading-react';
 import './accordion.css';
 
-export interface AccordionProps {
+export interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+  as?: ElementType;
   name?: string;
-  children: ReactNode;
-  className?: string;
 }
 
 export type AccordionLabelProps =
@@ -29,11 +29,16 @@ export type AccordionLabelProps =
 export type AccordionSectionProps = HTMLAttributes<HTMLDetailsElement> &
   AccordionLabelProps & { classNamePanel?: string };
 
-export const Accordion = ({ className, ...props }: AccordionProps) => {
+export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(({ as, className, children, ...props }, ref) => {
+  const Component = (as || 'div') as ElementType;
   const _className = clsx('ma-utrecht-accordion', 'utrecht-accordion', className);
 
-  return <div className={_className}>{props.children}</div>;
-};
+  return (
+    <Component ref={ref} className={_className} {...props}>
+      {children}
+    </Component>
+  );
+});
 
 export const AccordionSection = ({
   className,

--- a/packages/website/src/components/heading/heading.tsx
+++ b/packages/website/src/components/heading/heading.tsx
@@ -1,4 +1,4 @@
-import { Heading as NLHeading, type HeadingProps } from '@nl-design-system-candidate/heading-react';
+import { Heading as NLHeading, type HeadingProps as NLHeadingProps } from '@nl-design-system-candidate/heading-react';
 import '@nl-design-system-candidate/heading-css/heading.css';
 
 export const Heading = (props: HeadingProps) => <NLHeading {...props} />;
@@ -8,3 +8,5 @@ export const Heading3 = (props: HeadingProps) => <NLHeading {...props} level={3}
 export const Heading4 = (props: HeadingProps) => <NLHeading {...props} level={4} />;
 export const Heading5 = (props: HeadingProps) => <NLHeading {...props} level={5} />;
 export const Heading6 = (props: HeadingProps) => <NLHeading {...props} level={6} />;
+
+export type HeadingProps = NLHeadingProps;

--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -56,6 +56,8 @@ import { withCurrentIndication } from 'src/navigation/with-current-indication.ts
 import '@components/sr-only/sr-only.css';
 import '@components/body-copy/body-copy.css';
 import '../../../../src/components/Guideline.css';
+import '../../../../src/components/Checklist.css';
+import '@nl-design-system-candidate/data-badge-css/data-badge.css';
 import '../../../../src/components/Canvas/CanvasAstro.css';
 
 export interface Props {

--- a/packages/website/src/utils/mdx-components.astro
+++ b/packages/website/src/utils/mdx-components.astro
@@ -5,12 +5,9 @@ import ComponentOverview from '@components/docusaurus-mocks/ComponentOverview.as
 import ComponentAnatomy from '@components/docusaurus-mocks/ComponentAnatomy.astro';
 import { CriteriaList } from '@components/criteria-list/criteria-list';
 import { CriteriaListItem } from '@components/criteria-list/criteria-list-item';
-import { Checklist, ChecklistItem } from '@site/src/components/Checklist';
 
 export const MDXComponents = async ({ navigationItems } = {}) => {
   return {
-    Checklist,
-    ChecklistItem,
     ComponentOverview,
     ComponentAnatomy,
     CriteriaList,

--- a/src/components/Checklist.css
+++ b/src/components/Checklist.css
@@ -20,11 +20,6 @@
   padding-inline-start: 0;
 }
 
-.ma-new-checklist__title {
-  font-weight: 600;
-  margin-inline-start: 5px;
-}
-
 .ma-new-checklist__content {
   margin-block-end: 20px;
   margin-inline-start: 20px;
@@ -75,13 +70,22 @@
 
 .ma-filter-block {
   background-color: var(--basis-color-accent-1-bg-default);
-  border-color: var(--basis-color-accent-1-border-subtle);
+  border-color: transparent;
   border-style: solid;
   border-width: 1px;
   display: flex;
   flex-direction: column;
-  margin-block-end: var(--basis-space-row-xl);
-  padding-block: var(--basis-space-block-lg);
-  padding-inline: var(--basis-space-inline-lg);
+  margin-block-end: var(--basis-space-block-2xl);
+  margin-block-start: var(--basis-space-block-xl);
+  padding-block: var(--basis-space-block-xl);
+  padding-inline: var(--basis-space-inline-xl);
   row-gap: var(--basis-space-block-md);
+}
+
+.ma-filter-block .utrecht-form-field:first-of-type {
+  margin-block-start: var(--basis-space-block-lg);
+}
+
+.ma-filter-block + .ma-new-checklist .ma-new-checklist__item {
+  margin-block-start: -1px;
 }

--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import { Link } from '@site/src/components/Link';
 import { successCriteriaMap } from '@site/src/components/wcag22';
-import { BadgeList, Button, type HeadingProps } from '@utrecht/component-library-react';
+import { BadgeList } from '@utrecht/component-library-react';
+import { Paragraph } from '../../packages/website/src/components/paragraph/paragraph';
+import { Button } from '../../packages/website/src/components/button/button';
+import { Accordion, AccordionSection } from '../../packages/website/src/components/accordion/accordion';
+import { Heading, type HeadingProps } from '../../packages/website/src/components/heading/heading';
 import { DataBadge } from '@nl-design-system-candidate/data-badge-react/css';
 import clsx from 'clsx';
 import { useId, useState } from 'react';
 import './Checklist.css';
-import { Checkbox, Fieldset, FormField, FormLabel, Heading } from '@utrecht/component-library-react/css-module';
+import { Checkbox, Fieldset, FormField, FormLabel } from '@utrecht/component-library-react/css-module';
 
 /**
  * ChecklistItemProps defines expected variables for the item to test.
@@ -56,20 +60,22 @@ export const ChecklistItem = ({ title, sc, children, tags }: React.PropsWithChil
   }
   return (
     <li
+      data-tags={tags.join(',')}
       className={clsx(
         'ma-new-checklist__item',
         tags.map((tag) => `ma-new-checklist__item--${tag}`),
       )}
     >
       {/* <Checkbox className="ma-new-checklist__checkbox" aria-labelledby={labelId} /> */}
-      <details>
-        <summary>
+      <AccordionSection
+        label={
           <span className="ma-new-checklist__title" id={labelId}>
             {title}
           </span>
-        </summary>
-        <div className="ma-new-checklist__content">
-          {children && <div>{children}</div>}
+        }
+      >
+        <div className="ma-new-checklist__content ma-flow">
+          {children && <div className="ma-flow">{children}</div>}
           <BadgeList className="ma-new-checklist__badge-list">
             {badgeTags.map((tag, index) => {
               let badge = <DataBadge key={index}>{tag}</DataBadge>;
@@ -95,19 +101,19 @@ export const ChecklistItem = ({ title, sc, children, tags }: React.PropsWithChil
             })}
           </BadgeList>
         </div>
-      </details>
+      </AccordionSection>
     </li>
   );
 };
 
 export const Checklist = ({ children, headingLevel }: ChecklistProps) => {
-  const allTags = new Set<string>();
-  React.Children.forEach(children, (child) => {
-    (child?.props?.tags || []).forEach((tag) => allTags.add(tag));
-  });
-  const childrenLength = React.Children.count(children);
+  const listRef = React.useRef<HTMLDivElement>(null);
 
-  const [selectedTags, setSelectedTags] = useState<string[]>(Array.from(allTags.values()));
+  const [allChildren, setAllChildren] = useState<HTMLLIElement[]>([]);
+  const [allTheTags, setAllTheTags] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [totalChildren, setTotalChildren] = useState<number>(0);
+  const [shownChildren, setShownChildren] = useState<number>(0);
 
   const isSelectedTag = (tag: string) => selectedTags.includes(tag);
 
@@ -121,44 +127,64 @@ export const Checklist = ({ children, headingLevel }: ChecklistProps) => {
 
   const fieldsetLabelId = useId();
 
-  const filteredChildren =
-    selectedTags.length >= 1
-      ? React.Children.map(children, (child) => {
-          return child.props.tags.some((tag) => selectedTags.includes(tag)) ? child : null;
-        }).filter((x) => x)
-      : [children];
+  React.useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const tags = new Set<string>();
+    const items = Array.from(list.querySelectorAll<HTMLLIElement>('[data-tags]'));
+    items.forEach((li) => {
+      li.dataset.tags?.split(',')?.forEach((tag) => tag && tags.add(tag));
+    });
+    setAllChildren(items);
+    setAllTheTags([...tags]);
+    setTotalChildren(items.length);
+    setSelectedTags([...tags]);
+  }, []);
 
-  const hiddenItemCount = childrenLength - filteredChildren.length;
+  React.useEffect(() => {
+    const tagsToTest = selectedTags;
+    const childrenToShow = [];
+    const childrenToHide = [];
+
+    allChildren.forEach((child) => {
+      const tags = child.dataset.tags?.split(',') || [];
+      if (tags.some((tag) => tagsToTest.includes(tag))) {
+        childrenToShow.push(child);
+      } else {
+        childrenToHide.push(child);
+      }
+    });
+
+    childrenToShow.forEach((child) => (child.hidden = false));
+    childrenToHide.forEach((child) => (child.hidden = true));
+
+    setShownChildren(childrenToShow.length);
+  }, [selectedTags]);
 
   return (
     <div>
       <div className="ma-filter-block">
         <Fieldset aria-describedby="filter-results" aria-labelledby={fieldsetLabelId}>
-          <Heading level={Number(headingLevel)} id={fieldsetLabelId}>
+          <Heading level={headingLevel} id={fieldsetLabelId}>
             Filter acceptatiecriteria voor:
           </Heading>
-          {Array.from(allTags.values()).map((tag) => (
+          {Array.from(allTheTags).map((tag) => (
             <FormField key={tag} type="checkbox">
-              <Checkbox
-                defaultChecked={isSelectedTag(tag)}
-                checked={isSelectedTag(tag)}
-                id={tag}
-                onChange={() => toggleTag(tag)}
-              />
+              <Checkbox checked={isSelectedTag(tag)} id={tag} onChange={() => toggleTag(tag)} />
               <FormLabel htmlFor={tag}>{tag}</FormLabel>
             </FormField>
           ))}
         </Fieldset>
         <div>
           <>
-            <p role="status">
-              {childrenLength - hiddenItemCount} van de {childrenLength} items zijn nu zichtbaar.
-            </p>
-            {hiddenItemCount >= 1 ? (
+            <Paragraph role="status">
+              {shownChildren} van de {totalChildren} items zijn nu zichtbaar.
+            </Paragraph>
+            {shownChildren < totalChildren ? (
               <Button
-                appearance="secondary-action-button"
+                purpose="secondary"
                 onClick={() => {
-                  setSelectedTags(Array.from(allTags.values()));
+                  setSelectedTags(allTheTags);
                 }}
               >
                 Toon alles
@@ -170,9 +196,9 @@ export const Checklist = ({ children, headingLevel }: ChecklistProps) => {
         </div>
       </div>
 
-      <ul className="ma-new-checklist" role="list">
-        {filteredChildren}
-      </ul>
+      <Accordion as="ul" className="ma-new-checklist" role="list" ref={listRef}>
+        {children}
+      </Accordion>
     </div>
   );
 };

--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -6,11 +6,10 @@ import { Paragraph } from '../../packages/website/src/components/paragraph/parag
 import { Button } from '../../packages/website/src/components/button/button';
 import { Accordion, AccordionSection } from '../../packages/website/src/components/accordion/accordion';
 import { Heading, type HeadingProps } from '../../packages/website/src/components/heading/heading';
-import { DataBadge } from '@nl-design-system-candidate/data-badge-react/css';
+import { DataBadge } from '@nl-design-system-candidate/data-badge-react';
 import clsx from 'clsx';
 import { useId, useState } from 'react';
-import './Checklist.css';
-import { Checkbox, Fieldset, FormField, FormLabel } from '@utrecht/component-library-react/css-module';
+import { Checkbox, Fieldset, FormField, FormLabel } from '@utrecht/component-library-react';
 
 /**
  * ChecklistItemProps defines expected variables for the item to test.

--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from '@site/src/components/Link';
 import { successCriteriaMap } from '@site/src/components/wcag22';
-import { BadgeList } from '@utrecht/component-library-react';
+import { BadgeList, Checkbox, Fieldset, FormField, FormLabel } from '@utrecht/component-library-react';
 import { Paragraph } from '../../packages/website/src/components/paragraph/paragraph';
 import { Button } from '../../packages/website/src/components/button/button';
 import { Accordion, AccordionSection } from '../../packages/website/src/components/accordion/accordion';
@@ -9,7 +9,6 @@ import { Heading, type HeadingProps } from '../../packages/website/src/component
 import { DataBadge } from '@nl-design-system-candidate/data-badge-react';
 import clsx from 'clsx';
 import { useId, useState } from 'react';
-import { Checkbox, Fieldset, FormField, FormLabel } from '@utrecht/component-library-react';
 
 /**
  * ChecklistItemProps defines expected variables for the item to test.
@@ -66,7 +65,6 @@ export const ChecklistItem = ({ title, sc, children, tags }: React.PropsWithChil
         tags.map((tag) => `ma-new-checklist__item--${tag}`),
       )}
     >
-      {/* <Checkbox className="ma-new-checklist__checkbox" aria-labelledby={labelId} /> */}
       <AccordionSection
         label={
           <span className="ma-new-checklist__title" id={labelId}>

--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -58,7 +58,8 @@ export const ChecklistItem = ({ title, sc, children, tags }: React.PropsWithChil
     }
   }
   return (
-    <li
+    <div
+      role="listitem"
       data-tags={tags.join(',')}
       className={clsx(
         'ma-new-checklist__item',
@@ -101,7 +102,7 @@ export const ChecklistItem = ({ title, sc, children, tags }: React.PropsWithChil
           </BadgeList>
         </div>
       </AccordionSection>
-    </li>
+    </div>
   );
 };
 
@@ -195,7 +196,7 @@ export const Checklist = ({ children, headingLevel }: ChecklistProps) => {
         </div>
       </div>
 
-      <Accordion as="ul" className="ma-new-checklist" role="list" ref={listRef}>
+      <Accordion className="ma-new-checklist" role="list" ref={listRef}>
         {children}
       </Accordion>
     </div>

--- a/src/theme/MDXContent/index.tsx
+++ b/src/theme/MDXContent/index.tsx
@@ -21,7 +21,6 @@ import { isValidElement } from 'react';
 import { OverviewPage } from '@site/src/components/OverviewPage';
 import DocCardList from '@theme/DocCardList';
 import { ComponentOverview } from '@site/src/components/ComponentOverview';
-import { Checklist, ChecklistItem } from '@site/src/components/Checklist';
 import { ComponentAnatomy } from '@site/src/components/ComponentAnatomy';
 import { CriteriaList, CriteriaListItem } from '@site/src/components/ComponentCriteriaList';
 import { TaskList, TaskListItem } from '@nl-design-system-community/ma-task-list-react/dist/ma-task-list.mjs';
@@ -76,8 +75,6 @@ export default function MDXContent({ children }: Props): ReactElement {
         OverviewPage,
         DocCardList,
         ComponentOverview,
-        Checklist,
-        ChecklistItem,
         ComponentAnatomy,
         CriteriaList,
         CriteriaListItem,

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -7,6 +7,9 @@ import { PageLayout } from '@utrecht/page-layout-react/css';
 
 import '@utrecht/root-css/dist/html/index.css';
 import '@utrecht/document-css/dist/html/index.css';
+import '@utrecht/component-library-css/dist/html.css';
+import '@utrecht/data-badge-css/dist/index.css';
+import '../components/Checklist.css';
 
 // Default implementation, that you can customize
 function Root({ children }: PropsWithChildren<object>) {


### PR DESCRIPTION
Deze PR doet een aantal dingen:

1. De `<Checklist>` component kijkt naar de al gerenderde DOM om uit te vinden op welke tags er gefiltered kan worden, in plaats van over de children heen te lopen. Dat laatste kan in Astro niet
2. De `<Checklist>` componenten moeten (in Astro) een `client:load` attribute krijgen, om aan Astro aan te geven dat deze clientside logica nodig hebben. Daar hebben we een remark plugin voor. Deze plugin is generiek gemaakt. Maar om dit te laten werken heeft Astro een import nodig in de mdx file, inplaats van dat die via MDXComponents wordt mee gegeven. Alle imports zijn dus ook weer terug.
3. De Checlist items zijn nu geen kale `details`/`summary` meer, maar het Accordion component wordt gebruikt
4. Verplaatst de css import naar een plek waar CSP hashes gegenereerd kan worden

closes: #4474
