### PR TITLE
fix: uppercase admonition

### DIFF
--- a/packages/website/markdown-plugins/admonitions.ts
+++ b/packages/website/markdown-plugins/admonitions.ts
@@ -2,7 +2,7 @@ import { visit } from 'unist-util-visit';
 
 const TYPES = { tip: 'tip', info: 'info', note: 'note', caution: 'caution', danger: 'danger', warning: 'warning' };
 const MAP = {
-  [TYPES.tip]: 'ok',
+  [TYPES.tip]: 'success',
   [TYPES.info]: 'info',
   [TYPES.note]: 'info',
   [TYPES.danger]: 'error',
@@ -24,7 +24,7 @@ export function remarkAdmonitions() {
       data.hName = 'div';
       data.hProperties = {
         ...node.attributes,
-        className: ['utrecht-spotlight-section', `utrecht-spotlight-section--${MAP[node.name]}`],
+        className: ['utrecht-note', `utrecht-note--${MAP[node.name]}`],
       };
 
       if (node.children[0]?.data?.directiveLabel) {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -75,6 +75,8 @@
     "@utrecht/link-css": "3.0.1",
     "@utrecht/link-list-css": "4.0.0",
     "@utrecht/nav-list-css": "2.0.0",
+    "@utrecht/note-css": "1.0.0",
+    "@utrecht/note-react": "1.0.0",
     "@utrecht/ordered-list-css": "4.0.1",
     "@utrecht/page-body-css": "2.0.0",
     "@utrecht/page-body-react": "1.0.11",

--- a/packages/website/src/components/spotlight-section/spotlight-section.tsx
+++ b/packages/website/src/components/spotlight-section/spotlight-section.tsx
@@ -1,2 +1,6 @@
-export { SpotlightSection } from '@utrecht/component-library-react';
+import { Note } from '@utrecht/note-react';
+import { SpotlightSection as UtrechtSpotlightSection } from '@utrecht/component-library-react';
 import '@utrecht/spotlight-section-css/dist/index.css';
+import '@utrecht/note-css/dist/index.css';
+
+export const SpotlightSection = globalThis.isAstro ? Note : UtrechtSpotlightSection;

--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -42,6 +42,7 @@ import '@utrecht/ordered-list-css/dist/index.css';
 import '@utrecht/table-css/dist/index.css';
 import '@utrecht/textarea-css/dist/index.css';
 import '@utrecht/textbox-css/dist/index.css';
+import '@utrecht/note-css/dist/index.css';
 import '@utrecht/img-css/dist/index.css';
 import '@utrecht/spotlight-section-css/dist/index.css';
 import '@nl-design-system-candidate/paragraph-css/paragraph.css';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,12 @@ importers:
       '@utrecht/nav-list-css':
         specifier: 2.0.0
         version: 2.0.0
+      '@utrecht/note-css':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@utrecht/note-react':
+        specifier: 1.0.0
+        version: 1.0.0(@babel/runtime@7.28.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@utrecht/ordered-list-css':
         specifier: 4.0.1
         version: 4.0.1
@@ -5299,6 +5305,16 @@ packages:
 
   '@utrecht/navigation-css@1.1.0':
     resolution: {integrity: sha512-2dOXz7RyCNgkouRiIsPYZoa6zPI0PrQP905ym8g9gNvUDu5yJ3qUucRyAS04hF+vatfUp0eKIKghDvUNoKbmyw==}
+
+  '@utrecht/note-css@1.0.0':
+    resolution: {integrity: sha512-muRBccnBatzi8yb7+oIOkmcdzbuzL5wBzWU1jdTn5O+RHlx3k5wbhtAEJs7oo9CDmbM/B8fVSQlr8kkKIr9pGw==}
+
+  '@utrecht/note-react@1.0.0':
+    resolution: {integrity: sha512-ITpmQ2F4s6Ey+tkPokD8HIrfQURtkrkQumjDRafKMlzu4IOcYtq1vW6JMoC1MhPEHWqb6rIyX7rzvxll69EHTA==}
+    peerDependencies:
+      '@babel/runtime': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@utrecht/number-badge-css@3.0.1':
     resolution: {integrity: sha512-t1HwU+bRlerdFicFZa4w5xyZh00ihITUb2kxU11e9Vxb2D32VU1jBOMW8qtKpuiya5mPZJjGF0uc6ZyGPAdXTw==}
@@ -18329,6 +18345,16 @@ snapshots:
   '@utrecht/nav-list-css@2.0.0': {}
 
   '@utrecht/navigation-css@1.1.0': {}
+
+  '@utrecht/note-css@1.0.0': {}
+
+  '@utrecht/note-react@1.0.0(@babel/runtime@7.28.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@utrecht/note-css': 1.0.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@utrecht/number-badge-css@3.0.1': {}
 

--- a/test/docs/admonition-with-title.spec.ts
+++ b/test/docs/admonition-with-title.spec.ts
@@ -5,7 +5,7 @@ const websiteURL = 'http://localhost:4321/private/content-test/admonition-with-t
 test('renders admonition with title as spotlight section and strong label', async ({ page }) => {
   await page.goto(websiteURL);
 
-  const spotlight = page.locator('div.utrecht-spotlight-section--ok').filter({ hasText: /Good to know/i });
+  const spotlight = page.locator('div.utrecht-note--success').filter({ hasText: /Good to know/i });
   await expect(spotlight).toBeVisible();
 
   const title = spotlight.locator('strong').filter({ hasText: /Good to know/i });


### PR DESCRIPTION
Moest (voor Astro) ook upgraden van @utrecht/spotlight-section naar @utrecht/note. Voor Docusaurus gelaten, omdat ik niet wist wat de upgrade in ma-design-tokens nog meer met zich mee brengt als dat in Docusaurus ook geupgrade wordt

closes: #4478
