### PR TITLE
fix: refactor canvas in astro

### DIFF
--- a/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
+++ b/docs/richtlijnen/formulieren/multistep/1-step-count/_code.mdx
@@ -13,6 +13,7 @@ import { Guideline } from "@site/src/components/Guideline";
   <Canvas
     language="html"
     code={<title>Stap 2 van 3, uw gegevens - Gemeente voorbeeld</title>}
+    rawCode="<title>Stap 2 van 3, uw gegevens - Gemeente voorbeeld</title>"
     defaultCollapsed={false}
   ></Canvas>
 </Guideline>
@@ -22,7 +23,12 @@ import { Guideline } from "@site/src/components/Guideline";
   title="Voor elke (volgende) stap / dezelfde titel."
   description="Met de titel bedoelen we hier het title-element. Bekijk de code voor een voorbeeld in HTML."
 >
-<Canvas language="html" code={<title>Contact opnemen - Gemeente voorbeeld</title>} defaultCollapsed={false}></Canvas>
+<Canvas
+  language="html"
+  code={<title>Contact opnemen - Gemeente voorbeeld</title>}
+  rawCode="<title>Contact opnemen - Gemeente voorbeeld</title>"
+  defaultCollapsed={false}
+></Canvas>
 
 </Guideline>
 

--- a/packages/website/markdown-plugins/remark-canvas-fix/index.ts
+++ b/packages/website/markdown-plugins/remark-canvas-fix/index.ts
@@ -13,7 +13,8 @@ import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 export function remarkCanvasFix() {
   return async (tree: Root) => {
     visit(tree, 'mdxJsxFlowElement', (node, _, parent) => {
-      if (node.name !== 'Canvas' && (parent as MdxJsxFlowElement).name !== 'Guideline') return;
+      if (node.name !== 'Canvas') return;
+      if (!parent || parent.type !== 'mdxJsxFlowElement' || parent.name !== 'Guideline') return;
 
       const parentNode = parent as MdxJsxFlowElement;
 

--- a/packages/website/markdown-plugins/remark-canvas-fix/index.ts
+++ b/packages/website/markdown-plugins/remark-canvas-fix/index.ts
@@ -1,6 +1,7 @@
 import type { Root } from 'mdast';
 import { visit } from 'unist-util-visit';
 import prettierSync from '@prettier/sync';
+import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 
 /**
  * The Canvas component used in Docusaurus depends on a function providing the
@@ -14,31 +15,53 @@ export function remarkCanvasFix() {
     visit(tree, 'mdxFlowExpression', (node, _, parent) => {
       if (parent.type !== 'mdxJsxFlowElement' || parent.name !== 'Canvas') return;
 
+      const parentNode = parent as MdxJsxFlowElement;
+
       if (node.value.startsWith('() => ')) {
         const code = node.value
-          .replace(/\(\)\s=>\s\(?/, '')
-          .replace(/\)$/, '')
-          .replaceAll(/\n/g, '')
+          .replace(/\(\)\s=>\s\(?/, '') // remove the arrow function from the string
+          .replace(/\)$/, '') // remove the closing `)` of the arrow function
+          .replaceAll(/\n/g, '') // remove newlines, prettier will reformat
+          .replaceAll(/\bhtmlFor=/g, 'for=') // replace jsx style attribute name `htmlFor` with `for`
+          .replaceAll(/\bclassName=/g, 'class=') // replace jsx style attribute name `className` with `class`
+          .replaceAll('<>', '') // remove jsx fragment wrapper start
+          .replaceAll('</>', '') // remove jsx fragment wrapper end
           .trim();
 
         const styleTransformedCode = styleObjectToString(code);
 
-        const formattedCode = prettierSync.format(styleTransformedCode, { parser: 'babel' });
+        const formattedCode = prettierSync
+          .format(styleTransformedCode, {
+            parser: 'html',
+            singleAttributePerLine: true,
+            embeddedLanguageFormatting: 'off',
+            htmlWhitespaceSensitivity: 'ignore',
+          })
+          // complex regex to remove multiline string literals in JSX
+          .replaceAll(/\{\s*"(?:[^"\\]|\\.)*"\s*\}/g, (m) =>
+            m
+              .replace(/^\{\s*"/, '')
+              .replace(/"\s*\}$/, '')
+              .replaceAll('\\"', '"')
+              .replaceAll("\\'", "'"),
+          );
 
-        node.value = formattedCode
-          .replaceAll(/;$/gm, '')
-          .replace('<>', '')
-          .replace('</>', '')
-          .replaceAll('{" "}', ' ')
-          .replaceAll(/^\s+$\n/gm, '\n');
+        const codeAttr: MdxJsxAttribute = {
+          type: 'mdxJsxAttribute',
+          name: 'code',
+          value: formattedCode,
+        };
 
-        // @ts-expect-error - The type html is not assignable to mdxFlowExpression. Which is true, but we want to force it to
-        node.type = 'html';
+        // only if no existing `code` attribute is present create a new one
+        if (parentNode.attributes.some((attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'code') === false) {
+          parentNode.attributes.push(codeAttr);
+        }
       }
     });
   };
 }
 
+// Transform JSX (multiline) style attributes into html style attributes
 function styleObjectToString(input: string) {
   let output = input;
   const matches = output.matchAll(/style=(\{\{.+?\}\})/g);
@@ -51,7 +74,11 @@ function styleObjectToString(input: string) {
       .replace('{{', '"')
       .replace('}}', '"');
 
+    // camel case to snake case
     replacement = replacement.replaceAll(/([a-z])([A-Z])/g, (_, p1, p2) => `${p1}-${p2}`.toLowerCase());
+
+    // collapse double spaces into a single space
+    replacement = replacement.replaceAll(/\s+/g, ' ').trim();
 
     output = output.replace(match, replacement);
   });

--- a/packages/website/markdown-plugins/remark-canvas-fix/index.ts
+++ b/packages/website/markdown-plugins/remark-canvas-fix/index.ts
@@ -13,7 +13,7 @@ import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 export function remarkCanvasFix() {
   return async (tree: Root) => {
     visit(tree, 'mdxJsxFlowElement', (node, _, parent) => {
-      if (node.name !== 'Canvas' && parent.name !== 'Guideline') return;
+      if (node.name !== 'Canvas' && (parent as MdxJsxFlowElement).name !== 'Guideline') return;
 
       const parentNode = parent as MdxJsxFlowElement;
 

--- a/packages/website/markdown-plugins/remark-canvas-fix/index.ts
+++ b/packages/website/markdown-plugins/remark-canvas-fix/index.ts
@@ -12,6 +12,24 @@ import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
  */
 export function remarkCanvasFix() {
   return async (tree: Root) => {
+    visit(tree, 'mdxJsxFlowElement', (node, _, parent) => {
+      if (node.name !== 'Canvas' && parent.name !== 'Guideline') return;
+
+      const parentNode = parent as MdxJsxFlowElement;
+
+      if (
+        parentNode.attributes.some(
+          (attr) => attr.type === 'mdxJsxAttribute' && attr.name === 'appearance' && attr.value === 'do',
+        )
+      ) {
+        node.attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'copyCode',
+          value: 'allow',
+        });
+      }
+    });
+
     visit(tree, 'mdxFlowExpression', (node, _, parent) => {
       if (parent.type !== 'mdxJsxFlowElement' || parent.name !== 'Canvas') return;
 

--- a/packages/website/src/components/accordion/accordion.tsx
+++ b/packages/website/src/components/accordion/accordion.tsx
@@ -27,7 +27,7 @@ export type AccordionLabelProps =
     };
 
 export type AccordionSectionProps = HTMLAttributes<HTMLDetailsElement> &
-  AccordionLabelProps & { classNamePanel?: string };
+  AccordionLabelProps & { classNamePanel?: string; open?: boolean };
 
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(({ as, className, children, ...props }, ref) => {
   const Component = (as || 'div') as ElementType;

--- a/packages/website/src/components/sr-only/sr-only.css
+++ b/packages/website/src/components/sr-only/sr-only.css
@@ -1,4 +1,5 @@
 /** Taken from https://kittygiraudel.com/snippets/sr-only-class/ */
+.sr-only,
 .ma-sr-only {
   block-size: 1px !important;
   border: 0 !important;

--- a/packages/website/src/components/table-of-content/table-of-content.astro
+++ b/packages/website/src/components/table-of-content/table-of-content.astro
@@ -21,7 +21,7 @@ import '@nl-design-system-candidate/link-css/link.css';
   const toc = document.querySelector('ma-table-of-contents');
   const codeExampleHeadings = new Set(
     document.querySelectorAll(
-      '.nlds-guideline h1, .nlds-guideline h2, .nlds-guideline h3, .nlds-guideline h4, .nlds-guideline h5,.nlds-guideline h6',
+      '.ma-canvas-astro h1, .ma-canvas-astro h2, .ma-canvas-astro h3, .ma-canvas-astro h4, .ma-canvas-astro h5,.ma-canvas-astro h6',
     ),
   );
   toc.headingsToIgnore = toc.headingsToIgnore.union(codeExampleHeadings);

--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -218,5 +218,12 @@ const footerNavigationItems = [
         }
       });
     </script>
+    <script>
+      document.addEventListener('click', (event) => {
+        const button = (event.target as HTMLElement)?.closest<HTMLElement>('[data-copy-code]');
+        if (!button) return;
+        navigator.clipboard.writeText(button.dataset['copyCode'] ?? '').catch(() => {});
+      });
+    </script>
   </body>
 </html>

--- a/packages/website/src/styles/missing-tokens.css
+++ b/packages/website/src/styles/missing-tokens.css
@@ -223,3 +223,10 @@ kbd {
   padding-block: 0.15rem;
   padding-inline: 0.3rem;
 }
+
+.nlds-icon-ext {
+  background-image: url("../../../../src/icons/external-link.svg");
+  background-position: right center;
+  background-repeat: no-repeat;
+  padding-inline-end: 24px;
+}

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -2,21 +2,20 @@ import type { CanvasProps } from './Canvas';
 import Prism from 'prismjs';
 import clsx from 'clsx';
 import { Accordion, AccordionSection } from '../../../packages/website/src/components/accordion/accordion';
+import { Button } from '../../../packages/website/src/components/button/button';
 import './CanvasAstro.css';
 import '@utrecht/component-library-css/dist/html.css';
 
 export interface CanvasAstroProps extends CanvasProps {
   code?: string;
+  copyCode?: 'allow' | 'deny';
 }
 
-export const CanvasAstro = ({ language, className, code = '<p>No code provided</p>' }: CanvasAstroProps) => {
+export const CanvasAstro = ({ language, className, code = '<p>No code provided</p>', copyCode }: CanvasAstroProps) => {
   const highlighed = Prism.highlight(code, Prism.languages[language], language);
 
   return (
     <div className={clsx('ma-canvas-astro', className)}>
-      {/* Code to be copied with the copy button. */}
-      <template dangerouslySetInnerHTML={{ __html: code }}></template>
-
       {/* Live preview */}
       <div className="ma-canvas-astro__example utrecht-html ma-flow" dangerouslySetInnerHTML={{ __html: code }} />
 
@@ -26,6 +25,13 @@ export const CanvasAstro = ({ language, className, code = '<p>No code provided</
           <pre className="language-html nl-code-block">
             <code className="language-html nl-code-block__code" dangerouslySetInnerHTML={{ __html: highlighed }} />
           </pre>
+
+          {/* Because of the arrow function syntax, the <Canvas> element can not be clientside rendered with client:load. therefore, the javascript allowing to copy the code is included in the `document.astro` file as a <script> element */}
+          {copyCode === 'allow' && (
+            <Button data-copy-code={code} purpose="secondary">
+              Kopieer code
+            </Button>
+          )}
         </AccordionSection>
       </Accordion>
     </div>

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -1,33 +1,26 @@
 import type { CanvasProps } from './Canvas';
 import Prism from 'prismjs';
 import clsx from 'clsx';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { Accordion, AccordionSection } from '../../../packages/website/src/components/accordion/accordion';
 import './CanvasAstro.css';
 import '@utrecht/component-library-css/dist/html.css';
 
-export const CanvasAstro = ({ children, language, className }: CanvasProps) => {
-  const _children = typeof children === 'function' ? children() : children;
-  const code = renderToStaticMarkup(_children);
-  const formattedCode = code
-    .replaceAll(/&quot;/g, '"')
-    .replaceAll(/\sclass="[\w-\s]+"/g, '')
-    .replace('<astro-static-slot>', '')
-    .replace('</astro-static-slot>', '')
-    .replaceAll(/{"\s"}/g, '')
-    .replaceAll(/\n{2,}/g, '\n')
-    .replaceAll(/^\s\s/gm, '')
-    .replaceAll(/\salt\s/g, ' alt="" ')
-    .replaceAll(' loading="lazy"', ' ');
+export interface CanvasAstroProps extends CanvasProps {
+  code?: string;
+}
 
-  const highlighed = Prism.highlight(formattedCode, Prism.languages[language], language);
+export const CanvasAstro = ({ language, className, code = '<p>No code provided</p>' }: CanvasAstroProps) => {
+  const highlighed = Prism.highlight(code, Prism.languages[language], language);
 
   return (
     <div className={clsx('ma-canvas-astro', className)}>
-      <div
-        className="ma-canvas-astro__example utrecht-html ma-flow"
-        dangerouslySetInnerHTML={{ __html: formattedCode }}
-      />
+      {/* Code to be copied with the copy button. */}
+      <template dangerouslySetInnerHTML={{ __html: code }}></template>
+
+      {/* Live preview */}
+      <div className="ma-canvas-astro__example utrecht-html ma-flow" dangerouslySetInnerHTML={{ __html: code }} />
+
+      {/* Highlighted code example */}
       <Accordion>
         <AccordionSection label="Code">
           <pre className="language-html nl-code-block">

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -11,7 +11,13 @@ export interface CanvasAstroProps extends CanvasProps {
   copyCode?: 'allow' | 'deny';
 }
 
-export const CanvasAstro = ({ language, className, code = '<p>No code provided</p>', copyCode }: CanvasAstroProps) => {
+export const CanvasAstro = ({
+  language,
+  className,
+  code = '<p>No code provided</p>',
+  copyCode,
+  defaultExpandedCode,
+}: CanvasAstroProps) => {
   const highlighed = Prism.highlight(code, Prism.languages[language], language);
 
   return (
@@ -21,7 +27,7 @@ export const CanvasAstro = ({ language, className, code = '<p>No code provided</
 
       {/* Highlighted code example */}
       <Accordion>
-        <AccordionSection label="Code">
+        <AccordionSection label="Code" open={defaultExpandedCode}>
           <pre className="language-html nl-code-block">
             <code className="language-html nl-code-block__code" dangerouslySetInnerHTML={{ __html: highlighed }} />
           </pre>

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -20,7 +20,7 @@ export const CanvasAstro = ({
   defaultExpandedCode,
   designTokens,
 }: CanvasAstroProps) => {
-  const highlighed = Prism.highlight(code, Prism.languages[language], language);
+  const highlighed = typeof code === 'string' ? Prism.highlight(code, Prism.languages[language], language) : code;
 
   return (
     <div className={clsx('ma-canvas-astro', 'voorbeeld-theme', className)} style={designTokens as CSSProperties}>

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -5,6 +5,7 @@ import { Accordion, AccordionSection } from '../../../packages/website/src/compo
 import { Button } from '../../../packages/website/src/components/button/button';
 import './CanvasAstro.css';
 import '@utrecht/component-library-css/dist/html.css';
+import type { CSSProperties } from 'react';
 
 export interface CanvasAstroProps extends CanvasProps {
   code?: string;
@@ -17,17 +18,18 @@ export const CanvasAstro = ({
   code = '<p>No code provided</p>',
   copyCode,
   defaultExpandedCode,
+  designTokens,
 }: CanvasAstroProps) => {
   const highlighed = Prism.highlight(code, Prism.languages[language], language);
 
   return (
-    <div className={clsx('ma-canvas-astro', className)}>
+    <div className={clsx('ma-canvas-astro', 'voorbeeld-theme', className)} style={designTokens as CSSProperties}>
       {/* Live preview */}
       <div className="ma-canvas-astro__example utrecht-html ma-flow" dangerouslySetInnerHTML={{ __html: code }} />
 
       {/* Highlighted code example */}
       <Accordion>
-        <AccordionSection label="Code" open={defaultExpandedCode}>
+        <AccordionSection label="Code" className="utrecht-html" open={defaultExpandedCode}>
           <pre className="language-html nl-code-block">
             <code className="language-html nl-code-block__code" dangerouslySetInnerHTML={{ __html: highlighed }} />
           </pre>

--- a/src/components/Canvas/CanvasAstro.tsx
+++ b/src/components/Canvas/CanvasAstro.tsx
@@ -9,6 +9,7 @@ import type { CSSProperties } from 'react';
 
 export interface CanvasAstroProps extends CanvasProps {
   code?: string;
+  rawCode?: string;
   copyCode?: 'allow' | 'deny';
 }
 
@@ -16,27 +17,35 @@ export const CanvasAstro = ({
   language,
   className,
   code = '<p>No code provided</p>',
+  rawCode,
   copyCode,
   defaultExpandedCode,
   designTokens,
 }: CanvasAstroProps) => {
-  const highlighed = typeof code === 'string' ? Prism.highlight(code, Prism.languages[language], language) : code;
+  const _code = typeof code === 'string' ? code : rawCode || '';
+
+  const highlighed =
+    typeof code === 'string'
+      ? Prism.highlight(code, Prism.languages[language], language)
+      : Prism.highlight(rawCode || '', Prism.languages[language], language);
 
   return (
-    <div className={clsx('ma-canvas-astro', 'voorbeeld-theme', className)} style={designTokens as CSSProperties}>
+    <div className={clsx('ma-canvas-astro', className)}>
       {/* Live preview */}
-      <div className="ma-canvas-astro__example utrecht-html ma-flow" dangerouslySetInnerHTML={{ __html: code }} />
+      <div className="voorbeeld-theme" style={designTokens as CSSProperties}>
+        <div className="ma-canvas-astro__example utrecht-html ma-flow" dangerouslySetInnerHTML={{ __html: _code }} />
+      </div>
 
       {/* Highlighted code example */}
       <Accordion>
-        <AccordionSection label="Code" className="utrecht-html" open={defaultExpandedCode}>
-          <pre className="language-html nl-code-block">
+        <AccordionSection label="Code" open={defaultExpandedCode}>
+          <pre className="language-html nl-code-block" tabIndex={0}>
             <code className="language-html nl-code-block__code" dangerouslySetInnerHTML={{ __html: highlighed }} />
           </pre>
 
           {/* Because of the arrow function syntax, the <Canvas> element can not be clientside rendered with client:load. therefore, the javascript allowing to copy the code is included in the `document.astro` file as a <script> element */}
           {copyCode === 'allow' && (
-            <Button data-copy-code={code} purpose="secondary">
+            <Button data-copy-code={_code} purpose="secondary">
               Kopieer code
             </Button>
           )}

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -67,7 +67,7 @@ export default {
       '^(ams|rhc|denhaag|docusaurus|example|ifm|nl|nlds|utrecht|ma|basis|pra|docsearch)-[a-z0-9-]+|DocSearch-.+$',
     'selector-attribute-quotes': ['always'],
     'selector-class-pattern':
-      '^(ams|rhc|denhaag|docusaurus|example|ifm|nl|nlds|utrecht|ma|basis|pra|docsearch)-[a-z0-9_-]+|DocSearch-.+$',
+      '^(ams|rhc|denhaag|docusaurus|example|ifm|nl|nlds|utrecht|ma|basis|pra|docsearch|sr)-[a-z0-9_-]+|DocSearch-.+$',
     'selector-max-id': [0],
     'selector-pseudo-class-no-unknown': [true],
     'selector-pseudo-element-no-unknown': [true],

--- a/test/docs/canvas-arrow-function.mdx
+++ b/test/docs/canvas-arrow-function.mdx
@@ -14,4 +14,95 @@ Tests whether a Canvas with arrow function children renders correctly
 
 <TestPageNote />
 
-<Canvas language="html">{() => <p>Hello from Canvas</p>}</Canvas>
+## Simple example
+
+<Canvas language="html">
+  {() => (
+    <p>
+      Hello <strong>from</strong> Canvas
+    </p>
+  )}
+</Canvas>
+
+## Code attr wins over children
+
+<Canvas language="html" code="<p>existing <em>code</em> attr</p>">
+  {() => (
+    <p>
+      Hello <strong>from</strong> Canvas
+    </p>
+  )}
+</Canvas>
+
+## Authored attributes are being preserved, elements won't receive `.nl-*` classes
+
+<Canvas language="html">
+  {() => (
+    <>
+      <p>
+        <label htmlFor="first-name">Voornaam (een of meerdere)</label>
+      </p>
+      <p id="first-name-description">Vul de voornaam of voornamen in zoals deze op je id-kaart of paspoort staan.</p>
+      <p>
+        <input
+          autoComplete="given-name"
+          type="text"
+          name="first_name"
+          id="first-name"
+          aria-describedby="first-name-description"
+        />
+      </p>
+    </>
+  )}
+</Canvas>
+
+## JSX artifacts do not show up
+
+<Canvas language="html">
+  {() => (
+    <p id="desc">
+      {
+        "Wij hebben jouw toestemming nodig om je e-mailadres op te slaan zodat we je onze nieuwsbrief kunnen sturen. Lees onze "
+      }
+      <a href="#" target="_blank">
+        {"privacybeleid (opent in een nieuw venster)"}
+      </a>
+      {"."}
+    </p>
+  )}
+</Canvas>
+
+## Headings do not show up in table of contents
+
+<Canvas language="html">{() => <h2>This is an heading</h2>}</Canvas>
+
+## External icon is rendered
+
+<Canvas language="html">
+  {() => (
+    <p>
+      <a href="#" target="_blank" className="nlds-icon-ext">
+        Lees het privacybeleid
+        <span className="sr-only">, opent in een nieuwe tab</span>
+      </a>
+      .
+    </p>
+  )}
+</Canvas>
+
+## Multiline style tags are being rendered correctly
+
+<Canvas language="html">
+  {() => (
+    <>
+      <div
+        style={{
+          background:
+            "center center no-repeat url('https://raw.githubusercontent.com/nl-design-system/documentatie/assets/richtlijnen_content_afbeeldingen-Kaart.jpg')",
+        }}
+      >
+        <h2 style={{ padding: "50px", color: "white", backgroundColor: "#00000088" }}>Kaarten van Nederland</h2>
+      </div>
+    </>
+  )}
+</Canvas>

--- a/test/e2e/seo.spec.ts
+++ b/test/e2e/seo.spec.ts
@@ -9,7 +9,7 @@ const CONFIG = {
   sitemap: '/sitemap-index.xml',
 };
 
-// A selection of urls coverig all different templates configurations. A minimal set of paths to cover all template paths so all combinations are testable without testing every single page
+// A selection of urls covering all different templates configurations. A minimal set of paths to cover all template paths so all combinations are testable without testing every single page
 const pathnamesSelection = [
   // Homepage
   '/',


### PR DESCRIPTION
Deze PR refactored de Astro oplossing van de Canvas component. Voorheen was de oplossing om in een remark plugin de arrow function te tranformeren zodat enkel de body van de arrow function als children aan het Canvas element gegeven kon worden. Astro zag de html in die arrow function en kon die vervolgens verder renderen.

Dit gaf verschillende problemen met de markdown -> html pijplijn van mdx, remark, rehype en astro.

Deze refactor neemt de zelfde body van de arrow function maar geeft deze als string via een prop aan het Canvas component. Dit zorgt er voor dat de hele markdown transformatie pijplijn wordt overgeslagen (het gewenste effect). Hoewel de plugin wat complexer geworden is  met Regexes (er zijn meer edgecases afgehandeld zoals multiline string expressions), is het CanvasAstro component simpeler geworden. Alle complexe logica is naar de plugin verhuist die, als de syntax in de mdx eenmaal anders is, geheel verwijderd kan worden.

closes: #4484
closes: #4483
closes: #4497
closes: #4498 
