### PR TITLE
docs: Richtlijnen voor Grootte (starten met target size)

### DIFF
--- a/docs/richtlijnen/stijl/icons/index.mdx
+++ b/docs/richtlijnen/stijl/icons/index.mdx
@@ -4,8 +4,8 @@ title_sm: Iconen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Introductie iconen
-sidebar_position: 4
-navigation_order: 4
+sidebar_position: 5
+navigation_order: 5
 pagination_label: Introductie richtlijnen voor iconen
 description: Iconen worden gebruikt om extra betekenis te geven. Ze brengen boodschappen in één oogopslag over en vestigen aandacht op belangrijke informatie. Ook kunnen ze hulp bieden aan iemand met een cognitieve beperking of als iemand moeite heeft met taal.
 slug: /richtlijnen/stijl/iconen/

--- a/docs/richtlijnen/stijl/size/1-interactive/_category_.json
+++ b/docs/richtlijnen/stijl/size/1-interactive/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Interactieve elementen",
+  "link": {
+    "type": "doc",
+    "id": "index"
+  }
+}

--- a/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
+++ b/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
@@ -44,7 +44,7 @@ In het [Start-thema](/handboek/huisstijl/themas/start-thema) zijn beide tokens i
 
 Gebruik deze tokens wanneer je de minimale grootte van het aanwijsgebied instelt. Zo blijft de minimale grootte consistent tussen componenten en thema’s en kan je de waarde centraal aanpassen.
 
-## Meer informatie:
+## Bronnen:
 
 - [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA)
 - [2.5.5 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA)

--- a/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
+++ b/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
@@ -15,7 +15,7 @@ Gebruik voor interactieve elementen een minimaal aanwijsgebied van 48px bij 48px
 
 Deze succescriteria beschrijven een minimum. Voor een prettigere bediening is het aan te raden om interactieve elementen groter te maken.
 
-Google adviseert binnen Material Design een aanwijsgebied van minimaal 48dp bij 48dp. [Onderzoek naar het selecteren van aanwijsgebieden](https://youtu.be/nTNwZXVRGdY?si=G_XSNEPZTB5oepGx&t=163) laat zien dat de nauwkeurigheid toeneemt naarmate een doel groter wordt. Bij tweedimensionale aanwijsgebieden bereikt de nauwkeurigheid rond 48dp een plateau. (ResearchGate)
+Google adviseert binnen Material Design een aanwijsgebied van minimaal 48dp bij 48dp. Dit komt in CSS overeen met 48px bij 48px. [Uit onderzoek](https://youtu.be/nTNwZXVRGdY?si=G_XSNEPZTB5oepGx&t=163) blijkt dat grotere aanwijsgebieden makkelijker te raken zijn. Rond 48dp wordt de nauwkeurigheid nauwelijks nog beter.
 
 ## Het zichtbare element hoeft niet 48px groot te zijn
 

--- a/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
+++ b/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
@@ -1,0 +1,54 @@
+<!-- @license CC0-1.0 -->
+
+Zorg ervoor dat interactieve elementen zoals buttons, links en formuliervelden groot genoeg zijn om makkelijk aan te wijzen met een muis, vinger of andere aanwijzer. Een groter aanwijsgebied maakt het makkelijker om een element te selecteren en verkleint de kans dat iemand per ongeluk een ander element activeert.
+
+Het aanwijsgebied (target size) hoeft niet gelijk te zijn aan de zichtbare grootte van een element. Een icoon van 24px kan bijvoorbeeld onderdeel zijn van een groter interactief element. Door rondom het icoon ruimte toe te voegen, kan het aanwijsgebied groter worden zonder dat het icoon zelf groter wordt.
+
+## Gebruik minimaal 48px voor interactieve elementen
+
+Gebruik voor interactieve elementen een minimaal aanwijsgebied van 48px bij 48px. Dit geldt zowel voor de breedte als de hoogte van het aanwijsgebied.
+
+48px is groter dan de minimale afmetingen die WCAG voorschrijft. WCAG 2.2 kent twee succescriteria voor de grootte van het aanwijsgebied:
+
+- [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA) schrijft een aanwijsgebied van minimaal 24px bij 24px voor, met voorwaarden voor de ruimte tussen aanwijsgebieden.
+- [2.5.5 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA) schrijft een aanwijsgebied van minimaal 44px bij 44px voor.
+
+Deze succescriteria beschrijven een minimum. Voor een prettigere bediening is het aan te raden om interactieve elementen groter te maken.
+
+Google adviseert binnen Material Design een aanwijsgebied van minimaal 48dp bij 48dp. [Onderzoek naar het selecteren van aanwijsgebieden](https://youtu.be/nTNwZXVRGdY?si=G_XSNEPZTB5oepGx&t=163) laat zien dat de nauwkeurigheid toeneemt naarmate een doel groter wordt. Bij tweedimensionale aanwijsgebieden bereikt de nauwkeurigheid rond 48dp een plateau. (ResearchGate)
+
+## Het zichtbare element hoeft niet 48px groot te zijn
+
+De minimale grootte gaat over het aanwijsgebied en niet per se over de zichtbare vorm van een component.
+
+Een icoon kan bijvoorbeeld 24px bij 24px zijn, terwijl de button eromheen een aanwijsgebied van 48px bij 48px heeft. Gebruik hiervoor bijvoorbeeld padding of een minimale breedte en hoogte.
+
+Op deze manier kunnen kleine iconen en andere visuele elementen onderdeel zijn van een goed bruikbaar interactief element, zonder dat ze visueel onnodig groot worden.
+
+## Houd rekening met de ruimte tussen elementen
+
+Een groter aanwijsgebied voorkomt niet automatisch dat iemand het verkeerde element activeert. Wanneer interactieve elementen dicht bij elkaar staan, kan het aanwijsgebied van het ene element overlappen met het andere.
+
+Zorg daarom ook voor voldoende ruimte tussen interactieve elementen. Een veelgebruikte richtlijn is om minimaal 8px ruimte tussen aanwijsgebieden te houden.
+
+De richtlijn voor de ruimte tussen interactieve elementen staat verder beschreven in [Reserveer ruimte tussen interactieve elementen](/richtlijnen/stijl/ruimte/interactieve-elementen).
+
+## Gebruik design tokens voor de minimale grootte
+
+Om componenten binnen NL Design System van een minimale grootte voor het aanwijsgebied te voorzien, zijn op het [Common-niveau](/handboek/huisstijl/design-tokens) twee [basis-tokens](/handboek/huisstijl/basis-tokens) beschikbaar:
+
+- `basis.pointer-target.min-block-size`
+- `basis.pointer-target.min-inline-size`
+
+In het [Start-thema](/handboek/huisstijl/themas/start-thema) zijn beide tokens ingesteld op `3rem` (48px).
+
+Gebruik deze tokens wanneer je de minimale grootte van het aanwijsgebied instelt. Zo blijft de minimale grootte consistent tussen componenten en thema’s en kan je de waarde centraal aanpassen.
+
+## Meer informatie:
+
+- [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA)
+- [2.5.5 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA)
+- [Designing A11y with Material Design - Youtube](https://youtu.be/nTNwZXVRGdY?si=G_XSNEPZTB5oepGx&t=163)
+- [Designing better target sizes – Ahmad Shadeed](https://ishadeed.com/article/target-size/)
+- [Target Size and 2.5.5 - Adrian Roselli](https://adrianroselli.com/2019/06/target-size-and-2-5-5.html)
+- [Accessible tap targets – web.dev](https://web.dev/articles/accessible-tap-targets)

--- a/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
+++ b/docs/richtlijnen/stijl/size/1-interactive/_guideline.md
@@ -1,6 +1,8 @@
 <!-- @license CC0-1.0 -->
 
-Zorg ervoor dat interactieve elementen zoals buttons, links en formuliervelden groot genoeg zijn om makkelijk aan te wijzen met een muis, vinger of andere aanwijzer. Een groter aanwijsgebied maakt het makkelijker om een element te selecteren en verkleint de kans dat iemand per ongeluk een ander element activeert.
+Geef interactieve elementen een groot aanwijzergebied van tenminste 48 bij 48 pixels, zodat gebruikers gemakkelijk het juiste onderdeel kunnen activeren. Uit onderzoek blijkt dat de 2 keer het minimum van WCAG het meest gebruiksvriendelijk is voor bijvoorbeeld buttons, links en formuliervelden.
+
+<!-- technically is het "4 keer het minimum van WCAG" omdat het een oppervlakte is, maar ik denk dat 2 keer duidelijker is: 2 x 24px = 48px -->
 
 Het aanwijsgebied (target size) hoeft niet gelijk te zijn aan de zichtbare grootte van een element. Een icoon van 24px kan bijvoorbeeld onderdeel zijn van een groter interactief element. Door rondom het icoon ruimte toe te voegen, kan het aanwijsgebied groter worden zonder dat het icoon zelf groter wordt.
 

--- a/docs/richtlijnen/stijl/size/1-interactive/index.mdx
+++ b/docs/richtlijnen/stijl/size/1-interactive/index.mdx
@@ -1,14 +1,17 @@
 ---
-title: Reserveer ruimte tussen interactieve elementen
+title: Maak interactieve elementen groot genoeg
 title_sm: Interactieve elementen
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: Interactieve elementen
-pagination_label: Reserveer ruimte tussen interactieve elementen
-description: Om ruimte consistent toe te passen is het verstandig om te werken met een vaste set aan waardes die oplopen in grootte. Een zogenoemde spacing scale.
-slug: /richtlijnen/stijl/ruimte/interactieve-elementen
+pagination_label: Maak interactieve elementen groot genoeg
+description: Maak interactieve elementen groot genoeg
+slug: /richtlijnen/stijl/grootte/interactieve-elementen
 keywords:
-  - ruimte
+  - grootte
+  - aanwijsgebied
+  - target-size
+  - minimal-target-size
   - interactieve elementen
 ---
 
@@ -18,7 +21,7 @@ import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_fo
 import Code from "./_code.mdx";
 import Guideline from "./_guideline.md";
 
-# Reserveer ruimte tussen interactieve elementen
+# Maak interactieve elementen groot genoeg
 
 <Guideline />
 <Code />

--- a/docs/richtlijnen/stijl/size/_category_.json
+++ b/docs/richtlijnen/stijl/size/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "Grootte",
+  "link": {
+    "type": "doc",
+    "id": "richtlijnen/stijl/size/index"
+  },
+  "customProps": {
+    "showLinkedDoc": true
+  }
+}

--- a/docs/richtlijnen/stijl/size/index.mdx
+++ b/docs/richtlijnen/stijl/size/index.mdx
@@ -1,0 +1,37 @@
+---
+title: Introductie richtlijnen voor grootte
+title_sm: Grootte
+hide_title: true
+hide_table_of_contents: false
+sidebar_label: Introductie grootte
+sidebar_position: 4
+navigation_order: 4
+pagination_label: Introductie richtlijnen voor grootte
+description: Grootte (Sizing in het Engels) helpt bij het bepalen van de afmetingen van elementen. Door grootte op een voorspelbare manier toe te passen kun je de bruikbaarheid en toegankelijkheid van een interface verbeteren.
+slug: /richtlijnen/stijl/grootte/
+keywords:
+  - grootte
+---
+
+{/* @license CC0-1.0 */}
+
+import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_footer_info.md";
+
+# Richtlijnen NL Design System voor grootte
+
+Grootte (_Sizing_ in het Engels) helpt bij het bepalen van de afmetingen van elementen. Door grootte op een voorspelbare manier toe te passen kun je de bruikbaarheid en toegankelijkheid van een interface verbeteren.
+
+## Overzicht richtlijnen
+
+<OverviewPage excludeDocIDs={["richtlijnen/stijl/size/index"]} />
+
+## Gerelateerde WCAG-succescriteria:
+
+- [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA)
+- [2.5.8 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA)
+
+## Deel je gebruikersonderzoek
+
+Er is nog veel te onderzoeken over het gebruik van grootte. Doe je gebruikersonderzoek? Deel dan alsjeblieft je bevindingen op [gebruikersonderzoeken.nl](http://gebruikersonderzoeken.nl/) zodat we hiervan allemaal kunnen leren.
+
+<FooterInfo />

--- a/docs/richtlijnen/stijl/size/index.mdx
+++ b/docs/richtlijnen/stijl/size/index.mdx
@@ -19,7 +19,7 @@ import FooterInfo from "@nl-design-system-unstable/documentation/richtlijnen/_fo
 
 # Richtlijnen NL Design System voor grootte
 
-Grootte (_Sizing_ in het Engels) helpt bij het bepalen van de afmetingen van elementen. Door grootte op een voorspelbare manier toe te passen kun je de bruikbaarheid en toegankelijkheid van een interface verbeteren.
+Grootte helpt bij het bepalen van de afmetingen van elementen. In het Engels is de term "_size_", die zie je vaak terug in naamgeving van design tokens. Door grootte op een voorspelbare manier toe te passen kun je de bruikbaarheid en toegankelijkheid van een interface verbeteren.
 
 ## Overzicht richtlijnen
 

--- a/docs/richtlijnen/stijl/space/3-spacing-concepts/_guideline.md
+++ b/docs/richtlijnen/stijl/space/3-spacing-concepts/_guideline.md
@@ -1,6 +1,6 @@
 <!-- @license CC0-1.0 -->
 
-Binnen NL Design System is ruimte conceptueel opgezet door vijf herbruikbare spacing scales: Inline, Block, Text, Column en Row. Deze 'spacing concepten' worden met behulp van Design Tokens toegepast op alle componenten en templates.
+Binnen NL Design System is ruimte conceptueel opgezet met vijf herbruikbare spacing scales: Inline, Block, Text, Column en Row. De naamgeving sluit aan bij de logische eigenschappen (Logical Properties) van CSS, die ruimte beschrijven onafhankelijk van de schrijfrichting of taal. Deze spacing concepten worden met behulp van design tokens toegepast op componenten en templates.
 
 **Let wel**: gebruik 'Spacing' design tokens enkel voor ruimte binnen en tussen componenten. Gebruik 'Sizing' design tokens voor de grootte van elementen.
 

--- a/docs/richtlijnen/stijl/space/3-spacing-concepts/index.mdx
+++ b/docs/richtlijnen/stijl/space/3-spacing-concepts/index.mdx
@@ -8,8 +8,11 @@ pagination_label: Maak gebruik van de spacing concepten
 description: Binnen NL Design System is ruimte conceptueel opgezet door vijf herbruikbare spacing scales, dit zijn Inline, Block, Text, Column en Row.
 slug: /richtlijnen/stijl/ruimte/spacing-concepten
 keywords:
-  - kleurcontrast
-  - tekst
+  - ruimte
+  - spacing
+  - concepten
+  - logische eigenschappen
+  - logical properties
 ---
 
 {/* @license CC0-1.0 */}

--- a/docs/richtlijnen/stijl/space/7-interactive/_guideline.md
+++ b/docs/richtlijnen/stijl/space/7-interactive/_guideline.md
@@ -1,7 +1,46 @@
 <!-- @license CC0-1.0 -->
 
-Hoewel WCAG wel een richtlijnen heeft voor de grootte van het aanwijsgebied (_target size_), wordt er niets vermeld over ruimte tussen interactieve elementen. Toch is het aan te raden om tussen interactieve elementen wat ruimte te reserveren. Op die manier neemt de kans om onbedoeld iets te activeren af.
+Hoewel WCAG wel een richtlijn heeft voor de grootte van het aanwijsgebied (_target size_), wordt er niets vermeld over ruimte tussen interactieve elementen. Toch is het aan te raden om voldoende ruimte te reserveren tussen interactieve elementen, zoals buttons, links en formuliervelden. Hierdoor is de kans kleiner dat iemand per ongeluk het verkeerde element activeert.
+
+Dit is vooral belangrijk wanneer interactieve elementen met een vinger of andere grove aanwijzer worden bediend. Voor mensen met een motorische beperking, zoals een bevende hand, kan het lastig zijn om precies een interactief element aan te wijzen. Op een small viewport staan interactieve elementen bovendien vaak dichter bij elkaar. Voldoende ruimte tussen de elementen helpt om ze beter van elkaar te onderscheiden en verkleint de kans op een verkeerde activatie.
+
+## Gebruik minimaal 8px ruimte
+
+Houd minimaal 8px (0.5rem) ruimte tussen de aanwijsgebieden van interactieve elementen. Dit geldt zowel voor de horizontale als de verticale ruimte.
+
+Een aanwijsgebied is het gebied waarmee iemand een interactief element kan bedienen. Het aanwijsgebied kan groter zijn dan het zichtbare element. Een icoon van 24px kan bijvoorbeeld een aanwijsgebied van 48px hebben.
+
+Door ruimte tussen de aanwijsgebieden te houden, verklein je de kans dat iemand per ongeluk een ander interactief element activeert.
+
+Deze richtlijn sluit aan bij de aanbevolen minimale grootte van het aanwijsgebied. Gebruik voor interactieve elementen een aanwijsgebied van minimaal 48px bij 48px. Zie hiervoor [Maak interactieve elementen groot genoeg](/richtlijnen/stijl/grootte/interactieve-elementen).
+
+## Gebruik extra ruimte tussen grote interactieve elementen
+
+Bij grote interactieve elementen, zoals een Card as Link, kan het prettig zijn om meer ruimte tussen de elementen te gebruiken dan de minimale 8px.
+
+Dit is vooral belangrijk op kleinere schermen, waar meerdere grote interactieve elementen vaak onder elkaar staan. Extra ruimte maakt de afzonderlijke elementen duidelijker van elkaar te onderscheiden en verkleint de kans dat iemand per ongeluk het verkeerde element activeert.
 
 Voor iemand met een bevende hand kan een website lastiger te gebruiken zijn als grote delen van het scherm interactief (button of link) zijn.
 
-![Drie verticaal gestapelde vlakken met daarin het woord 'Interactie element'. Tussen deze vlakken bevindt zich een lege ruimte met de tekst 'witruimte'](https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_stijl_ruimte_interactieve-elementen.png)
+## Houd interactieve elementen die bij elkaar horen bij elkaar
+
+Extra ruimte tussen interactieve elementen is niet altijd nodig. Wanneer meerdere interactieve elementen samen één geheel vormen, kan extra witruimte de visuele groepering juist verstoren.
+
+Dit geldt bijvoorbeeld voor menu-items in een gestapelde navigatie. Door tussen ieder item extra ruimte toe te voegen, kunnen de items als losse elementen gaan aanvoelen in plaats van als onderdelen van één menu.
+
+In deze situaties is het belangrijker dat de interactieve elementen als één groep herkenbaar zijn. Zorg wel dat de afzonderlijke aanwijsgebieden groot genoeg zijn en dat duidelijk is welk gebied bij welk interactief element hoort.
+
+Gebruik daarom niet zomaar extra witruimte tussen alle interactieve elementen. Kijk naar de relatie tussen de elementen en gebruik ruimte om onderscheid te maken waar dat nodig is, maar behoud de visuele samenhang van elementen die bij elkaar horen.
+
+## Grootte en ruimte samen
+
+De richtlijnen voor grootte en ruimte vullen elkaar aan:
+
+- Zorg voor een aanwijsgebied van minimaal 48px bij 48px.
+- Houd minimaal 8px ruimte tussen aanwijsgebieden.
+- Gebruik extra ruimte wanneer grote interactieve elementen dicht bij elkaar staan.
+- Voeg niet automatisch extra ruimte toe wanneer interactieve elementen samen één visuele groep vormen.
+
+Zo zijn interactieve elementen groot genoeg om te bedienen en voldoende van elkaar gescheiden om vergissingen te voorkomen, zonder dat de visuele samenhang van groepen verloren gaat.
+
+[Maak interactieve elementen groot genoeg](/richtlijnen/stijl/grootte/interactieve-elementen) voor meer informatie over de minimale grootte van het aanwijsgebied.

--- a/docs/richtlijnen/stijl/space/7-interactive/index.mdx
+++ b/docs/richtlijnen/stijl/space/7-interactive/index.mdx
@@ -5,7 +5,7 @@ hide_title: true
 hide_table_of_contents: false
 sidebar_label: Interactieve elementen
 pagination_label: Reserveer ruimte tussen interactieve elementen
-description: Om ruimte consistent toe te passen is het verstandig om te werken met een vaste set aan waardes die oplopen in grootte. Een zogenoemde spacing scale.
+description: Voldoende ruimte tussen interactieve elementen helpt om ze van elkaar te onderscheiden en voorkomt dat iemand per ongeluk het verkeerde element activeert.
 slug: /richtlijnen/stijl/ruimte/interactieve-elementen
 keywords:
   - ruimte

--- a/docs/richtlijnen/stijl/space/index.mdx
+++ b/docs/richtlijnen/stijl/space/index.mdx
@@ -28,8 +28,6 @@ Ruimte (_Spacing_ in het Engels) helpt bij het organiseren van inhoud. Door ruim
 ## Gerelateerde WCAG-succescriteria:
 
 - [1.4.12 Tekstafstand](/wcag/1.4.12) (niveau AA)
-- [2.5.8 Grootte van het aanwijsgebied (minimum)](/wcag/2.5.8) (niveau AA)
-- [2.5.8 Grootte van het aanwijsgebied (uitgebreid)](/wcag/2.5.5) (niveau AAA)
 
 ## Bronnen
 


### PR DESCRIPTION
[Preview](https://documentatie-git-docs-add-grootte-documentatie-nl-design-system.vercel.app/richtlijnen/stijl/grootte/interactieve-elementen/)

Met deze PR

- voegen we 'Grootte' toe als sub-categorie onder 'Richtlijnen / Stijl'.
- Passen we enkele keywords aan (die niet klopte)
- Breiden we de introductie van spacing concepten aan met de benoeming van de term logical properties.