### PR TITLE
chore: uniform component usage in mdx

### DIFF
--- a/docs/baseline/index.mdx
+++ b/docs/baseline/index.mdx
@@ -16,13 +16,14 @@ keywords:
   - WCAG
 ---
 
-import { Paragraph, SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # NL Design System Baseline
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Wij maken technologie voor gebruikers, daarom bepalen we hier welke browsers en hulpmiddelen zoveel gebruikt worden
   dat je moet zorgen dat het er goed mee werkt.
 </Paragraph>

--- a/docs/baseline/index.mdx
+++ b/docs/baseline/index.mdx
@@ -16,7 +16,7 @@ keywords:
   - WCAG
 ---
 
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}

--- a/docs/community/belangenorganisaties/aanmelden.mdx
+++ b/docs/community/belangenorganisaties/aanmelden.mdx
@@ -9,11 +9,11 @@ slug: /community/belangenorganisaties/aanmelden
 ---
 
 import { NewsletterSignUp } from "@site/src/components/NewsletterSignUp";
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Meld je aan als belangenorganisatie
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System deelt bouwblokken voor toegankelijke en gebruiksvriendelijke webapplicaties en websites. Voor het
   best mogelijke resultaat willen we graag samenwerken met ervaringsdeskundigen en belangenorganisaties. Meld je aan als
   je ons wil helpen, en op de hoogte wil blijven!

--- a/docs/community/community-sprints/index.mdx
+++ b/docs/community/community-sprints/index.mdx
@@ -18,7 +18,8 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import { Heading3, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Heading3 } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { Card, CardContent, CardGroup } from "@site/src/components/CardGroup";
 import { Link } from "@site/src/components/Link";
 

--- a/docs/community/community-sprints/index.mdx
+++ b/docs/community/community-sprints/index.mdx
@@ -18,7 +18,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import { Heading3 } from "@utrecht/component-library-react/dist/css-module";
+import { Heading3 } from "@components/heading/heading";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { Card, CardContent, CardGroup } from "@site/src/components/CardGroup";
 import { Link } from "@site/src/components/Link";

--- a/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
@@ -32,7 +32,7 @@ Elke even week op donderdag van 10:00 tot 11:00 kan je meedoen aan de [MijnServi
     download="https://nldesignsystem.nl/mijn-services-community/mijn-services-community-check-in.ics"
     aria-label="iCal bestand voor de MijnServices Community Check-in (download)"
   >
-    <IconCalendarEvent />
+    <IconCalendarEvent slot="icon-start" />
     {" Download het kalenderbestand"}
   </ButtonLink>
 </ActionGroup>

--- a/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/mijn-services-community/aanmelden-success.mdx
@@ -10,7 +10,7 @@ unlisted: true
 
 import { IconCalendarEvent } from "@tabler/icons-react";
 import { ButtonLink } from "@site/src/components/ButtonLink";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Bedankt!
 

--- a/docs/community/community-sprints/mijn-services-community/index.mdx
+++ b/docs/community/community-sprints/mijn-services-community/index.mdx
@@ -21,7 +21,7 @@ keywords:
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Community Sprint: MijnServices Community
 

--- a/docs/community/community-sprints/mijn-services-community/index.mdx
+++ b/docs/community/community-sprints/mijn-services-community/index.mdx
@@ -99,7 +99,7 @@ Elke even week op donderdag van 10:00 tot 11:00 kan je meedoen aan de [MijnServi
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/mijn-services-community/aanmelden" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
@@ -35,7 +35,7 @@ Voor iedereen die interesse heeft in de Rijkshuisstijl is er in de oneven weken,
     download="https://nldesignsystem.nl/rijkshuisstijl-community/rijkshuisstijl-community-open-hour.ics"
     aria-label="iCal bestand voor de Rijkshuisstijl Community Open Hour (download)"
   >
-    <IconCalendarEvent />
+    <IconCalendarEvent slot="icon-start" />
     {" Download het kalenderbestand voor de Open Hour"}
   </ButtonLink>
 </ActionGroup>

--- a/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/aanmelden-success.mdx
@@ -11,7 +11,7 @@ unlisted: true
 import { IconCalendarEvent } from "@tabler/icons-react";
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Bedankt!
 

--- a/docs/community/community-sprints/rijkshuisstijl-community/index.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/index.mdx
@@ -141,7 +141,7 @@ We organiseren de volgende vaste momenten om samen te komen:
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/rijkshuisstijl-community/aanmelden" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/community-sprints/rijkshuisstijl-community/index.mdx
+++ b/docs/community/community-sprints/rijkshuisstijl-community/index.mdx
@@ -17,7 +17,7 @@ keywords:
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Community Sprint: Rijkshuisstijl Community
 

--- a/docs/community/design-systems.mdx
+++ b/docs/community/design-systems.mdx
@@ -18,11 +18,11 @@ keywords:
   - overheid
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Design systems bij de overheid
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System is er om de succesvolle onderdelen uit design systems bij de overheid beschikbaar te maken voor
   iedereen. We kijken met de hele community bij elkaar in de keuken, om van elkaar te leren. Daarom hebben een overzicht
   gemaakt.

--- a/docs/community/events/design-open-hour/index.mdx
+++ b/docs/community/events/design-open-hour/index.mdx
@@ -11,7 +11,7 @@ slug: /events/design-open-hour
 
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Design Open Hour
 

--- a/docs/community/events/design-open-hour/index.mdx
+++ b/docs/community/events/design-open-hour/index.mdx
@@ -29,7 +29,7 @@ Voel je niet verplicht om elke keer aan te sluiten. Kan je er een keer niet bij 
 
 <ActionGroup>
   <ButtonLink href="/events/design-open-hour/aanmelden/" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 
@@ -59,10 +59,10 @@ Door je aan te melden kunnen wij je op de hoogte houden van Design Open Hours. J
 
 <ActionGroup>
   <ButtonLink href="/events/design-open-hour/aanmelden/" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="/slack/" appearance="secondary-action">
-    {"Doe mee op Slack"} <IconChevronRight />
+    {"Doe mee op Slack"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/design-systems-week/eerdere-edities/2022.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2022.mdx
@@ -12,11 +12,11 @@ slug: /events/design-systems-week-2022
 ---
 
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Design Systems Week 2022
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Tijdens Design Systems Week 2022 hadden we diverse sprekers over de NL Design System community. Gelukkig hebben we de
   video's nog!
 </Paragraph>

--- a/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
@@ -15,11 +15,12 @@ translations:
 
 import { OldSession as DSWSession } from "../\_2023/OldSession";
 import speakers from "../\_2023/speakers.json";
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Design Systems Week 2023 terugkijken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Tijdens Design Systems Week 2023 met nationale én internationale sprekers. Vanuit verschillende perspectieven hebben
   we gehoord hoe design systems bijdragen aan toegankelijkheid en zijn we technisch de diepte ingegaan met design tokens
   en web components. Gelukkig hebben we de video's nog!

--- a/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2023.mdx
@@ -15,7 +15,7 @@ translations:
 
 import { OldSession as DSWSession } from "../\_2023/OldSession";
 import speakers from "../\_2023/speakers.json";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@components/link/link";
 import { Paragraph } from "@components/paragraph/paragraph";
 
 # Design Systems Week 2023 terugkijken

--- a/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
@@ -15,7 +15,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 14-17 oktober, online
 ---
 
-import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@components/link/link";
 import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_2024/sessions.json";
 import speakers from "../\_2024/speakers.json";

--- a/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2024.mdx
@@ -15,14 +15,15 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 14-17 oktober, online
 ---
 
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_2024/sessions.json";
 import speakers from "../\_2024/speakers.json";
 import { DSWSession } from "@site/src/components/DSWSession";
 
 # Design Systems Week 2024 terugkijken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Tijdens Design Systems Week kon je 4 dagen lang meerdere korte talks per dag volgen. Bijvoorbeeld over het managen van
   design systems, toegankelijkheid, gebruikersonderzoek en code. Gelukkig hebben we de video's nog!
 </Paragraph>

--- a/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
@@ -15,7 +15,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2024 27-30 Oktober, online
 ---
 
-import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@components/link/link";
 import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_2025/sessions.json";
 import speakers from "../\_2025/speakers.json";

--- a/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/2025.mdx
@@ -15,14 +15,15 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2024 27-30 Oktober, online
 ---
 
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_2025/sessions.json";
 import speakers from "../\_2025/speakers.json";
 import { DSWSession } from "@site/src/components/DSWSession";
 
 # Design Systems Week 2025 terugkijken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Tijdens Design Systems Week kon je 4 dagen lang meerdere korte talks per dag volgen. Bijvoorbeeld over het TEDI:
   Estlands nieuwe design system, toegankelijkheid, AI, gebruikersonderzoek en praktische tests voor het beoordelen van
   toegankelijkheid. Gelukkig hebben we de video's nog!

--- a/docs/community/events/design-systems-week/eerdere-edities/_template.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/_template.mdx
@@ -13,7 +13,6 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week PLACEHOLDER_YEAR PLACEHOLDER_DATERANGE, online
 ---
 
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_PLACEHOLDER_YEAR/sessions.json";
 import speakers from "../\_PLACEHOLDER_YEAR/speakers.json";

--- a/docs/community/events/design-systems-week/eerdere-edities/_template.mdx
+++ b/docs/community/events/design-systems-week/eerdere-edities/_template.mdx
@@ -13,14 +13,15 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week PLACEHOLDER_YEAR PLACEHOLDER_DATERANGE, online
 ---
 
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../\_PLACEHOLDER_YEAR/sessions.json";
 import speakers from "../\_PLACEHOLDER_YEAR/speakers.json";
 import { DSWSession } from "@site/src/components/DSWSession";
 
 # Design Systems Week PLACEHOLDER_YEAR terugkijken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Tijdens Design Systems Week kon je 4 dagen lang meerdere korte talks per dag volgen. Bijvoorbeeld over
   PLACEHOLDER_TOPICS_SUMMARY. Gelukkig hebben we de video's nog!
 </Paragraph>

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -16,7 +16,8 @@ image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink, ButtonGroup as ActionGroup, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink, ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "../settings.json";
 
 export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappening;
@@ -25,7 +26,7 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 
 {!!isUpComingOrHappening && (<>
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System is organising the Design Systems Week for the {settings.en.edition} time. It will feature a number of
   short talks about the how and why of design systems. All online. From {settings.en.dateRange}, we will cover subjects
   like managing design systems, integrating accessibility, user research and code.
@@ -46,7 +47,7 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 
 {!isUpComingOrHappening && (<>
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Design Systems Week is an online event organized by NL Design System. During this week, several short sessions are
   offered in which various (international) organizations share how and why they use design systems. The goal is to bring
   together designers, developers, and other professionals working on digital government services to exchange experiences

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -16,7 +16,8 @@ image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink, ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "../settings.json";
 

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -36,11 +36,11 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 <ActionGroup>
   <ButtonLink href={`/events/design-systems-week/en/sign-up`} appearance="primary-action">
     {"Sign up"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="secondary-action">
     {"View the Program"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/design-systems-week/en/index.mdx
+++ b/docs/community/events/design-systems-week/en/index.mdx
@@ -16,7 +16,7 @@ image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "../settings.json";
@@ -34,11 +34,11 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 </Paragraph>
 
 <ActionGroup>
-  <ButtonLink href={`/events/design-systems-week/en/sign-up`} appearance="primary-action-button">
+  <ButtonLink href={`/events/design-systems-week/en/sign-up`} appearance="primary-action">
     {"Sign up"}
     <IconChevronRight />
   </ButtonLink>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="secondary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="secondary-action">
     {"View the Program"}
     <IconChevronRight />
   </ButtonLink>

--- a/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
@@ -16,13 +16,14 @@ translations:
 
 import { OldSession as DSWSession } from "../../\_2023/OldSession.tsx";
 import speakers from "../../\_2023/speakers.json";
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 <div lang="en">
 
 # Design Systems Week 2023
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   From 2 to 5 October NL Design System has organised the third edition of Design Systems Week. Speakers from various
   organisations have joined us for short talks about the how and why of design systems.
 </Paragraph>

--- a/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2023.mdx
@@ -16,7 +16,7 @@ translations:
 
 import { OldSession as DSWSession } from "../../\_2023/OldSession.tsx";
 import speakers from "../../\_2023/speakers.json";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@components/link/link";
 import { Paragraph } from "@components/paragraph/paragraph";
 
 <div lang="en">

--- a/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2024.mdx
@@ -16,7 +16,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 14-17 October, online
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { DSWSession } from "@site/src/components/DSWSession";
 import sessions from "../../\_2024/sessions.json";
 import speakers from "../../\_2024/speakers.json";
@@ -25,7 +25,7 @@ import speakers from "../../\_2024/speakers.json";
 
 # Design Systems Week 2024
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Design Systems Week featured a number of short talks about the how and why of design systems. All online. In 2024,
   we've covered subjects like managing design systems, integrating accessibility, user research and code.
 </Paragraph>

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -16,12 +16,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 27-30 October, online
 ---
 
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Link,
-  Paragraph,
-} from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../../\_2025/sessions.json";
 import speakers from "../../\_2025/speakers.json";
@@ -31,7 +27,7 @@ import { DSWSession } from "@site/src/components/DSWSession";
 
 # Design Systems Week 2025
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   During Design Systems Week, you could follow several short talks each day for four days. Topics included TEDI,
   Estonia’s new design system, accessibility, AI, user research, and practical tests for evaluating accessibility.
   Luckily, we still have the videos!

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -16,7 +16,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 27-30 October, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../../\_2025/sessions.json";

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -16,7 +16,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 27-30 October, online
 ---
 
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";

--- a/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/2025.mdx
@@ -16,7 +16,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/ds
 image_alt: NL Design System Design Systems Week 2024 27-30 October, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../../\_2025/sessions.json";

--- a/docs/community/events/design-systems-week/en/previous-editions/_template.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/_template.mdx
@@ -14,7 +14,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week PLACEHOLDER_YEAR PLACEHOLDER_DATERANGE, online
 ---
 
-import { Link, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../../\_PLACEHOLDER_YEAR/sessions.json";
 import speakers from "../../\_PLACEHOLDER_YEAR/speakers.json";
 import { DSWSession } from "@site/src/components/DSWSession";
@@ -23,7 +24,7 @@ import { DSWSession } from "@site/src/components/DSWSession";
 
 # Design Systems Week PLACEHOLDER_YEAR
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   During Design Systems Week, you could follow several short talks each day for four days. Topics included TEDI,
   Estonia’s new design system, accessibility, AI, user research, and practical tests for evaluating accessibility.
   Luckily, we still have the videos!

--- a/docs/community/events/design-systems-week/en/previous-editions/_template.mdx
+++ b/docs/community/events/design-systems-week/en/previous-editions/_template.mdx
@@ -14,7 +14,6 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week PLACEHOLDER_YEAR PLACEHOLDER_DATERANGE, online
 ---
 
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import sessions from "../../\_PLACEHOLDER_YEAR/sessions.json";
 import speakers from "../../\_PLACEHOLDER_YEAR/speakers.json";

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -14,7 +14,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
@@ -34,12 +34,12 @@ import settings from "../settings.json";
 </Paragraph>
 
 <ActionGroup>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/timetable`} appearance="primary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/timetable`} appearance="primary-action">
     {"View the timetable"}
     <IconChevronRight />
   </ButtonLink>
   {!!settings.miro && (
-    <ButtonLink href={settings.miro} appearance="secondary-action-button">
+    <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Use Miro"}
       <IconChevronRight />
     </ButtonLink>

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -14,12 +14,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Paragraph,
-  Link,
-} from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../\_2026/sessions.json";
 import speakers from "../\_2026/speakers.json";
@@ -30,7 +26,7 @@ import settings from "../settings.json";
 
 # Design Systems Week {settings.year}
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System is organising the Design Systems Week for the fifth time. It will feature a number of short talks
   about the how and why of design systems. All online. From {settings.en.dateRange}, we will cover subjects like
   managing design systems, integrating accessibility, user research and code.

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -14,7 +14,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../\_2026/sessions.json";

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -36,12 +36,12 @@ import settings from "../settings.json";
 <ActionGroup>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/en/timetable`} appearance="primary-action">
     {"View the timetable"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   {!!settings.miro && (
     <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Use Miro"}
-      <IconChevronRight />
+      <IconChevronRight slot="icon-end" />
     </ButtonLink>
   )}
 </ActionGroup>

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -14,7 +14,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../\_2026/sessions.json";

--- a/docs/community/events/design-systems-week/en/timetable.mdx
+++ b/docs/community/events/design-systems-week/en/timetable.mdx
@@ -19,8 +19,8 @@ import {
   ButtonLink,
   Link,
   Heading2,
-  Paragraph,
 } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../\_2026/sessions.json";
 import speakers from "../\_2026/speakers.json";
@@ -29,7 +29,7 @@ import settings from "../settings.json";
 
 # Design Systems Week {settings.year} Timetable
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System is organising the Design Systems Week for the {settings.en.edition} time. It will feature a number of
   short talks about the how and why of design systems. All online. From {settings.en.dateRange}, we will cover subjects
   like managing design systems, integrating accessibility, user research and code.

--- a/docs/community/events/design-systems-week/en/timetable.mdx
+++ b/docs/community/events/design-systems-week/en/timetable.mdx
@@ -38,7 +38,7 @@ import settings from "../settings.json";
 {!settings.isHappening && (
 
 <ActionGroup>
-  <ButtonLink href="/events/design-systems-week/en" appearance="primary-action-button">
+  <ButtonLink href="/events/design-systems-week/en" appearance="primary-action">
     {"About Design Systems Week"}
     <IconChevronRight />
   </ButtonLink>
@@ -49,12 +49,12 @@ import settings from "../settings.json";
 {!!settings.isHappening && (<>
 
 <ActionGroup>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="primary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="primary-action">
     {"See the program"}
     <IconChevronRight />
   </ButtonLink>
   {!!settings.miro && (
-    <ButtonLink href={settings.miro} appearance="secondary-action-button">
+    <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Use Miro"}
       <IconChevronRight />
     </ButtonLink>

--- a/docs/community/events/design-systems-week/en/timetable.mdx
+++ b/docs/community/events/design-systems-week/en/timetable.mdx
@@ -14,12 +14,9 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 October, online
 ---
 
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Link,
-  Heading2,
-} from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
+import { ActionGroup } from "@components/action-group/action-group";
+import { Link } from "@components/link/link";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "../\_2026/sessions.json";
@@ -40,7 +37,7 @@ import settings from "../settings.json";
 <ActionGroup>
   <ButtonLink href="/events/design-systems-week/en" appearance="primary-action">
     {"About Design Systems Week"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 
@@ -51,12 +48,12 @@ import settings from "../settings.json";
 <ActionGroup>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/en/program`} appearance="primary-action">
     {"See the program"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   {!!settings.miro && (
     <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Use Miro"}
-      <IconChevronRight />
+      <IconChevronRight slot="icon-end" />
     </ButtonLink>
   )}
 </ActionGroup>

--- a/docs/community/events/design-systems-week/index.mdx
+++ b/docs/community/events/design-systems-week/index.mdx
@@ -35,11 +35,11 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 <ActionGroup>
   <ButtonLink href="/events/design-systems-week/aanmelden" appearance="primary-action">
     Meld je aan
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="secondary-action">
     Bekijk het programma
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/design-systems-week/index.mdx
+++ b/docs/community/events/design-systems-week/index.mdx
@@ -15,7 +15,8 @@ image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink, ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "./settings.json";
 

--- a/docs/community/events/design-systems-week/index.mdx
+++ b/docs/community/events/design-systems-week/index.mdx
@@ -15,7 +15,7 @@ image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "./settings.json";
@@ -33,11 +33,11 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 </Paragraph>
 
 <ActionGroup>
-  <ButtonLink href="/events/design-systems-week/aanmelden" appearance="primary-action-button">
+  <ButtonLink href="/events/design-systems-week/aanmelden" appearance="primary-action">
     Meld je aan
     <IconChevronRight />
   </ButtonLink>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="secondary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="secondary-action">
     Bekijk het programma
     <IconChevronRight />
   </ButtonLink>

--- a/docs/community/events/design-systems-week/index.mdx
+++ b/docs/community/events/design-systems-week/index.mdx
@@ -15,7 +15,8 @@ image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonLink, ButtonGroup as ActionGroup, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink, ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import settings from "./settings.json";
 
 export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappening;
@@ -24,7 +25,7 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 
 {!!isUpComingOrHappening && (<>
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System organiseert in {settings.year} voor de {settings.nl.edition} keer de Design Systems Week. Van{" "}
   <strong>{settings.nl.dateRange}</strong> zijn er dagelijks meerdere korte sessies van diverse organisaties online te
   volgen over het <strong>hoe en waarom van design systems</strong>.
@@ -45,7 +46,7 @@ export const isUpComingOrHappening = !!settings.isUpComing || !!settings.isHappe
 
 {!isUpComingOrHappening && (<>
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Design Systems Week is een online evenement georganiseerd door NL Design System. Tijdens deze week worden meerdere
   korte sessies aangeboden waarin diverse (internationale) organisaties delen hoe en waarom ze design systems inzetten.
   Het doel is om designers, developers of andere professionals die werken aan digitale diensten voor de overheid samen

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -33,12 +33,12 @@ import settings from "./settings.json";
 <ActionGroup>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/tijdschema`} appearance="primary-action">
     {"Bekijk het tijdschema"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   {!!settings.miro && (
     <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Gebruik Miro"}
-      <IconChevronRight />
+      <IconChevronRight slot="icon-end" />
     </ButtonLink>
   )}
 </ActionGroup>

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -13,7 +13,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -13,7 +13,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
@@ -31,12 +31,12 @@ import settings from "./settings.json";
 </Paragraph>
 
 <ActionGroup>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/tijdschema`} appearance="primary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/tijdschema`} appearance="primary-action">
     {"Bekijk het tijdschema"}
     <IconChevronRight />
   </ButtonLink>
   {!!settings.miro && (
-    <ButtonLink href={settings.miro} appearance="secondary-action-button">
+    <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Gebruik Miro"}
       <IconChevronRight />
     </ButtonLink>

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -13,7 +13,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -13,12 +13,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Paragraph,
-  Link,
-} from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";
 import speakers from "./\_2026/speakers.json";
@@ -27,7 +23,7 @@ import settings from "./settings.json";
 
 # Programma Design Systems Week {settings.year}
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System organiseert in {settings.year} voor de {settings.nl.edition} keer de Design Systems Week. Van{" "}
   <strong>{settings.nl.dateRange}</strong> zijn er dagelijks meerdere korte sessies van diverse organisaties online te
   volgen over het **hoe en waarom van design systems**.

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -13,7 +13,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@site/src/components/ButtonLink";
 import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
@@ -33,7 +33,7 @@ import settings from "./settings.json";
 {!settings.isHappening && (
 
 <ActionGroup>
-  <ButtonLink href="/events/design-systems-week/" appearance="primary-action-button">
+  <ButtonLink href="/events/design-systems-week/" appearance="primary-action">
     {"Over Design Systems Week"}
     <IconChevronRight />
   </ButtonLink>
@@ -43,12 +43,12 @@ import settings from "./settings.json";
 {!!settings.isHappening && (<>
 
 <ActionGroup>
-  <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="primary-action-button">
+  <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="primary-action">
     {"Bekijk het programma"}
     <IconChevronRight />
   </ButtonLink>
   {!!settings.miro && (
-    <ButtonLink href={settings.miro} appearance="secondary-action-button">
+    <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Gebruik Miro"}
       <IconChevronRight />
     </ButtonLink>

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -35,7 +35,7 @@ import settings from "./settings.json";
 <ActionGroup>
   <ButtonLink href="/events/design-systems-week/" appearance="primary-action">
     {"Over Design Systems Week"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 )}
@@ -45,12 +45,12 @@ import settings from "./settings.json";
 <ActionGroup>
   <ButtonLink href={`/events/design-systems-week-${settings.year}/programma`} appearance="primary-action">
     {"Bekijk het programma"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   {!!settings.miro && (
     <ButtonLink href={settings.miro} appearance="secondary-action">
       {"Gebruik Miro"}
-      <IconChevronRight />
+      <IconChevronRight slot="icon-end" />
     </ButtonLink>
   )}
 </ActionGroup>

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -13,12 +13,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import {
-  ButtonGroup as ActionGroup,
-  ButtonLink,
-  Heading2,
-  Paragraph,
-} from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink, Heading2 } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";
 import speakers from "./\_2026/speakers.json";
@@ -27,7 +23,7 @@ import settings from "./settings.json";
 
 # Tijdschema Design Systems Week {settings.year}
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System organiseert in {settings.year} voor de {settings.nl.edition} keer de Design Systems Week. Van{" "}
   <strong>{settings.nl.dateRange}</strong> zijn er dagelijks meerdere korte sessies van diverse organisaties online te
   volgen over het **hoe en waarom van design systems**.

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -13,7 +13,7 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink, Heading2 } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -13,7 +13,8 @@ image: https://raw.githubusercontent.com/nl-design-system/documentatie/assets/co
 image_alt: NL Design System Design Systems Week 2026 26-29 Oktober, online
 ---
 
-import { ButtonGroup as ActionGroup, ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ButtonLink } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { IconChevronRight } from "@tabler/icons-react";
 import sessions from "./\_2026/sessions.json";

--- a/docs/community/events/developer-open-hour/index.mdx
+++ b/docs/community/events/developer-open-hour/index.mdx
@@ -38,10 +38,10 @@ Door je aan te melden kunnen wij je op de hoogte houden van Developer Open Hours
 
 <ActionGroup>
   <ButtonLink href="/events/developer-open-hour/aanmelden" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="/slack/" appearance="secondary-action">
-    {"Doe mee op Slack"} <IconChevronRight />
+    {"Doe mee op Slack"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/developer-open-hour/index.mdx
+++ b/docs/community/events/developer-open-hour/index.mdx
@@ -11,7 +11,7 @@ slug: /events/developer-open-hour
 
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Developer Open Hour
 

--- a/docs/community/events/heartbeat/index.mdx
+++ b/docs/community/events/heartbeat/index.mdx
@@ -13,7 +13,7 @@ slug: /events/heartbeat
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { Link } from "@site/src/components/Link";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Heartbeat
 

--- a/docs/community/events/heartbeat/index.mdx
+++ b/docs/community/events/heartbeat/index.mdx
@@ -22,11 +22,11 @@ In de Heartbeat vertelt het kernteam van NL Design System elke twee weken wat de
 <ActionGroup>
   <ButtonLink href="/events/heartbeat/aanmelden/" appearance="primary-action">
     {"Meld je aan"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="/events/heartbeat/videos/" appearance="secondary-action">
     {"Kijk de Heartbeat terug"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/mijn-services-check-in.mdx
+++ b/docs/community/events/mijn-services-check-in.mdx
@@ -38,10 +38,10 @@ Aanmelden is niet verplicht, maar door je aan te melden voor de MijnServices Che
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/mijn-services-community/aanmelden" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="/slack/" appearance="secondary-action">
-    {"Doe mee op Slack"} <IconChevronRight />
+    {"Doe mee op Slack"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 
@@ -53,7 +53,7 @@ Of je nu werkt aan een pagina, een formulier of een specifieke flow, met deze te
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/mijn-services-community" appearance="primary-action">
-    {"Lees meer over de MijnServices Community"} <IconChevronRight />
+    {"Lees meer over de MijnServices Community"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/mijn-services-check-in.mdx
+++ b/docs/community/events/mijn-services-check-in.mdx
@@ -19,7 +19,7 @@ keywords:
 
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # MijnServices Check-in
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour.mdx
@@ -39,10 +39,10 @@ Door je aan te melden voor de Rijkshuisstijl Community kunnen wij je op de hoogt
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/rijkshuisstijl-community/aanmelden" appearance="primary-action">
-    {"Meld je aan"} <IconChevronRight />
+    {"Meld je aan"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="/slack/" appearance="secondary-action">
-    {"Doe mee op Slack"} <IconChevronRight />
+    {"Doe mee op Slack"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 
@@ -54,7 +54,7 @@ Organisaties van de centrale overheid van Nederland (bijvoorbeeld: Belastingdien
 
 <ActionGroup>
   <ButtonLink href="/community/community-sprints/rijkshuisstijl-community" appearance="primary-action">
-    {"Lees meer over de Rijkshuisstijl Community"} <IconChevronRight />
+    {"Lees meer over de Rijkshuisstijl Community"} <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/events/rijkshuisstijl-community-open-hour.mdx
+++ b/docs/community/events/rijkshuisstijl-community-open-hour.mdx
@@ -11,7 +11,7 @@ slug: /events/rijkshuisstijl-community-open-hour
 
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Rijkshuisstijl Community Open Hour
 

--- a/docs/community/expertteam-digitale-toegankelijkheid/_rich-text-editor.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/_rich-text-editor.mdx
@@ -16,7 +16,7 @@ keywords:
 import { RichTextEditor } from "@site/src/components/RichTextEditor";
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Toegankelijkheid door c met CMS-en
 

--- a/docs/community/expertteam-digitale-toegankelijkheid/_rich-text-editor.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/_rich-text-editor.mdx
@@ -25,11 +25,11 @@ Momenteel is de Clippy Rich Text Editor volop in ontwikkeling door het NL Design
 <ActionGroup>
   <ButtonLink href="https://editor.nl-design-system-community.nl/" appearance="primary-action">
     {"Documentatie en demo"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
   <ButtonLink href="https://github.com/nl-design-system/editor" appearance="secondary-action">
     {"Editor op GitHub"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/expertteam-digitale-toegankelijkheid/design-tokens-lint/index.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/design-tokens-lint/index.mdx
@@ -17,7 +17,7 @@ keywords:
   - thema's
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Design Tokens valideren
 

--- a/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
@@ -13,7 +13,6 @@ keywords:
   - contact
 ---
 
-import { Heading3 } from "@utrecht/component-library-react/dist/css-module";
 import { Paragraph } from "@components/paragraph/paragraph";
 import { Card, CardContent, CardGroup } from "@site/src/components/CardGroup";
 import { Link } from "@site/src/components/Link";

--- a/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
@@ -13,7 +13,8 @@ keywords:
   - contact
 ---
 
-import { Heading3, Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Heading3 } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import { Card, CardContent, CardGroup } from "@site/src/components/CardGroup";
 import { Link } from "@site/src/components/Link";
 import { VideoPlayer } from "@site/src/components/VideoPlayer";

--- a/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
+++ b/docs/community/expertteam-digitale-toegankelijkheid/index.mdx
@@ -19,7 +19,7 @@ import { Link } from "@site/src/components/Link";
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react/dist/css-module";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Deelproject Expertteam Digitale Toegankelijkheid
 

--- a/docs/community/slack.mdx
+++ b/docs/community/slack.mdx
@@ -33,7 +33,7 @@ NL Design System werkt met de [Slack van de Code for NL community](https://codef
 <ActionGroup>
   <ButtonLink href="https://praatmee.codefor.nl/" appearance="primary-action">
     {"Doe mee op Slack"}
-    <IconChevronRight />
+    <IconChevronRight slot="icon-end" />
   </ButtonLink>
 </ActionGroup>
 

--- a/docs/community/slack.mdx
+++ b/docs/community/slack.mdx
@@ -24,7 +24,7 @@ keywords:
 
 import { ButtonLink } from "@site/src/components/ButtonLink";
 import { IconChevronRight } from "@tabler/icons-react";
-import { ButtonGroup as ActionGroup } from "@utrecht/component-library-react";
+import { ActionGroup } from "@components/action-group/action-group";
 
 # Slack voor NL Design System
 

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -49,7 +49,6 @@ import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -49,7 +49,8 @@ import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink, Link } from "@utrecht/component-library-react/dist/css-module";
+import { Link } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 

--- a/docs/componenten/button/index.mdx
+++ b/docs/componenten/button/index.mdx
@@ -50,7 +50,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink, Link } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 
 import {

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -48,7 +48,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/code-block/index.mdx
+++ b/docs/componenten/code-block/index.mdx
@@ -47,7 +47,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -45,7 +45,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/code/index.mdx
+++ b/docs/componenten/code/index.mdx
@@ -44,7 +44,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -50,7 +50,7 @@ import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/color-sample/index.mdx
+++ b/docs/componenten/color-sample/index.mdx
@@ -51,7 +51,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -56,7 +56,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/data-badge/index.mdx
+++ b/docs/componenten/data-badge/index.mdx
@@ -55,7 +55,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -50,7 +50,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 import ContrastMeta from "@nl-design-system-unstable/documentation/componenten/heading/\_issues/contrast/metadata.json";

--- a/docs/componenten/heading/index.mdx
+++ b/docs/componenten/heading/index.mdx
@@ -49,7 +49,7 @@ import AcComponent from "@nl-design-system-unstable/documentation/componenten/ac
 import AcImplementatie from "@nl-design-system-unstable/documentation/componenten/ac/\_ac_implementatie.md";
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/\_component_gebruiken_intro.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -50,7 +50,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import LinkIllustration from "@nl-design-system-candidate/link-docs/docs/anatomy/anatomy.svg";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/link/index.mdx
+++ b/docs/componenten/link/index.mdx
@@ -51,7 +51,7 @@ import LinkIllustration from "@nl-design-system-candidate/link-docs/docs/anatomy
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -42,7 +42,7 @@ import MarkIllustration from "@nl-design-system-candidate/mark-docs/docs/anatomy
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/mark/index.mdx
+++ b/docs/componenten/mark/index.mdx
@@ -41,7 +41,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import MarkIllustration from "@nl-design-system-candidate/mark-docs/docs/anatomy/anatomy.svg";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -36,7 +36,7 @@ import AcImplementatie from "@nl-design-system-unstable/documentation/componente
 import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/ac/_component_gebruiken_intro.md";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/number-badge/index.mdx
+++ b/docs/componenten/number-badge/index.mdx
@@ -37,7 +37,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -76,7 +76,7 @@ import UnderlineMeta from "@nl-design-system-unstable/documentation/componenten/
 import UnderlineExplanation from "@nl-design-system-unstable/documentation/componenten/paragraph/_issues/underline/explanation.md";
 import UnderlineSolution from "@nl-design-system-unstable/documentation/componenten/paragraph/_issues/underline/solution.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/paragraph/index.mdx
+++ b/docs/componenten/paragraph/index.mdx
@@ -77,7 +77,7 @@ import UnderlineExplanation from "@nl-design-system-unstable/documentation/compo
 import UnderlineSolution from "@nl-design-system-unstable/documentation/componenten/paragraph/_issues/underline/solution.md";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -54,7 +54,7 @@ import IntroGebruik from "@nl-design-system-unstable/documentation/componenten/a
 import SkipLinkIllustration from "@nl-design-system-candidate/skip-link-docs/docs/anatomy/anatomy.svg";
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
-import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
+import { LinkList, LinkListLink } from "@components/link-list/link-list";
 import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";

--- a/docs/componenten/skip-link/index.mdx
+++ b/docs/componenten/skip-link/index.mdx
@@ -55,7 +55,7 @@ import SkipLinkIllustration from "@nl-design-system-candidate/skip-link-docs/doc
 import * as Acceptatiecriteria from "./_acceptatiecriteria.tsx";
 import { Card, CardContent, CardIllustration } from "@site/src/components/CardGroup";
 import { LinkList, LinkListLink } from "@utrecht/component-library-react/dist/css-module";
-import { Heading } from "@nl-design-system-candidate/heading-react/css";
+import { Heading } from "@components/heading/heading";
 import { BrandIcon } from "@site/src/components/BrandIcon";
 import { ComponentAliases } from "@site/src/components/ComponentAliases";
 import {

--- a/docs/handboek/developer/01-index.mdx
+++ b/docs/handboek/developer/01-index.mdx
@@ -14,7 +14,7 @@ keywords:
 ---
 
 import { CardGroup } from "@site/src/components/CardGroup";
-import { Card } from "@utrecht/card-react/css";
+import { Card } from "@components/card/card";
 
 # Introductie voor developers
 
@@ -34,31 +34,31 @@ Combineer componenten van verschillende organisaties tot jouw perfecte oplossing
 
 <CardGroup>
   <Card
-    body="Bekijk de onboarding sessie voor developers op YouTube"
+    description="Bekijk de onboarding sessie voor developers op YouTube"
     heading="Onboarding video"
     headingLevel={3}
     href="https://youtu.be/Yh4NqpphJQ4?si=gN0J3IllC_eoevu7&t=2809"
   ></Card>
   <Card
-    body="Leer hoe je NL Design System kunt gebruiken voor een snel prototype."
+    description="Leer hoe je NL Design System kunt gebruiken voor een snel prototype."
     heading="Prototypes"
     headingLevel={3}
     href="/handboek/developer/prototypes/"
   ></Card>
   {/* <Card
-    body="Zet NL Design System succesvol in voor websites en webapplicaties"
+    description="Zet NL Design System succesvol in voor websites en webapplicaties"
     heading="Websites en webapplicaties"
     headingLevel={3}
     href="/handboek/developer/productie/"
   ></Card>
   <Card
-    body="Maak en onderhoud een design system met NL Design System"
+    description="Maak en onderhoud een design system met NL Design System"
     heading="Design Systems"
     headingLevel={3}
     href="/handboek/developer/design-systems/"
   ></Card>
   <Card
-    body="Gebruik NL Design System in CMS-en zoals WordPress, Drupal, Typo3 en Strapi"
+    description="Gebruik NL Design System in CMS-en zoals WordPress, Drupal, Typo3 en Strapi"
     heading="CMS-en"
     headingLevel={3}
     href="/handboek/developer/cms/"
@@ -71,25 +71,25 @@ NL Design System componenten zijn huisstijl onafhankelijk. Applicaties die hierm
 
 <CardGroup appearance="medium">
   <Card
-    body="Leer hoe je je huisstijl kunt vastleggen als NL Design System thema met Design Tokens JSON"
+    description="Leer hoe je je huisstijl kunt vastleggen als NL Design System thema met Design Tokens JSON"
     heading="Thema maken"
     headingLevel={3}
     href="/handboek/developer/thema-maken/"
   ></Card>
   <Card
-    body="Lees meer over design tokens bij NL Design System"
+    description="Lees meer over design tokens bij NL Design System"
     heading="Design Tokens"
     headingLevel={3}
     href="/handboek/huisstijl/design-tokens/"
   ></Card>
   <Card
-    body="Gebruik het start-thema om sneller te starten met de huisstijl vastleggen met basis-tokens."
+    description="Gebruik het start-thema om sneller te starten met de huisstijl vastleggen met basis-tokens."
     heading="Start thema"
     headingLevel={3}
     href="/handboek/huisstijl/themas/start-thema/"
   ></Card>
   <Card
-    body="Gebruik het voorbeeld-thema voor prototypes zonder huisstijl"
+    description="Gebruik het voorbeeld-thema voor prototypes zonder huisstijl"
     heading="Voorbeeld thema"
     headingLevel={3}
     href="/handboek/huisstijl/themas/voorbeeld-thema/"
@@ -111,61 +111,61 @@ De HTML structuur en design beslissingen van NL Design System componenten worden
 <>
   {/* <CardGroup appearance="medium">
   <Card
-    body="CSS componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="CSS componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="CSS"
     headingLevel={3}
     href="/handboek/developer/componenten/css"
   ></Card>
   <Card
-    body="React componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="React componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="React"
     headingLevel={3}
     href="/handboek/developer/componenten/react"
   ></Card>
   <Card
-    body="Web Components gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="Web Components gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="Web Components"
     headingLevel={3}
     href="/handboek/developer/componenten/web-component"
   ></Card>
   <Card
-    body="Angular componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="Angular componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="Angular"
     headingLevel={3}
     href="/handboek/developer/componenten/angular"
   ></Card>
   <Card
-    body="Vue.js componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="Vue.js componenten gebruiken, uitbreiden, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="Vue.js"
     headingLevel={3}
     href="/handboek/developer/componenten/vue"
   ></Card>
   <Card
-    body="HTML componenten gebruiken, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="HTML componenten gebruiken, maken, testen en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="HTML"
     headingLevel={3}
     href="/handboek/developer/componenten/html"
   ></Card>
   <Card
-    body="SCSS gebruiken, uitbreiden en maken? Onder code vind je alle informatie die je nodig hebt."
+    description="SCSS gebruiken, uitbreiden en maken? Onder code vind je alle informatie die je nodig hebt."
     heading="SCSS"
     headingLevel={3}
     href="/handboek/developer/componenten/scss"
   ></Card>
   <Card
-    body="Twig componenten gebruiken, maken en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="Twig componenten gebruiken, maken en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="Twig"
     headingLevel={3}
     href="/handboek/developer/componenten/twig"
   ></Card>
   <Card
-    body="TipTap componenten gebruiken, maken en bijdragen? Onder code vind je alle informatie die je nodig hebt."
+    description="TipTap componenten gebruiken, maken en bijdragen? Onder code vind je alle informatie die je nodig hebt."
     heading="TipTap"
     headingLevel={3}
     href="/handboek/developer/componenten/tiptap"
   ></Card>
   <Card
-    body="Componenten gebruiken in Mendix? Onder code vind je alle informatie die je nodig hebt."
+    description="Componenten gebruiken in Mendix? Onder code vind je alle informatie die je nodig hebt."
     heading="Mendix"
     headingLevel={3}
     href="/handboek/developer/componenten/mendix"
@@ -183,19 +183,19 @@ Een gedeelde aanpak zorgt ervoor dat componenten binnen NL Design System er cons
 
 <CardGroup appearance="medium">
   <Card
-    body="Lees wat de NL Design System conventies zijn voor White Label componenten, Design Tokens, herbruikbare CSS, een API conventie, geautomatiseerde tests en versionering."
+    description="Lees wat de NL Design System conventies zijn voor White Label componenten, Design Tokens, herbruikbare CSS, een API conventie, geautomatiseerde tests en versionering."
     heading="Conventies"
     headingLevel={3}
     href="/handboek/developer/conventies/"
   ></Card>
   <Card
-    body="Leer hoe de infrastructuur van NL Design System helpt om samen met andere organisaties te werken in een open source design system ecosysteem"
+    description="Leer hoe de infrastructuur van NL Design System helpt om samen met andere organisaties te werken in een open source design system ecosysteem"
     heading="Infrastructuur"
     headingLevel={3}
     href="/handboek/developer/infrastructuur/"
   ></Card>
   <Card
-    body="Bekijk het Estafettemodel en leer hoe deze helpt om samen met verschillende organisaties toe te werken naar gestandaardiseerde componenten, patronen en templates met ruimte voor innovatie."
+    description="Bekijk het Estafettemodel en leer hoe deze helpt om samen met verschillende organisaties toe te werken naar gestandaardiseerde componenten, patronen en templates met ruimte voor innovatie."
     heading="Estafettemodel"
     headingLevel={3}
     href="/handboek/estafettemodel/"

--- a/docs/handboek/developer/02-aan-de-slag/01-prototypes/02-cdn.mdx
+++ b/docs/handboek/developer/02-aan-de-slag/01-prototypes/02-cdn.mdx
@@ -8,11 +8,11 @@ pagination_label: CDN gebruiken
 slug: /handboek/developer/cdn/
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Content-Delivery Network (CDN) gebruiken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Voor een prototype is snel een idee verspreiden en laagdrempelig samenwerken vaak belangrijker dan betrouwbaarheid en
   veiligheid. Frameworks, libraries en fonts worden vaak geladen vanaf een gratis CDN zodat 1 bestand voldoende is voor
   het hele prototype.

--- a/docs/handboek/developer/02-aan-de-slag/01-prototypes/03-cdn-migratie.mdx
+++ b/docs/handboek/developer/02-aan-de-slag/01-prototypes/03-cdn-migratie.mdx
@@ -8,11 +8,11 @@ pagination_label: Migreer van een CDN naar pnpm
 slug: /handboek/developer/cdn-migratie/
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Migreer van een CDN naar pnpm
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   De dependencies op de aanbevolen manier installeren via pnpm is één van de eerste stappen wanneer je het prototype gaat doorontwikkelen.
 
 </Paragraph>

--- a/docs/handboek/developer/03-conventies/05-states.mdx
+++ b/docs/handboek/developer/03-conventies/05-states.mdx
@@ -7,11 +7,11 @@ pagination_label: Namen van states
 slug: /handboek/developer/state-conventie/
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Namen van states
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   De namen van states van componenten zijn gebaseerd op webstandaarden die veel gebruik worden. Door deze conventies te
   gebruiken, zijn APIs voor states voorspelbaar en stabiel.
 </Paragraph>

--- a/docs/handboek/developer/05-infrastructuur/08-npm-publish.mdx
+++ b/docs/handboek/developer/05-infrastructuur/08-npm-publish.mdx
@@ -20,11 +20,11 @@ keywords:
 {/* - Als developer/maintainer wil ik weten hoe ik mijn repository moet inrichten om packages te publiceren via Changesets */}
 {/* - Als DevOps Engineer wil ik dat de community kan troubleshooten bij publiceren, omdat eventuele foutmeldingen bij problemen vaak onduidelijk zijn */}
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Publiceren van npm packages
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Het publiceren van NL Design System packages gaat altijd via CI/CD pipelines. Dat is handig en veiliger dan handmatig
   publiceren. We volgen hierbij de Changesets-workflow: bij elke wijziging die je wilt publiceren voorzie je die gelijk
   van de tekst voor de changelog, en je publiceert op een goed moment één of meerdere wijzigingen door een Pull Request

--- a/docs/handboek/estafettemodel.mdx
+++ b/docs/handboek/estafettemodel.mdx
@@ -16,11 +16,11 @@ keywords:
 {/* @license CC0-1.0 */}
 
 import { StatusVisual } from "@site/src/components/StatusVisual";
-import { Paragraph } from "@utrecht/component-library-react";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Estafettemodel
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Het Estafettemodel is een door NL Design System ontwikkelde methodiek die samenwerken aan Open Source makkelijk maakt.
 </Paragraph>
 

--- a/docs/handboek/organisatie/beheren-van-een-community-repository.mdx
+++ b/docs/handboek/organisatie/beheren-van-een-community-repository.mdx
@@ -15,11 +15,11 @@ keywords:
   - repository
 ---
 
-import { Paragraph } from "@utrecht/component-library-react";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Beheren van een repository
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Met een repository binnen de organisatie wordt deze onderdeel van het NL Design System ecosysteem, waarop anderen
   kunnen vertrouwen en voortbouwen. Dit komt met een bepaalde verantwoordelijkheid en vraagt om actief onderhoud. Op
   deze pagina lichten we toe wat daarbij komt kijken.

--- a/docs/project/klachten.mdx
+++ b/docs/project/klachten.mdx
@@ -11,7 +11,7 @@ keywords:
   - klachten
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Klachten
 

--- a/docs/project/kwaliteitsaanpak/agile-sprint.mdx
+++ b/docs/project/kwaliteitsaanpak/agile-sprint.mdx
@@ -8,11 +8,11 @@ description: Aanpak voor het voorbereiden van agile sprints voor mensen die de N
 
 {/* @license CC0-1.0 */}
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Agile sprint
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Elke twee weken wordt een sprint gepland, waar prioriteit wordt gegeven aan werkzaamheden binnen het open source
   project.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/backup.mdx
+++ b/docs/project/kwaliteitsaanpak/backup.mdx
@@ -10,13 +10,13 @@ keywords:
   - backup
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Backup
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Wanneer je open source code aanbiedt op publieke infrastructuur, dan is het belangrijk dat je backups hebt waarvan de
   integriteit in orde is.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/broncodekwaliteit.mdx
+++ b/docs/project/kwaliteitsaanpak/broncodekwaliteit.mdx
@@ -11,13 +11,13 @@ keywords:
   - editorconfig
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Broncodekwaliteit
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Broncodekwaliteit moet zoveel mogelijk automatisch gecontroleerd en verbeterd worden. Continuous integration checks
   garanderen de kwaliteit van code die wordt gemerged in de `main` branch. Effectieve integratie in de workflow van
   developers verhoogt de snelheid van werken en zorgt voor draagvlak van rigide kwaliteitseisen.

--- a/docs/project/kwaliteitsaanpak/code-review.mdx
+++ b/docs/project/kwaliteitsaanpak/code-review.mdx
@@ -12,13 +12,13 @@ keywords:
   - review
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Code reviews
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Werk samen met anderen om jouw wijzigingen te controleren, en gebruik de feedback om het afgesproken kwaliteitsniveau
   te bereiken.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/continuous-delivery.mdx
+++ b/docs/project/kwaliteitsaanpak/continuous-delivery.mdx
@@ -11,13 +11,13 @@ keywords:
   - cd
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Continuous Delivery
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Zorg dat op elk moment een software release gedaan kan worden van de laatste versie in de `main` branch, zodat
   verbeteringen snel beschikbaar worden voor gebruikers. Gebruik semantic versioning tools om automatisch het volgende
   versienummer te bepalen.

--- a/docs/project/kwaliteitsaanpak/continuous-deployment.mdx
+++ b/docs/project/kwaliteitsaanpak/continuous-deployment.mdx
@@ -11,13 +11,13 @@ keywords:
   - cd
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Continuous Deployment
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Gebruik continous deployment voor websites, zodat wijzigingen die goedgekeurd zijn direct beschikbaar worden. Door
   continuous integration zijn de wijzigingen aan de website altijd van voldoende kwaliteit om direct een release te
   doen.

--- a/docs/project/kwaliteitsaanpak/continuous-integration.mdx
+++ b/docs/project/kwaliteitsaanpak/continuous-integration.mdx
@@ -10,7 +10,7 @@ keywords:
   - ci
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 

--- a/docs/project/kwaliteitsaanpak/definition-of-done.mdx
+++ b/docs/project/kwaliteitsaanpak/definition-of-done.mdx
@@ -8,13 +8,13 @@ pagination_label: Definition of Done
 description: Definition of Done voor mensen die de NL Design System kwaliteitsaanpak gebruiken.
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Definition of Done
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Controleer met Definition of Done of het werk klaar is om te presenteren aan de product owner, voor de laatste check.
 </Paragraph>
 

--- a/docs/project/kwaliteitsaanpak/definition-of-ready.mdx
+++ b/docs/project/kwaliteitsaanpak/definition-of-ready.mdx
@@ -8,7 +8,7 @@ pagination_label: Definition of Ready
 description: Definition of Done voor mensen die de NL Design System kwaliteitsaanpak gebruiken.
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
@@ -16,7 +16,7 @@ import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 
 {/* De Definition of Ready bevat de onderdelen uit de "INVEST" method: Independent, Negotiable, Valuable, Estimable, Small, Testable */}
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Controleer met Definition of Ready of het werk klaar is om aan te werken in een agile sprint.
 </Paragraph>
 

--- a/docs/project/kwaliteitsaanpak/i18n.mdx
+++ b/docs/project/kwaliteitsaanpak/i18n.mdx
@@ -13,7 +13,7 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Internationalisatie en localisatie
 

--- a/docs/project/kwaliteitsaanpak/index.mdx
+++ b/docs/project/kwaliteitsaanpak/index.mdx
@@ -10,13 +10,13 @@ keywords:
   - kwaliteitsaanpak
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Kwaliteitsaanpak
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Werk je in opdracht van NL Design System? Gebruik dan deze aanpak om veilige software van hoge kwaliteit te maken.
   Wanneer je in de community werkt, dan heb je misschien ook veel aan deze aanpak.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/open-source.mdx
+++ b/docs/project/kwaliteitsaanpak/open-source.mdx
@@ -10,13 +10,13 @@ keywords:
   - open source
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Open Source
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Publiceer alle code en documentatie onder een open source licentie, zodat het mogelijk is samen te werken voorbij
   organisatiegrenzen.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/product-backlog.mdx
+++ b/docs/project/kwaliteitsaanpak/product-backlog.mdx
@@ -12,11 +12,11 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Product backlog
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Om keuzes te kunnen maken welk werk prioriteit krijgt worden alle taken, ideeën en processen vooraf vastgelegd in de
   Product Backlog.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/productieomgeving.mdx
+++ b/docs/project/kwaliteitsaanpak/productieomgeving.mdx
@@ -14,11 +14,11 @@ keywords:
 
 {/* @license CC0-1.0 */}
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 # Productieomgeving
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Begin nieuwe website-projecten met een minimum viable product in productie krijgen, bij voorkeur al in de eerste
   sprint. Gebruik daarna continuous deployment om vaak en snel deployments te doen naar productie-omgeving.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/release-notes.mdx
+++ b/docs/project/kwaliteitsaanpak/release-notes.mdx
@@ -11,13 +11,13 @@ keywords:
   - release notes
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Release notes
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Publiceer documentatie over de wijzigingen in softwarereleases in een `CHANGELOG.md` bestand, zodat gebruikers weten
   wat ze kunnen verwachten en hoe ze kunnen migreren naar de nieuwe versie.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/sprint-review.mdx
+++ b/docs/project/kwaliteitsaanpak/sprint-review.mdx
@@ -12,13 +12,13 @@ keywords:
   - test
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Sprint review
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Presenteer de ontwikkelingen aan de product owner en andere belangrijke stakeholders, aan het eind van elke agile
   sprint. Zorg dat de product owner het resultaat accepteert en je voldoet aan de acceptatiecriteria en de Definition of
   Done.

--- a/docs/project/kwaliteitsaanpak/supply-chain.mdx
+++ b/docs/project/kwaliteitsaanpak/supply-chain.mdx
@@ -12,13 +12,13 @@ keywords:
   - peerDependencies
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Software supply chain
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Beperk de risico's bij het werken met externe software en libraries, door alle wijzigingen in dependencies te
   controleren en in te grijpen wanneer nieuwe kwetsbaarheden bekend zijn.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/testomgeving.mdx
+++ b/docs/project/kwaliteitsaanpak/testomgeving.mdx
@@ -12,13 +12,13 @@ keywords:
   - test
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Testomgeving
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Biedt een testomgeving aan voor elke wijziging, zodat het laagdrempelig is om een review te doen van een wijziging.
   Laat ook weten waar in testomgeving je moet zijn, en hoe je de wijzigingen kan testen. Zo maak je samen een beter
   product.

--- a/docs/project/kwaliteitsaanpak/veilig-werken.mdx
+++ b/docs/project/kwaliteitsaanpak/veilig-werken.mdx
@@ -8,13 +8,13 @@ pagination_label: Veilig werken
 description: Veilig werken is belangrijk voor NL Design System, dit is wat je kunt doen.
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Veilig werken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Samen houden we NL Design System veilig. Het is belangrijk dat je weet hoe je veilig kunt werken met je eigen devices
   en accounts, en dat je geen onverantwoorde risico's neemt.
 </Paragraph>

--- a/docs/project/kwaliteitsaanpak/veilige-werkomgeving.mdx
+++ b/docs/project/kwaliteitsaanpak/veilige-werkomgeving.mdx
@@ -10,13 +10,13 @@ keywords:
   - coc
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Veilige werkomgeving
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Respectvolle en constructieve communicatie is een essentiëel onderdeel van softwareontwikkeling, bij het bespreken van
   de product backlog en bij code reviews. De Code of Conduct helpt om te weten wat andere mensen nodig hebben om hun
   beste werk te doen.

--- a/docs/project/kwaliteitsaanpak/versiebeheer.mdx
+++ b/docs/project/kwaliteitsaanpak/versiebeheer.mdx
@@ -13,13 +13,13 @@ keywords:
   - versiebeheer
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Versiebeheer
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Gebruik Git om code te delen met anderen, samen te werken aan code, vorige implementaties te vinden, de evolutie van
   de code te begrijpen, nieuwe releases uit te brengen en open source samenwerkingen aan te gaan.
 </Paragraph>

--- a/docs/project/schrijfwijzer/afbeeldingen.mdx
+++ b/docs/project/schrijfwijzer/afbeeldingen.mdx
@@ -9,7 +9,7 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 

--- a/docs/project/schrijfwijzer/beslissingen.mdx
+++ b/docs/project/schrijfwijzer/beslissingen.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Beslissingen voor schrijfwijze
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Wanneer we keuze maken voor de schrijfwijze van een term, dan willen we die vastleggen zodat de teksten consistent en
   begrijpelijk zijn.
 </Paragraph>

--- a/docs/project/schrijfwijzer/code.mdx
+++ b/docs/project/schrijfwijzer/code.mdx
@@ -9,13 +9,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Code
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Met herkenbare code-voorbeelden wordt het makkelijker om richtlijnen en patronen uit het design system te begrijpen.
   Gebruik deze tips om goede voorbeelden te maken.
 </Paragraph>

--- a/docs/project/schrijfwijzer/doelen.mdx
+++ b/docs/project/schrijfwijzer/doelen.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Doelen voor communicatie
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Met duidelijke en positieve communicatie kunnen we mensen overtuigen om hun dienstverlening te verbeteren met onze
   concrete oplossingen.
 </Paragraph>

--- a/docs/project/schrijfwijzer/doelgroepen.mdx
+++ b/docs/project/schrijfwijzer/doelgroepen.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Meerdere doelgroepen aanspreken
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Pas je schrijfwijze aan voor de doelgroep van de content die je maakt. We willen specialisten in de community niet
   betuttelen door vaktaal te vermijden. Maar we willen ook bijvoorbeeld managers of nieuwe doelgroepen goed kunnen
   uitleggen wat we doen. Daarom hebben we een aanpak waar we rekening houden met een gemengd publiek.

--- a/docs/project/schrijfwijzer/engels.mdx
+++ b/docs/project/schrijfwijzer/engels.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Richtlijnen voor Engelse teksten
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Sommige pagina's op de website zijn Engelstalig, omdat ze bedoeld zijn voor een internationaal publiek. Veel
   softwaredocumentatie is ook alleen in het Engels beschikbaar, vanwege de Standard for Public Code.
 </Paragraph>

--- a/docs/project/schrijfwijzer/index.mdx
+++ b/docs/project/schrijfwijzer/index.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Schrijfwijzer
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Gebruik deze Schrijfwijzer om goede teksten te maken voor de NL Design System community, wanneer je werkt in opdracht
   van het project. Dit geldt voor communicatie via e-mails, brieven, teksten op de website, social media, chats,
   e-mails, posters, folders of presentaties. Maar ook online in de programma's of tools waar we mee werken, zoals in

--- a/docs/project/schrijfwijzer/nederlands.mdx
+++ b/docs/project/schrijfwijzer/nederlands.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Richtlijnen voor Nederlandse teksten
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   De overige richtlijnen gelden voor teksten in alle talen die we gebruiken, zoals Nederlands en Engels. De volgende
   richtlijnen zijn specifiek voor Nederlandse teksten.
 </Paragraph>

--- a/docs/project/schrijfwijzer/pagina-opbouw.mdx
+++ b/docs/project/schrijfwijzer/pagina-opbouw.mdx
@@ -10,7 +10,7 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 

--- a/docs/project/schrijfwijzer/reviews.mdx
+++ b/docs/project/schrijfwijzer/reviews.mdx
@@ -10,13 +10,13 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
 # Reviews
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   Heb je een tekst geschreven? Laat dan altijd een ander meelezen vóór je de tekst publiceert. Zou houden we elkaar
   scherp.
 </Paragraph>

--- a/docs/project/schrijfwijzer/video.mdx
+++ b/docs/project/schrijfwijzer/video.mdx
@@ -9,7 +9,7 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 

--- a/docs/project/schrijfwijzer/wcag.mdx
+++ b/docs/project/schrijfwijzer/wcag.mdx
@@ -9,7 +9,7 @@ keywords:
   - kernteam
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 
 {/* @license CC0-1.0 */}
 
@@ -18,7 +18,7 @@ import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
 {/* Er is een GitHub Project board om bij of de WCAG-pagina's al voldoen aan de schrijfwijzer: */}
 {/* https://github.com/orgs/nl-design-system/projects/95 */}
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   De WCAG-pagina's zijn een praktische aanvulling op de abstracte teksten in de officiële specificatie. Mensen die voor
   het eerst een toegankelijke website maken leren waar ze op moeten letten. De WCAG-pagina's zijn ook een startpunt voor
   NL Design System oplossingen voor problemen die zijn gevonden bij een toegankelijkheidsonderzoek.

--- a/docs/richtlijnen/formulieren/visual-design/1-field-contrast/_code.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/1-field-contrast/_code.mdx
@@ -2,7 +2,6 @@
 
 import { Canvas } from "@site/src/components/Canvas/Canvas";
 import { Guideline } from "@site/src/components/Guideline";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 
 <Guideline
   appearance="do"

--- a/docs/richtlijnen/formulieren/visual-design/2-text-contrast/_code.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/2-text-contrast/_code.mdx
@@ -2,7 +2,6 @@
 
 import { Canvas } from "@site/src/components/Canvas/Canvas";
 import { Guideline } from "@site/src/components/Guideline";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 
 <Guideline
   appearance="do"

--- a/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/_code.mdx
+++ b/docs/richtlijnen/formulieren/visual-design/3-placeholder-contrast/_code.mdx
@@ -2,7 +2,6 @@
 
 import { Canvas } from "@site/src/components/Canvas/Canvas";
 import { Guideline } from "@site/src/components/Guideline";
-import { Link } from "@utrecht/component-library-react/dist/css-module";
 
 ## Voorbeelden
 

--- a/docs/wcag/1.1.01.mdx
+++ b/docs/wcag/1.1.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.01.mdx
+++ b/docs/wcag/1.2.01.mdx
@@ -26,7 +26,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.02.mdx
+++ b/docs/wcag/1.2.02.mdx
@@ -25,7 +25,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.03.mdx
+++ b/docs/wcag/1.2.03.mdx
@@ -28,7 +28,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.04.mdx
+++ b/docs/wcag/1.2.04.mdx
@@ -24,7 +24,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.05.mdx
+++ b/docs/wcag/1.2.05.mdx
@@ -25,7 +25,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.2.06.mdx
+++ b/docs/wcag/1.2.06.mdx
@@ -26,7 +26,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.2.07.mdx
+++ b/docs/wcag/1.2.07.mdx
@@ -26,7 +26,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.2.08.mdx
+++ b/docs/wcag/1.2.08.mdx
@@ -24,7 +24,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.2.09.mdx
+++ b/docs/wcag/1.2.09.mdx
@@ -24,7 +24,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.3.01.mdx
+++ b/docs/wcag/1.3.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.3.02.mdx
+++ b/docs/wcag/1.3.02.mdx
@@ -32,7 +32,7 @@ import { Guideline } from "@site/src/components/Guideline";
 import { Markdown } from "@site/src/components/Markdown";
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.3.03.mdx
+++ b/docs/wcag/1.3.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.3.04.mdx
+++ b/docs/wcag/1.3.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.3.05.mdx
+++ b/docs/wcag/1.3.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.3.06.mdx
+++ b/docs/wcag/1.3.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.4.01.mdx
+++ b/docs/wcag/1.4.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.02.mdx
+++ b/docs/wcag/1.4.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.03.mdx
+++ b/docs/wcag/1.4.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.04.mdx
+++ b/docs/wcag/1.4.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.05.mdx
+++ b/docs/wcag/1.4.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.06.mdx
+++ b/docs/wcag/1.4.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.4.07.mdx
+++ b/docs/wcag/1.4.07.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.4.08.mdx
+++ b/docs/wcag/1.4.08.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.4.09.mdx
+++ b/docs/wcag/1.4.09.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/1.4.10.mdx
+++ b/docs/wcag/1.4.10.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.11.mdx
+++ b/docs/wcag/1.4.11.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.12.mdx
+++ b/docs/wcag/1.4.12.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/1.4.13.mdx
+++ b/docs/wcag/1.4.13.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.1.01.mdx
+++ b/docs/wcag/2.1.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.1.02.mdx
+++ b/docs/wcag/2.1.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.1.03.mdx
+++ b/docs/wcag/2.1.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.1.04.mdx
+++ b/docs/wcag/2.1.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.2.01.mdx
+++ b/docs/wcag/2.2.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.2.02.mdx
+++ b/docs/wcag/2.2.02.mdx
@@ -23,7 +23,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.2.03.mdx
+++ b/docs/wcag/2.2.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.2.04.mdx
+++ b/docs/wcag/2.2.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.2.05.mdx
+++ b/docs/wcag/2.2.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.2.06.mdx
+++ b/docs/wcag/2.2.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.3.01.mdx
+++ b/docs/wcag/2.3.01.mdx
@@ -23,7 +23,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.3.02.mdx
+++ b/docs/wcag/2.3.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.3.03.mdx
+++ b/docs/wcag/2.3.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.4.01.mdx
+++ b/docs/wcag/2.4.01.mdx
@@ -23,7 +23,7 @@ keywords:
 import { Markdown } from "@site/src/components/Markdown";
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.02.mdx
+++ b/docs/wcag/2.4.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.03.mdx
+++ b/docs/wcag/2.4.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.04.mdx
+++ b/docs/wcag/2.4.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.05.mdx
+++ b/docs/wcag/2.4.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.06.mdx
+++ b/docs/wcag/2.4.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.07.mdx
+++ b/docs/wcag/2.4.07.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.08.mdx
+++ b/docs/wcag/2.4.08.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.4.09.mdx
+++ b/docs/wcag/2.4.09.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.4.10.mdx
+++ b/docs/wcag/2.4.10.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.4.11.mdx
+++ b/docs/wcag/2.4.11.mdx
@@ -23,7 +23,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.4.12.mdx
+++ b/docs/wcag/2.4.12.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.4.13.mdx
+++ b/docs/wcag/2.4.13.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.5.01.mdx
+++ b/docs/wcag/2.5.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.5.02.mdx
+++ b/docs/wcag/2.5.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.5.03.mdx
+++ b/docs/wcag/2.5.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.5.04.mdx
+++ b/docs/wcag/2.5.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.5.05.mdx
+++ b/docs/wcag/2.5.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.5.06.mdx
+++ b/docs/wcag/2.5.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/2.5.07.mdx
+++ b/docs/wcag/2.5.07.mdx
@@ -23,7 +23,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/2.5.08.mdx
+++ b/docs/wcag/2.5.08.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.1.01.mdx
+++ b/docs/wcag/3.1.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.1.02.mdx
+++ b/docs/wcag/3.1.02.mdx
@@ -23,7 +23,7 @@ keywords:
 import { Markdown } from "@site/src/components/Markdown";
 import { VideoPlayer } from "@site/src/components/VideoPlayer";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.1.03.mdx
+++ b/docs/wcag/3.1.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.1.04.mdx
+++ b/docs/wcag/3.1.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.1.05.mdx
+++ b/docs/wcag/3.1.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.1.06.mdx
+++ b/docs/wcag/3.1.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.2.01.mdx
+++ b/docs/wcag/3.2.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.2.02.mdx
+++ b/docs/wcag/3.2.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.2.03.mdx
+++ b/docs/wcag/3.2.03.mdx
@@ -23,7 +23,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.2.04.mdx
+++ b/docs/wcag/3.2.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.2.05.mdx
+++ b/docs/wcag/3.2.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.2.06.mdx
+++ b/docs/wcag/3.2.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.01.mdx
+++ b/docs/wcag/3.3.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.02.mdx
+++ b/docs/wcag/3.3.02.mdx
@@ -24,7 +24,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.03.mdx
+++ b/docs/wcag/3.3.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.04.mdx
+++ b/docs/wcag/3.3.04.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.05.mdx
+++ b/docs/wcag/3.3.05.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/3.3.06.mdx
+++ b/docs/wcag/3.3.06.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import AAAMessage from "./_wcag-aaa-message.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.07.mdx
+++ b/docs/wcag/3.3.07.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.08.mdx
+++ b/docs/wcag/3.3.08.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/3.3.09.mdx
+++ b/docs/wcag/3.3.09.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import AAAMessage from "./_wcag-aaa-message.md";

--- a/docs/wcag/4.1.01.mdx
+++ b/docs/wcag/4.1.01.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/4.1.02.mdx
+++ b/docs/wcag/4.1.02.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/4.1.03.mdx
+++ b/docs/wcag/4.1.03.mdx
@@ -22,7 +22,7 @@ keywords:
 
 import { Markdown } from "@site/src/components/Markdown";
 import { WcagHeadingGroup } from "@site/src/components/WcagHeadingGroup";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import CTAGebruikersonderzoek from "./_cta_gebruikersonderzoek.md";
 import Disclaimer from "./_wcag-disclaimer.md";
 import WCAGFooterInfo from "./_wcag_footer_info.md";

--- a/docs/wcag/index.mdx
+++ b/docs/wcag/index.mdx
@@ -15,7 +15,7 @@ keywords:
 ---
 
 import { Markdown } from "@site/src/components/Markdown";
-import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@components/spotlight-section/spotlight-section";
 import { Paragraph } from "@components/paragraph/paragraph";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 import { successCriteria } from "@site/src/components/wcag22";

--- a/docs/wcag/index.mdx
+++ b/docs/wcag/index.mdx
@@ -15,7 +15,8 @@ keywords:
 ---
 
 import { Markdown } from "@site/src/components/Markdown";
-import { Paragraph, SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { SpotlightSection } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import WCAGFooterInfo from "./_wcag_footer_info.md";
 import { successCriteria } from "@site/src/components/wcag22";
 

--- a/docs/woordenlijst/index.mdx
+++ b/docs/woordenlijst/index.mdx
@@ -15,7 +15,7 @@ keywords:
   - uitleg
 ---
 
-import { Paragraph } from "@utrecht/component-library-react/dist/css-module";
+import { Paragraph } from "@components/paragraph/paragraph";
 import terms from "./terms.json";
 import { TermsList } from "@site/src/components/TermsList";
 
@@ -23,7 +23,7 @@ import { TermsList } from "@site/src/components/TermsList";
 
 # NL Design System Woordenlijst
 
-<Paragraph lead>
+<Paragraph purpose="lead">
   NL Design System streeft naar een vriendelijke gebruikerservaring. Hier en daar kunnen er toch lastige woorden en
   termen tussen zitten. De woordenlijst legt deze woorden uit en verwijst door naar bronnen waar dat handig is.
 </Paragraph>

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,7 @@
 // Note: type annotations allow type checking and IDEs autocompletion
 
 import type { Config } from '@docusaurus/types';
+import path from 'node:path';
 import footer from './footerConfig';
 import navbar from './navConfig';
 import nldsPrismTheme from './nldsPrism';
@@ -11,6 +12,19 @@ import remarkCustomHeaderId from 'remark-custom-header-id';
 const siteUrl = 'https://nldesignsystem.nl';
 
 const config: Config = {
+  plugins: [
+    () => ({
+      name: 'alias-components',
+      configureWebpack: () => ({
+        resolve: {
+          alias: {
+            // These are the component in the Astro website.
+            '@components': path.resolve(__dirname, 'packages/website/src/components'),
+          },
+        },
+      }),
+    }),
+  ],
   title: 'NL Design System',
   titleDelimiter: '·',
   tagline: 'Eén design system voor alle huisstijlen',

--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -12,6 +12,7 @@ import { removeH1FromMarkdown } from './markdown-plugins/remark-remove-h1';
 import { remarkUnwrapDiv } from './markdown-plugins/remark-unwrap-div';
 import { remarkCanvasFix } from './markdown-plugins/remark-canvas-fix';
 import { remarkUndoInlineDirectives } from './markdown-plugins/remark-undo-inline-directives';
+import { remarkUnwrapParagraph } from './markdown-plugins/remark-unwrap-paragraph';
 import { clientLoadPlugin } from './markdown-plugins/remark-client-load';
 const siteUrl = 'https://nldesignsystem.nl';
 
@@ -118,6 +119,7 @@ export default defineConfig({
       remarkDirective,
       remarkUndoInlineDirectives,
       remarkAdmonitions,
+      remarkUnwrapParagraph,
       removeH1FromMarkdown(),
     ],
     rehypePlugins: [
@@ -136,6 +138,7 @@ export default defineConfig({
         remarkDirective,
         remarkUndoInlineDirectives,
         remarkAdmonitions,
+        remarkUnwrapParagraph,
         clientLoadPlugin(['Videoplayer', 'VideoPlayer', 'Checklist', 'DesignTokens']),
         removeH1FromMarkdown(),
       ],

--- a/packages/website/markdown-plugins/remark-unwrap-paragraph/index.ts
+++ b/packages/website/markdown-plugins/remark-unwrap-paragraph/index.ts
@@ -1,0 +1,33 @@
+import { visit, SKIP } from 'unist-util-visit';
+
+/**
+ * Remark plugin that unwraps `paragraph` nodes inside a `<Paragraph>` JSX element.
+ * MDX processes text content inside JSX elements as markdown, wrapping it in `paragraph`
+ * nodes. When the `Paragraph` component renders its own `<p>` element, this results in
+ * nested `<p>` tags (invalid HTML). This plugin flattens those `paragraph` children so
+ * the text flows directly into the component's `<p>`.
+ */
+export function remarkUnwrapParagraph() {
+  const tagName = 'Paragraph';
+
+  function matchesParent(parent) {
+    return (parent.type === 'mdxJsxFlowElement' || parent.type === 'mdxJsxTextElement') && parent.name === tagName;
+  }
+
+  return (tree) => {
+    visit(tree, (node, index, parent) => {
+      if (!parent || index === null) {
+        return undefined;
+      }
+
+      const isMatch = node.type === 'paragraph' && matchesParent(parent);
+
+      if (!isMatch) {
+        return undefined;
+      }
+
+      parent.children.splice(index, 1, ...(node.children ?? []));
+      return [SKIP, index];
+    });
+  };
+}

--- a/packages/website/markdown-plugins/remark-unwrap-paragraph/index.ts
+++ b/packages/website/markdown-plugins/remark-unwrap-paragraph/index.ts
@@ -8,10 +8,12 @@ import { visit, SKIP } from 'unist-util-visit';
  * the text flows directly into the component's `<p>`.
  */
 export function remarkUnwrapParagraph() {
-  const tagName = 'Paragraph';
+  const tagNames = ['Paragraph', 'Link'];
 
   function matchesParent(parent) {
-    return (parent.type === 'mdxJsxFlowElement' || parent.type === 'mdxJsxTextElement') && parent.name === tagName;
+    return (
+      (parent.type === 'mdxJsxFlowElement' || parent.type === 'mdxJsxTextElement') && tagNames.includes(parent.name)
+    );
   }
 
   return (tree) => {

--- a/packages/website/src/components/spotlight-section/spotlight-section.tsx
+++ b/packages/website/src/components/spotlight-section/spotlight-section.tsx
@@ -1,0 +1,2 @@
+export { SpotlightSection } from '@utrecht/component-library-react';
+import '@utrecht/spotlight-section-css/dist/index.css';

--- a/test/docs/paragraph-unwrap.mdx
+++ b/test/docs/paragraph-unwrap.mdx
@@ -1,0 +1,20 @@
+---
+title: Paragraph unwrap
+description: Test that markdown inside a Paragraph component is unwrapped to avoid nested p tags
+unlisted: true
+---
+
+import { Paragraph } from "@nl-design-system-candidate/paragraph-react";
+import TestPageNote from "./_test-page-note.md";
+
+{/* @license CC0-1.0 */}
+
+Tests whether a paragraph inside a Paragraph component is unwrapped to avoid nested p tags
+
+<TestPageNote />
+
+<Paragraph purpose="lead">
+
+This text should not be wrapped in a nested paragraph.
+
+</Paragraph>

--- a/test/docs/paragraph-unwrap.spec.ts
+++ b/test/docs/paragraph-unwrap.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+const websiteURL = 'http://localhost:4321/private/content-test/paragraph-unwrap';
+
+test('renders Paragraph children without nested p tags', async ({ page }) => {
+  await page.goto(websiteURL);
+
+  const leadParagraph = page.locator('p.nl-paragraph--lead');
+  await expect(leadParagraph).toHaveCount(1);
+  await expect(leadParagraph.locator('p')).toHaveCount(0);
+  await expect(leadParagraph).toContainText('This text should not be wrapped in a nested paragraph');
+});


### PR DESCRIPTION
Deze PR vervangt imports van `@utrecht/component-library-react` in .mdx-bestanden door components via de `@components` alias. Dit zorgt er voor dat de Docusaurus en Astro versies van de website zo veel mogelijk de zelfde componenten gebruiken.

Voor sommige componenten is alleen de referentie aangepast, van `@utrecht/component-library-react` naar `@components`. De onderliggende component is dus het zelfde gebleven. Dit geld voor: `LinkList`, `LinkListLink`, `SpotlightSection` en `ButtonGroup/ActionGroup`.

Andere componenten zijn daadwerkelijk vervangen met andere props. Dit geld voor `Paragraph` (`lead` -> `purpose="lead"`) en `Card` (`body` → `description`). `Link` en `Heading` zijn ook andere componenten maar hadden geen prop wijzigingen.

De `ButtonLink` gaat via de `@site` alias (ook in Astro). De icons die daarin gebruikt worden hebben een `slot` gekregen zodat ze op de juiste plek in de button gerendered worden

## unwrappen van een `<p>` in `<Paragraph>`
Als je kijkt naar deze markdown:

```md
<Paragraph>
  dit is een paragraaf
</Paragraph>
```

De content `dit is een paragraaf` wordt in een `<p>` element gerendered voor dat het aan de `<Paragraph>` gegeven wordt als children. Omdat `<Paragraph>` zelf ook een `<p>` rendered, wordt de markup invalid. Er is een remark plugin toegevoegd die dit tegengaat

closes: #4581 