### PR TITLE
docs: verplaats Documentatie pagina toevoegen stap

### DIFF
--- a/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
+++ b/docs/handboek/definition-of-done/help-wanted-stappenplan.mdx
@@ -494,20 +494,6 @@ Met de toetscombinatie `Cmd+D` (of `Ctrl+D`) kun je stukjes code selecteren die 
 feat: add illustration for {naam-component}
 ```
 
-### Documentatie pagina toevoegen
-
-- Ga naar de [folder 'docs/componenten'](https://github.com/nl-design-system/documentatie/tree/main/docs/componenten).
-- Voeg een nieuwe folder toe voor de component en gebruik hiervoor kebab-case als schrijfwijze.
-- Maak een nieuw bestand aan en noem het 'index.mdx'.
-- Vul het bestand in volgens [de component template](https://raw.githubusercontent.com/nl-design-system/documentatie/main/docs/componenten/_template.mdx).
-- Maak een commit en gebruik hierbij het volgende bericht:
-
-**Commit Message**
-
-```
-feat: add documentation page for {naam-component}
-```
-
 ### Component progress bijwerken
 
 **Tip!**
@@ -522,6 +508,20 @@ Voordat je de component progress gaat bijwerken is het handig om te controleren 
 
 ```
 build: update component progress
+```
+
+### Documentatie pagina toevoegen
+
+- Ga naar de [folder 'docs/componenten'](https://github.com/nl-design-system/documentatie/tree/main/docs/componenten).
+- Voeg een nieuwe folder toe voor de component en gebruik hiervoor kebab-case als schrijfwijze.
+- Maak een nieuw bestand aan en noem het 'index.mdx'.
+- Vul het bestand in volgens [de component template](https://raw.githubusercontent.com/nl-design-system/documentatie/main/docs/componenten/_template.mdx).
+- Maak een commit en gebruik hierbij het volgende bericht:
+
+**Commit Message**
+
+```
+feat: add documentation page for {naam-component}
 ```
 
 ### Branch publiceren


### PR DESCRIPTION
Reorder van de laatste stap zodat je eerst "Component progress bijwerken" doet en daarna pas "Documentatie pagina toevoegen"