### PR TITLE
docs: add design systems week 2026 - 3 sessions and 4 speakers

### DIFF
--- a/docs/community/events/design-systems-week/_2026/sessions.json
+++ b/docs/community/events/design-systems-week/_2026/sessions.json
@@ -3,7 +3,7 @@
     "uuid": "1bfd50e8-d845-492b-9553-51cae7dafd5b",
     "isoDateTime": "2026-10-26T12:00:00.000Z",
     "speakers": [
-      "StephDriver"
+      "DrStephDriver"
     ],
     "subject": "Tracking conformance data within the code-base",
     "language": {

--- a/docs/community/events/design-systems-week/_2026/sessions.json
+++ b/docs/community/events/design-systems-week/_2026/sessions.json
@@ -10,7 +10,8 @@
       "abbr": "EN",
       "description": "English"
     },
-    "videoId": null
+    "videoId": null,
+    "icalLink": null
   },
   {
     "uuid": "b919f274-381c-41db-9d1d-cc3b6934ce93",
@@ -24,7 +25,8 @@
       "abbr": "NL",
       "description": "Nederlands"
     },
-    "videoId": null
+    "videoId": null,
+    "icalLink": null
   },
   {
     "uuid": "a23217db-b17d-4e97-ad46-1fd7d113c567",
@@ -37,6 +39,7 @@
       "abbr": "EN",
       "description": "English"
     },
-    "videoId": null
+    "videoId": null,
+    "icalLink": null
   }
 ]

--- a/docs/community/events/design-systems-week/_2026/sessions.json
+++ b/docs/community/events/design-systems-week/_2026/sessions.json
@@ -2,9 +2,7 @@
   {
     "uuid": "1bfd50e8-d845-492b-9553-51cae7dafd5b",
     "isoDateTime": "2026-10-26T12:00:00.000Z",
-    "speakers": [
-      "DrStephDriver"
-    ],
+    "speakers": ["DrStephDriver"],
     "subject": "Tracking conformance data within the code-base",
     "language": {
       "abbr": "EN",
@@ -16,10 +14,7 @@
   {
     "uuid": "b919f274-381c-41db-9d1d-cc3b6934ce93",
     "isoDateTime": "2026-10-26T14:00:00.000Z",
-    "speakers": [
-      "EricVanMullekom",
-      "MiekeTenDam"
-    ],
+    "speakers": ["EricVanMullekom", "MiekeTenDam"],
     "subject": "Digitale toegankelijkheid van kaartviewers",
     "language": {
       "abbr": "NL",
@@ -31,9 +26,7 @@
   {
     "uuid": "a23217db-b17d-4e97-ad46-1fd7d113c567",
     "isoDateTime": "2026-10-27T14:00:00.000Z",
-    "speakers": [
-      "MarionCouesnon"
-    ],
+    "speakers": ["MarionCouesnon"],
     "subject": "Switching design systems without compromising accessibility",
     "language": {
       "abbr": "EN",

--- a/docs/community/events/design-systems-week/_2026/sessions.json
+++ b/docs/community/events/design-systems-week/_2026/sessions.json
@@ -1,1 +1,42 @@
-[]
+[
+  {
+    "uuid": "1bfd50e8-d845-492b-9553-51cae7dafd5b",
+    "isoDateTime": "2026-10-26T12:00:00.000Z",
+    "speakers": [
+      "StephDriver"
+    ],
+    "subject": "Tracking conformance data within the code-base",
+    "language": {
+      "abbr": "EN",
+      "description": "English"
+    },
+    "videoId": null
+  },
+  {
+    "uuid": "b919f274-381c-41db-9d1d-cc3b6934ce93",
+    "isoDateTime": "2026-10-26T14:00:00.000Z",
+    "speakers": [
+      "EricVanMullekom",
+      "MiekeTenDam"
+    ],
+    "subject": "Digitale toegankelijkheid van kaartviewers",
+    "language": {
+      "abbr": "NL",
+      "description": "Nederlands"
+    },
+    "videoId": null
+  },
+  {
+    "uuid": "a23217db-b17d-4e97-ad46-1fd7d113c567",
+    "isoDateTime": "2026-10-27T14:00:00.000Z",
+    "speakers": [
+      "MarionCouesnon"
+    ],
+    "subject": "Switching design systems without compromising accessibility",
+    "language": {
+      "abbr": "EN",
+      "description": "English"
+    },
+    "videoId": null
+  }
+]

--- a/docs/community/events/design-systems-week/_2026/speakers.json
+++ b/docs/community/events/design-systems-week/_2026/speakers.json
@@ -1,1 +1,52 @@
-{}
+{
+  "StephDriver": {
+    "name": "Dr Steph Driver - Publishing Technologies Developer",
+    "organisation": "Open Library of Humanities",
+    "image": {
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-StephDriver.png",
+      "alt": "Steph Driver"
+    },
+    "description": {
+      "en": "Steph is the accessibility-specialist developer at the Open Library of Humanities.  As an assistive technology user herself, she is passionate about making open access truly accessible for everyone. She combines deep technical expertise with a passion for education, helping teams develop smarter workflows and innovative accessibility solutions. With a background spanning natural sciences, creative writing, technology and disability-activism, Steph brings a unique perspective to inclusive digital design.",
+      "nl": "Steph is ontwikkelaar en specialist op het gebied van toegankelijkheid bij de Open Library of Humanities. Als gebruiker van ondersteunende technologie zet zij zich vol passie in om open access voor iedereen werkelijk toegankelijk te maken. Ze combineert diepgaande technische expertise met een passie voor onderwijs en helpt teams bij het ontwikkelen van slimmere werkprocessen en innovatieve oplossingen voor toegankelijkheid. Met een achtergrond in de natuurwetenschappen, creatief schrijven, technologie en activisme rondom handicaps brengt Steph een uniek perspectief in op inclusief digitaal ontwerp."
+    },
+    "language": "en"
+  },
+  "MarionCouesnon": {
+    "name": "Marion Couesnon - Accessibility designer (CPWA)",
+    "organisation": "Digitalservice GmbH des Bundes",
+    "image": {
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MarionCouesnon.png",
+      "alt": "Marion Couesnon"
+    },
+    "description": {
+      "en": "Marion is an accessibility designer based in Berlin. She has been passionate about design since 2011 and has specialised in accessibility since 2019. She currently works for DigitalService, a company owned by the German federal government. Within the organisation, she implements accessibility practices whilst contributing to the design of services, including the <a target=\"blank\" href=\"https://service.justiz.de\">Ministry of Justice’s online portal</a>. Outside of work, you might spot Marion at her boxing club or knitting on her sofa.",
+      "nl": "Marion is een ontwerper gespecialiseerd in toegankelijkheid, gevestigd in Berlijn. Ze is sinds 2011 gepassioneerd door design en heeft zich sinds 2019 toegelegd op toegankelijkheid. Momenteel werkt ze bij DigitalService, een bedrijf dat eigendom is van de Duitse federale overheid. Binnen de organisatie implementeert ze toegankelijkheidsmaatregelen en draagt ze bij aan het ontwerp van diensten, waaronder het <a target=\"blank\" href=\"https://service.justiz.de\">online portaal van het ministerie van Justitie</a>. Buiten haar werk kun je Marion tegenkomen bij haar boksclub of breiend op de bank."
+    },
+    "language": "en"
+  },
+  "EricVanMullekom": {
+    "name": "Eric van Mullekom - Product Owner Generic Geo Services",
+    "organisation": "Kadaster",
+    "image": {
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-EricVanMullekom.png",
+      "alt": "Eric van Mullekom"
+    },
+    "description": {
+      "nl": "Erik is sinds 2000 als projectmanager/product owner betrokken bij softwareontwikkeling, met oog voor techniek en gebruikersgemak. Bij het Kadaster is hij als Product Owner verantwoordelijk voor <a target=\"blank\" href=\"https://generiekegeocomponenten.nl\">generiekegeocomponenten.nl</a>, <a target=\"blank\" href=\"https://kaartenvannederland.nl\">kaartenvannederland.nl</a> en <a target=\"blank\" href=\"https://verbeterdekaart.nl\">terugmeldsysteem (o.a. verbeterdekaart.nl)</a>."
+    },
+    "language": "nl"
+  },
+  "MiekeTenDam": {
+    "name": "Mieke ten Dam - Software Engineer",
+    "organisation": "Kadaster",
+    "image": {
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MiekeTenDam.png",
+      "alt": "Mieke ten Dam"
+    },
+    "description": {
+      "nl": "Mieke werkt sinds 2019 bij het Kadaster als software engineer, met digitale toegankelijkheid als specialisme. Haar scrumteam ontwikkelt en beheert diverse websites, portals en applicaties, waaronder <a target=\"blank\" href=\"https://www.kadaster.nl\">www.kadaster.nl</a>, <a target=\"blank\" href=\"https://topokaarten.kadaster.nl\">topokaarten.kadaster.nl</a> en de zakelijke <a target=\"blank\" href=\"https://mijn.kadaster.nl\">mijn.kadaster.nl</a> omgeving."
+    },
+    "language": "nl"
+  }
+}

--- a/docs/community/events/design-systems-week/_2026/speakers.json
+++ b/docs/community/events/design-systems-week/_2026/speakers.json
@@ -3,7 +3,7 @@
     "name": "Dr Steph Driver - Publishing Technologies Developer",
     "organisation": "Open Library of Humanities",
     "image": {
-      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-StephDriver.png",
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-StephDriver.jpg",
       "alt": "Steph Driver"
     },
     "description": {
@@ -16,7 +16,7 @@
     "name": "Marion Couesnon - Accessibility designer (CPWA)",
     "organisation": "Digitalservice GmbH des Bundes",
     "image": {
-      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MarionCouesnon.png",
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MarionCouesnon.jpg",
       "alt": "Marion Couesnon"
     },
     "description": {
@@ -29,7 +29,7 @@
     "name": "Eric van Mullekom - Product Owner Generic Geo Services",
     "organisation": "Kadaster",
     "image": {
-      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-EricVanMullekom.png",
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-EricVanMullekom.jpg",
       "alt": "Eric van Mullekom"
     },
     "description": {
@@ -41,7 +41,7 @@
     "name": "Mieke ten Dam - Software Engineer",
     "organisation": "Kadaster",
     "image": {
-      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MiekeTenDam.png",
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MiekeTenDam.jpg",
       "alt": "Mieke ten Dam"
     },
     "description": {

--- a/docs/community/events/design-systems-week/_2026/speakers.json
+++ b/docs/community/events/design-systems-week/_2026/speakers.json
@@ -1,10 +1,10 @@
 {
-  "StephDriver": {
+  "DrStephDriver": {
     "name": "Dr Steph Driver - Publishing Technologies Developer",
     "organisation": "Open Library of Humanities",
     "image": {
-      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-StephDriver.jpg",
-      "alt": "Steph Driver"
+      "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-DrStephDriver.jpg",
+      "alt": "Dr Steph Driver"
     },
     "description": {
       "en": "Steph is the accessibility-specialist developer at the Open Library of Humanities.  As an assistive technology user herself, she is passionate about making open access truly accessible for everyone. She combines deep technical expertise with a passion for education, helping teams develop smarter workflows and innovative accessibility solutions. With a background spanning natural sciences, creative writing, technology and disability-activism, Steph brings a unique perspective to inclusive digital design.",

--- a/docs/community/events/design-systems-week/_2026/speakers.json
+++ b/docs/community/events/design-systems-week/_2026/speakers.json
@@ -1,6 +1,6 @@
 {
   "DrStephDriver": {
-    "name": "Dr Steph Driver - Publishing Technologies Developer",
+    "name": "Dr Steph Driver",
     "organisation": "Open Library of Humanities",
     "image": {
       "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-DrStephDriver.jpg",
@@ -13,7 +13,7 @@
     "language": "en"
   },
   "MarionCouesnon": {
-    "name": "Marion Couesnon - Accessibility designer (CPWA)",
+    "name": "Marion Couesnon",
     "organisation": "Digitalservice GmbH des Bundes",
     "image": {
       "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MarionCouesnon.jpg",
@@ -26,7 +26,7 @@
     "language": "en"
   },
   "EricVanMullekom": {
-    "name": "Eric van Mullekom - Product Owner Generic Geo Services",
+    "name": "Eric van Mullekom",
     "organisation": "Kadaster",
     "image": {
       "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-EricVanMullekom.jpg",
@@ -38,7 +38,7 @@
     "language": "nl"
   },
   "MiekeTenDam": {
-    "name": "Mieke ten Dam - Software Engineer",
+    "name": "Mieke ten Dam",
     "organisation": "Kadaster",
     "image": {
       "src": "https://raw.githubusercontent.com/nl-design-system/documentatie/assets/design-systems-week-2026-MiekeTenDam.jpg",

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -46,6 +46,15 @@ import settings from "../settings.json";
   )}
 </ActionGroup>
 
+{!settings.sessionsAreFinal && (<>
+
+<Paragraph>
+  The timetable is not yet final. The sessions will be further developed and added in the coming weeks. Keep an eye on this
+  page for updates.
+</Paragraph>
+
+</>)}
+
 {/* Vul in per sessie */}
 
 <DSWSession

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -49,8 +49,8 @@ import settings from "../settings.json";
 {!settings.sessionsAreFinal && (<>
 
 <Paragraph>
-  The timetable is not yet final. The sessions will be further developed and added in the coming weeks. Keep an eye on this
-  page for updates.
+  The timetable is not yet final. The sessions will be further developed and added in the coming weeks. Keep an eye on
+  this page for updates.
 </Paragraph>
 
 </>)}

--- a/docs/community/events/design-systems-week/en/program.mdx
+++ b/docs/community/events/design-systems-week/en/program.mdx
@@ -47,24 +47,58 @@ import settings from "../settings.json";
 </ActionGroup>
 
 {/* Vul in per sessie */}
-{/* prettier-ignore */}
-{/*
 
 <DSWSession
   allSpeakers={speakers}
   allSessions={sessions}
-  sessionId="74d8600f-b404-4e3d-a41e-9f652d8f9455"
+  sessionId="1bfd50e8-d845-492b-9553-51cae7dafd5b"
   headingLevel={2}
   lang="en"
 >
-
   <Paragraph>
-    How can cities make their design systems more transparent, consistent, and easy to use for developers? The City of Vienna found an answer in the Custom Elements Manifest (CEM) — a file format that describes custom elements and makes web components easier to document and use in code editors.
+    Accessibility conformance is often documented in separate reports that quickly become outdated. But what if
+    accessibility data lived alongside your code instead?
   </Paragraph>
   <Paragraph>
-    In this session, Manuel Matuzović shows how Vienna applies CEM to document and maintain its pattern library. He demonstrates how this approach improves usability, accessibility, and collaboration across teams.
+    In this session, you’ll discover how the open-source publishing platform Janeway rethought its accessibility process
+    by integrating conformance data directly into its code-base. Every accessibility finding is linked to the commit it
+    was audited against cross referenced with the work needed to improve it. This underpins a continuous workflow of
+    targeted accessibility audits and improvements instead of relying on audits every few years.
+  </Paragraph>
+  <Paragraph>
+    Steph shares the motivation behind this approach, how it was implemented, and the lessons learned along the way.
+    Whether you’re a developer, accessibility specialist, or simply curious about improving accessibility workflows,
+    this session offers practical insights into a more sustainable way of managing conformance data.
+  </Paragraph>
+  <Paragraph>
+    The implementation is open source, making it easy to dive into the technical details after the session.
   </Paragraph>
 </DSWSession>
-*/}
+
+<DSWSession
+  allSpeakers={speakers}
+  allSessions={sessions}
+  sessionId="a23217db-b17d-4e97-ad46-1fd7d113c567"
+  headingLevel={2}
+  lang="en"
+>
+  <Paragraph>
+    What happens when you replace your own design system with a new, shared standard? How do you make sure accessibility
+    doesn't take a step backwards?
+  </Paragraph>
+  <Paragraph>
+    In this session, Marion Couesnon from the Access to Justice team shares their experience of migrating from their
+    in-house design system to the KERN Design System, which they see as the future standard for German public services.
+  </Paragraph>
+  <Paragraph>
+    You'll learn how the team approached the migration from an accessibility perspective, the checks and decisions they
+    made along the way, and the unexpected challenges they still encountered. Because even when a design system is built
+    with accessibility in mind, adopting it doesn't automatically guarantee an accessible result.
+  </Paragraph>
+  <Paragraph>
+    A practical session packed with lessons learned, pitfalls to avoid, and tips for teams planning a similar
+    transition.
+  </Paragraph>
+</DSWSession>
 
 </div>

--- a/docs/community/events/design-systems-week/en/timetable.mdx
+++ b/docs/community/events/design-systems-week/en/timetable.mdx
@@ -62,9 +62,6 @@ import settings from "../settings.json";
 
 {/* Vul in per dag */}
 
-{/* prettier-ignore */}
-{/*
-
 ## Monday, October 26
 
 <SessionTable
@@ -92,8 +89,6 @@ import settings from "../settings.json";
   speakers={speakers}
   sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith(`${settings.year}-10-29`))}
 />
-
-\*/}
 
 {!!settings.isHappening && (<>
 

--- a/docs/community/events/design-systems-week/en/timetable.mdx
+++ b/docs/community/events/design-systems-week/en/timetable.mdx
@@ -60,6 +60,15 @@ import settings from "../settings.json";
 
 </>)}
 
+{!settings.sessionsAreFinal && (<>
+
+<Paragraph>
+  The timetable is not yet final. The sessions will be further developed and added in the coming weeks. Keep an eye on
+  this page for updates.
+</Paragraph>
+
+</>)}
+
 {/* Vul in per dag */}
 
 ## Monday, October 26

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -43,6 +43,15 @@ import settings from "./settings.json";
   )}
 </ActionGroup>
 
+{!settings.sessionsAreFinal && (<>
+
+<Paragraph>
+  Het tijdschema is nog niet definitief. De sessies worden de komende weken verder uitgewerkt en toegevoegd. Houd deze
+  pagina in de gaten voor updates.
+</Paragraph>
+
+</>)}
+
 {/* Vul in per sessie */}
 
 <DSWSession

--- a/docs/community/events/design-systems-week/programma.mdx
+++ b/docs/community/events/design-systems-week/programma.mdx
@@ -44,21 +44,82 @@ import settings from "./settings.json";
 </ActionGroup>
 
 {/* Vul in per sessie */}
-{/* prettier-ignore */}
-{/*
 
 <DSWSession
   allSpeakers={speakers}
   allSessions={sessions}
-  sessionId="74d8600f-b404-4e3d-a41e-9f652d8f9455"
+  sessionId="1bfd50e8-d845-492b-9553-51cae7dafd5b"
   headingLevel={2}
 >
-
   <Paragraph>
-    Hoe kunnen steden hun design systems transparanter, consistenter en gebruiksvriendelijker maken voor developers? De stad Wenen vond een antwoord in het Custom Elements Manifest (CEM) — een bestandsformaat dat custom elements beschrijft en web components makkelijker documenteerbaar en bruikbaar maakt in code editors.
+    Informatie over toegankelijkheidsconformiteit wordt vaak vastgelegd in aparte rapporten die snel verouderen. Maar
+    wat als toegankelijkheidsgegevens direct naast je code zouden staan?
   </Paragraph>
   <Paragraph>
-    In deze sessie laat Manuel Matuzović zien hoe Wenen CEM toepast om hun pattern library te documenteren en te onderhouden. Hij demonstreert hoe deze aanpak de bruikbaarheid, toegankelijkheid en samenwerking tussen teams verbetert.  
+    In deze sessie ontdek je hoe het open-source publicatieplatform Janeway zijn toegankelijkheidsproces opnieuw heeft
+    ingericht door gegevens over conformiteit rechtstreeks in de codebase te integreren. Elke bevinding op het gebied
+    van toegankelijkheid is gekoppeld aan de specifieke commit waarop de audit betrekking had, en wordt in verband
+    gebracht met de werkzaamheden die nodig zijn voor verbetering. Dit vormt de basis voor een continu proces van
+    gerichte toegankelijkheidsaudits en verbeteringen, in plaats van te vertrouwen op audits die slechts eens in de paar
+    jaar plaatsvinden.
+  </Paragraph>
+  <Paragraph>
+    Steph vertelt over de beweegredenen achter deze aanpak, de implementatie ervan en de lessen die gaandeweg zijn
+    geleerd. Of je nu ontwikkelaar of toegankelijkheidsspecialist bent, of simpelweg geïnteresseerd bent in het
+    verbeteren van workflows rondom toegankelijkheid: deze sessie biedt praktische inzichten in een duurzamere manier om
+    conformiteitsgegevens te beheren.
+  </Paragraph>
+  <Paragraph>
+    De implementatie is open source, waardoor je na de sessie eenvoudig in de technische details kunt duiken.
   </Paragraph>
 </DSWSession>
-*/}
+
+<DSWSession
+  allSpeakers={speakers}
+  allSessions={sessions}
+  sessionId="b919f274-381c-41db-9d1d-cc3b6934ce93"
+  headingLevel={2}
+>
+  <Paragraph>
+    Hoe maak je interactieve kaarten toegankelijk voor iedereen? Dat is een vraag waar het Kadaster dagelijks aan werkt.
+  </Paragraph>
+  <Paragraph>
+    Op de websites van het Kadaster wordt veel ruimtelijke informatie via kaartviewers aangeboden. Juist deze
+    interactieve toepassingen brengen unieke uitdagingen met zich mee op het gebied van digitale toegankelijkheid.
+  </Paragraph>
+  <Paragraph>
+    In deze sessie delen Eric en Mieke hoe het Kadaster deze vraagstukken multidisciplinair aanpakt. Aan de hand van
+    praktijkvoorbeelden laten zij zien welke uitdagingen zij tegenkwamen, welke oplossingen zij hebben ontwikkeld en
+    welke lessen zij onderweg hebben geleerd.
+  </Paragraph>
+  <Paragraph>
+    Een inspirerende sessie voor iedereen die werkt aan toegankelijke digitale dienstverlening, interactieve interfaces
+    of complexe gebruikerservaringen.
+  </Paragraph>
+</DSWSession>
+
+<DSWSession
+  allSpeakers={speakers}
+  allSessions={sessions}
+  sessionId="a23217db-b17d-4e97-ad46-1fd7d113c567"
+  headingLevel={2}
+>
+  <Paragraph>
+    Wat gebeurt er als je je eigen design-systeem vervangt door een nieuwe, gedeelde standaard? Hoe zorg je ervoor dat
+    de toegankelijkheid er niet op achteruitgaat?
+  </Paragraph>
+  <Paragraph>
+    In deze sessie deelt Marion Couesnon van het 'Access to Justice'-team haar ervaringen met de migratie van hun eigen
+    design-systeem naar het KERN Design System, dat zij zien als de toekomstige standaard voor Duitse overheidsdiensten.
+  </Paragraph>
+  <Paragraph>
+    Je leert hoe het team de migratie vanuit het oogpunt van toegankelijkheid aanpakte, welke controles en beslissingen
+    ze onderweg namen en welke onverwachte uitdagingen ze toch nog tegenkwamen. Want zelfs als een design-systeem met
+    toegankelijkheid in gedachten is ontwikkeld, biedt de implementatie ervan niet automatisch garantie op een
+    toegankelijk resultaat.
+  </Paragraph>
+  <Paragraph>
+    Een praktische sessie vol geleerde lessen, valkuilen om te vermijden en tips voor teams die een soortgelijke
+    overstap plannen.
+  </Paragraph>
+</DSWSession>

--- a/docs/community/events/design-systems-week/settings.json
+++ b/docs/community/events/design-systems-week/settings.json
@@ -2,6 +2,7 @@
   "year": "2026",
   "isUpComing": true,
   "isHappening": false,
+  "sessionsAreFinal": false,
   "miro": false,
   "nl": {
     "dateRange": "26 tot en met 29 oktober",

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -57,6 +57,15 @@ import settings from "./settings.json";
 
 </>)}
 
+{!settings.sessionsAreFinal && (<>
+
+<Paragraph>
+  Het tijdschema is nog niet definitief. De sessies worden de komende weken verder uitgewerkt en toegevoegd. Houd deze
+  pagina in de gaten voor updates.
+</Paragraph>
+
+</>)}
+
 {/* Vul in per dag */}
 
 ## Maandag 26 oktober

--- a/docs/community/events/design-systems-week/tijdschema.mdx
+++ b/docs/community/events/design-systems-week/tijdschema.mdx
@@ -59,9 +59,6 @@ import settings from "./settings.json";
 
 {/* Vul in per dag */}
 
-{/* prettier-ignore */}
-{/*
-
 ## Maandag 26 oktober
 
 <SessionTable
@@ -93,8 +90,6 @@ import settings from "./settings.json";
   speakers={speakers}
   sessions={sessions.filter(({ isoDateTime }) => isoDateTime.startsWith(`${settings.year}-10-29`))}
 />
-
-\*/}
 
 {!!settings.isHappening && (<>
 

--- a/src/components/DSWSession.tsx
+++ b/src/components/DSWSession.tsx
@@ -130,7 +130,10 @@ export const DSWSession = ({
         {speakers.map((speaker, index) => (
           <div key={index} className={clsx('ma-dsw-session__speaker', 'ma-dsw-speaker')}>
             <img className={clsx('ma-dsw-speaker__image')} src={speaker.image.src} alt={speaker.image.alt} />
-            <Paragraph className={clsx('ma-dsw-speaker__description')}>{speaker.description[lang]}</Paragraph>
+            <Paragraph
+              className={clsx('ma-dsw-speaker__description')}
+              dangerouslySetInnerHTML={{ __html: speaker.description[lang] as TrustedHTML }}
+            />
           </div>
         ))}
       </aside>

--- a/src/components/SessionTable.css
+++ b/src/components/SessionTable.css
@@ -13,6 +13,10 @@
   table-layout: auto;
 }
 
+.ma-session-table__header-cell {
+  word-break: initial;
+}
+
 .ma-session-table__speakers {
   display: flex;
   flex-direction: column;

--- a/src/components/SessionTable.tsx
+++ b/src/components/SessionTable.tsx
@@ -53,11 +53,21 @@ export const SessionTable = ({ lang, sessions, speakers: allSpeakers, className,
     <Table className={clsx('ma-session-table', className)} {...props}>
       <TableHeader>
         <TableRow className="ma-session-table__row">
-          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Tijd' : 'Time'}</TableHeaderCell>
-          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Taal' : 'Language'}</TableHeaderCell>
-          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Spreker' : 'Speaker'}</TableHeaderCell>
-          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Onderwerp' : 'Subject'}</TableHeaderCell>
-          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Agenda' : 'Calendar'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">
+            {lang === 'nl-NL' ? 'Tijd' : 'Time'}
+          </TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">
+            {lang === 'nl-NL' ? 'Taal' : 'Language'}
+          </TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">
+            {lang === 'nl-NL' ? 'Spreker' : 'Speaker'}
+          </TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">
+            {lang === 'nl-NL' ? 'Onderwerp' : 'Subject'}
+          </TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">
+            {lang === 'nl-NL' ? 'Agenda' : 'Calendar'}
+          </TableHeaderCell>
         </TableRow>
       </TableHeader>
       <TableBody>

--- a/src/components/SessionTable.tsx
+++ b/src/components/SessionTable.tsx
@@ -53,11 +53,11 @@ export const SessionTable = ({ lang, sessions, speakers: allSpeakers, className,
     <Table className={clsx('ma-session-table', className)} {...props}>
       <TableHeader>
         <TableRow className="ma-session-table__row">
-          <TableHeaderCell>{lang === 'nl-NL' ? 'Tijd' : 'Time'}</TableHeaderCell>
-          <TableHeaderCell>{lang === 'nl-NL' ? 'Taal' : 'Language'}</TableHeaderCell>
-          <TableHeaderCell>{lang === 'nl-NL' ? 'Spreker' : 'Speaker'}</TableHeaderCell>
-          <TableHeaderCell>{lang === 'nl-NL' ? 'Onderwerp' : 'Subject'}</TableHeaderCell>
-          <TableHeaderCell>{lang === 'nl-NL' ? 'Agenda' : 'Calendar'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Tijd' : 'Time'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Taal' : 'Language'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Spreker' : 'Speaker'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Onderwerp' : 'Subject'}</TableHeaderCell>
+          <TableHeaderCell className="ma-session-table__header-cell">{lang === 'nl-NL' ? 'Agenda' : 'Calendar'}</TableHeaderCell>
         </TableRow>
       </TableHeader>
       <TableBody>


### PR DESCRIPTION
Part of https://github.com/nl-design-system/documentatie/issues/3563

- Also changed that Speaker Bio is rendered as HTML, since it can now contain links. It uses dangerouslySetInnerHTML, however the source is always written by kernteam, so this is acceptable.
- Also added a "sessions are not final yet" text to program/timetable/programma/tijdschema, which is shown/hidden with settings.sessionsAreFinal.
- Also added that Session Table Heading Cells don't break words, so that long session titles don't break the headings for example for Taal.

Sources:
- Teksten en foto's: https://ictubeheer.sharepoint.com/teams/Project_NLDesignSystem/Besloten/Forms/AllItems.aspx?id=%2Fteams%2FProject%5FNLDesignSystem%2FBesloten%2F03%5FCommunicatie%2FEvents%2FDesign%20Systems%20Week%2F2026%2FTeksten%20en%20foto%27s%20sprekers&viewid=73416e8e%2Dede2%2D46b9%2D94ff%2D6a8b2776d590&d=w3445f2b00f5c4d18a3b4fd49fb31c7d0&csf=1&CID=10cfdfca%2Db3b7%2D430a%2D8122%2Db60e1f16b79c&FolderCTID=0x0120004BABA35BD11A0C4881DFD8CED370EC79
- Icals are not available yet.

Previews:
- [Preview programma](https://documentatie-git-docs-add-design-system-3867cd-nl-design-system.vercel.app/events/design-systems-week-2026/programma/)
- [Preview program](https://documentatie-git-docs-add-design-system-3867cd-nl-design-system.vercel.app/events/design-systems-week-2026/en/program/)
- [Preview tijdschema](https://documentatie-git-docs-add-design-system-3867cd-nl-design-system.vercel.app/events/design-systems-week-2026/tijdschema/)
- [Preview timetable](https://documentatie-git-docs-add-design-system-3867cd-nl-design-system.vercel.app/events/design-systems-week-2026/en/timetable/)