### PR TITLE
fix: CSP warnings

### DIFF
--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -87,6 +87,16 @@ export default defineConfig({
     },
     resolve: {
       noExternal: [/@rijkshuisstijl-community\/.*/],
+      alias: [
+        {
+          find: '@utrecht/component-library-react/dist/css-module',
+          replacement: '@utrecht/component-library-react',
+        },
+        {
+          find: '@utrecht/component-library-react/css-module',
+          replacement: '@utrecht/component-library-react',
+        },
+      ],
     },
   },
 

--- a/test/csp/csp.spec.ts
+++ b/test/csp/csp.spec.ts
@@ -29,7 +29,7 @@ test.describe('CSP issues', () => {
   pathnames.forEach((pathname) => {
     test(pathname, async ({ page }) => {
       const url = CONFIG.baseUrl + pathname;
-      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      await page.goto(url, { waitUntil: 'networkidle' });
     });
   });
 });


### PR DESCRIPTION
- **fix: alias utrecht css module in Astro to prevent csp issues**
- **chore: let csp test wait until `networkidle` before testing**
