### PR TITLE
feat: copy button design tokens

### DIFF
--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -132,7 +132,7 @@ export default defineConfig({
         remarkDirective,
         remarkUndoInlineDirectives,
         remarkAdmonitions,
-        clientLoadPlugin(['Videoplayer', 'VideoPlayer', 'Checklist']),
+        clientLoadPlugin(['Videoplayer', 'VideoPlayer', 'Checklist', 'DesignTokens']),
         removeH1FromMarkdown(),
       ],
       rehypePlugins: [

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,31 +1,20 @@
-import prettierPluginBabel from 'prettier/plugins/babel';
-import prettierPluginEstree from 'prettier/plugins/estree';
-import prettierPluginPostCSS from 'prettier/plugins/postcss';
-import prettier from 'prettier/standalone';
 import type { ButtonHTMLAttributes } from 'react';
 import { IconCopy } from '@tabler/icons-react';
 import { Button } from '@utrecht/component-library-react/dist/css-module';
 import { Icon } from '@utrecht/component-library-react';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
-  language: 'json' | 'css';
   content: string;
 }
 
-export function CopyButton({ children, content, language }: Props) {
+export function CopyButton({ children, content }: Props) {
   async function onClick() {
     try {
-      const formatted = await prettier.format(content, {
-        parser: language,
-        plugins: [prettierPluginBabel, prettierPluginEstree, prettierPluginPostCSS],
-      });
-      await navigator.clipboard.writeText(formatted);
+      await navigator.clipboard.writeText(content);
     } catch (e) {
       console.error(e);
     }
   }
-
-  if (!('clipboard' in navigator)) return null;
 
   return (
     <Button type="button" appearance="secondary-action-button" onClick={onClick}>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes } from 'react';
+import { useEffect, useState, type ButtonHTMLAttributes } from 'react';
 import { IconCopy } from '@tabler/icons-react';
 import { Button } from '@utrecht/component-library-react/dist/css-module';
 import { Icon } from '@utrecht/component-library-react';
@@ -8,6 +8,8 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export function CopyButton({ children, content }: Props) {
+  const [canCopy, setCanCopy] = useState(false);
+
   async function onClick() {
     try {
       await navigator.clipboard.writeText(content);
@@ -16,12 +18,21 @@ export function CopyButton({ children, content }: Props) {
     }
   }
 
+  useEffect(() => {
+    if (!('clipboard' in navigator)) return;
+    setCanCopy(true);
+  }, []);
+
   return (
-    <Button type="button" appearance="secondary-action-button" onClick={onClick}>
-      {children}
-      <Icon>
-        <IconCopy />
-      </Icon>
-    </Button>
+    <>
+      {canCopy && (
+        <Button type="button" appearance="secondary-action-button" onClick={onClick}>
+          {children}
+          <Icon>
+            <IconCopy />
+          </Icon>
+        </Button>
+      )}
+    </>
   );
 }

--- a/src/components/DesignTokens.tsx
+++ b/src/components/DesignTokens.tsx
@@ -55,7 +55,7 @@ export function DesignTokens({ tokens }: Props) {
   const cssCustomPropertiesString = sortedTokenPaths
     .map((tokenPath) => tokenPathToCSSCustomProperty(tokenPath) + ': ;')
     .join('\n');
-  const jsonString = JSON.stringify(cleanTokens);
+  const jsonString = JSON.stringify(cleanTokens, null, 2);
 
   return (
     <div className="ma-flow">
@@ -90,12 +90,8 @@ export function DesignTokens({ tokens }: Props) {
       </Table>
 
       <ActionGroup>
-        <CopyButton content={jsonString} language="json">
-          Kopieer als JSON
-        </CopyButton>
-        <CopyButton content={cssCustomPropertiesString} language="css">
-          Kopieer als CSS
-        </CopyButton>
+        <CopyButton content={jsonString}>Kopieer als JSON</CopyButton>
+        <CopyButton content={cssCustomPropertiesString}>Kopieer als CSS</CopyButton>
       </ActionGroup>
     </div>
   );

--- a/src/components/DesignTokens.tsx
+++ b/src/components/DesignTokens.tsx
@@ -58,7 +58,7 @@ export function DesignTokens({ tokens }: Props) {
   const jsonString = JSON.stringify(cleanTokens);
 
   return (
-    <>
+    <div className="ma-flow">
       <Table>
         <TableHeader>
           <TableRow>
@@ -97,6 +97,6 @@ export function DesignTokens({ tokens }: Props) {
           Kopieer als CSS
         </CopyButton>
       </ActionGroup>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Deze PR voegt `client:load` toe aan alle `<DesignTokens>` components. Omdat werkend te krijgen moetst de `<CopyButton>` aangepast worden. Daarin werd prettier (clientside) gebruikt om de JSON output te formatten. Echter is dat niet nodig. Want `JSON.stringify` doet dat al zelf. De CSS output was al geformat, dus ook daar is dat niet nodig.

closes: #4496
