### PR TITLE
fix: archief link appearance

### DIFF
--- a/packages/website/src/styles/missing-tokens.css
+++ b/packages/website/src/styles/missing-tokens.css
@@ -174,6 +174,13 @@ html .utrecht-link--html-a:any-link:focus {
   color: var(--basis-focus-color);
 }
 
+/* The proper fix would be to change the Den Haag component to not render a <a> element when there is no href in the data */
+.denhaag-side-navigation__link:not([href]) {
+  color: unset !important;
+  cursor: default !important;
+  text-decoration: none !important;
+}
+
 .denhaag-side-navigation__expand-button:hover {
   /* denhaag.side-navigation.expand-button.hover.color */
   --denhaag-icon-button-hover-color: var(--basis-color-action-2-color-hover);


### PR DESCRIPTION
Fix is gedaan in missing-tokens. Zodra we een PR voor de Den Haag Side Navigation component gaan maken nemen we dit mee. Een comment legt uit wat dan de juiste oplossing is

Het issue gaat om de `Archief` item in het submenu van `Handboek`

closes: #4601
