### PR TITLE
test: limit SEO e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "test-a11y": "playwright test test/a11y/axe.test.ts --workers=8",
     "test-a11y:next": "playwright test test/a11y/axe.next.test.ts --workers=8",
     "test-e2e": "playwright test test/e2e/ --workers=8",
+    "test-seo": "playwright test test/e2e/seo.spec.ts --workers=8",
+    "test-seo-full": "E2E_SEO_ALL_PAGES=1 playwright test test/e2e/seo.spec.ts --workers=8",
     "test-visual": "playwright test test/visual/",
     "test-csp": "playwright test test/csp/",
     "test-content": "playwright test test/docs/",

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -9,6 +9,7 @@ const CONFIG = {
   sitemap: '/sitemap-index.xml',
 };
 
+// A selection of urls coverig all different templates configurations. A minimal set of paths to cover all template paths so all combinations are testable without testing every single page
 const pathnamesSelection = [
   // Homepage
   '/',
@@ -36,9 +37,10 @@ const pathnamesSelection = [
 ];
 
 test.describe('SEO values', async () => {
-  const pathnames = process.env.FULL_SEO
-    ? getPathnamesFromSitemap(`${CONFIG.sitemapDir}${CONFIG.sitemap}`)
-    : pathnamesSelection;
+  const pathnames =
+    process.env.E2E_SEO_ALL_PAGES === '1'
+      ? getPathnamesFromSitemap(`${CONFIG.sitemapDir}${CONFIG.sitemap}`)
+      : pathnamesSelection;
 
   pathnames.forEach(async (pathname) => {
     test.describe(pathname, async () => {

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -9,8 +9,36 @@ const CONFIG = {
   sitemap: '/sitemap-index.xml',
 };
 
+const pathnamesSelection = [
+  // Homepage
+  '/',
+
+  // [...slug].astro - DetailLayout - nl - No Image
+  '/handboek/introductie/',
+
+  // [...slug].astro - OverviewLayout - nl
+  '/componenten/',
+
+  // [...slug].astro - OverviewLayout - en - Image
+  '/events/design-systems-week/en/',
+
+  // [...component].astro - keyword/description
+  '/accordion/',
+
+  // [...overview].astro - OverviewLayout - index.json
+  '/handboek/organisatie/overzicht/',
+
+  // [...wcag].astro - conformance-level
+  '/wcag/1.1.1/',
+
+  // .astro page (not a template)
+  '/zoeken/',
+];
+
 test.describe('SEO values', async () => {
-  const pathnames = await getPathnamesFromSitemap(`${CONFIG.sitemapDir}${CONFIG.sitemap}`);
+  const pathnames = process.env.FULL_SEO
+    ? getPathnamesFromSitemap(`${CONFIG.sitemapDir}${CONFIG.sitemap}`)
+    : pathnamesSelection;
 
   pathnames.forEach(async (pathname) => {
     test.describe(pathname, async () => {


### PR DESCRIPTION
Deze PR kiest een aantal URLs met de meeste variatie in template logica en runt de seo test enkel op deze urls, inplaats van elke bestaande url. Op deze manier blijft het vertouwen hoog maar het aantal tests behapbaar
