### PR TITLE
docs: verduidelijk pull request substap in Theme Storybook URL stap

### DIFF
--- a/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
+++ b/docs/handboek/definition-of-done/community-stappenplan/voor-organisaties.mdx
@@ -336,7 +336,13 @@ export const ORGANISATIE_PREFIX_COMPONENT_STORIES = [
 
 ### Maak een Pull Request
 
-Zorg dat de component beschikbaar komt met een Pull Request op GitHub en vraag het kernteam op [Slack](/slack) in het kanaal `#nl-design-system-developers` om een review.
+Zorg dat de component beschikbaar komt met een Pull Request op GitHub.
+
+Vraag het kernteam op [Slack](/slack) in het kanaal `#nl-design-system-developers` om een review. Het kernteam reviewed de Pull Request en reageert met feedback of dat de Pull Request approved is.
+
+Merge de Pull Request. Zodra de Pull Request is gemerged, wordt de component beschikbaar in de Themes Storybook. De URL hiervoor vind je in de Themes repository.
+
+Kopieer de URL van de component met jouw organisatie thema, en plak deze in het veld "Theme Storybook URL" in het Communitybord.
 
 **🚩 Checkpoint**: Theme Storybook URL
 


### PR DESCRIPTION
Maak "Maak een Pull Request" substap van "Theme Storybook URL" duidelijker.
- Tekst opsplitsen, zodat het delen van de PR met het kernteam duidelijker is.
- Toevoegen wie de verantwoordelijkheid heeft voor feedback, approven en mergen.
- Verduidelijken hoe de stap voltooid kan worden; waar de URL gevonden kan worden en dat die in het bord geplakt moet worden.

Getest met Community dat deze tekst duidelijk is.

Naar aanleiding van Community: het was makkelijk over het hoofd te zien waardoor de PR niet werd gedeeld in een kanaal, kernteam niet op de hoogte werd gesteld, en de overkoepelende stap niet word afgemaakt, waardoor de Organisatie de "Theme Storybook URL" leeg houd. Verantwoordelijkheid van wie merged en wie de link plaatst was ook onduidelijk.

Live situatie: https://nldesignsystem.nl/handboek/estafettemodel/componenten/community/voor-organisaties/#maak-een-pull-request
Preview documentatie: https://documentatie-git-docs-verduidelijk-pull-12a30e-nl-design-system.vercel.app//handboek/estafettemodel/componenten/community/voor-organisaties/#maak-een-pull-request
Preview documentatie-next: https://documentatie-next-git-docs-verduidelijk-577a46-nl-design-system.vercel.app//handboek/estafettemodel/componenten/community/voor-organisaties/#maak-een-pull-request