### PR TITLE
fix: icon alignment

### DIFF
--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -32,6 +32,7 @@ import '@utrecht/card-css/dist/index.css';
 import '@utrecht/custom-checkbox-css/dist/index.css';
 import '@utrecht/checkbox-css/dist/index.css';
 import '@utrecht/emphasis-css/dist/index.css';
+import '@utrecht/icon-css/dist/index.css';
 import '@utrecht/figure-css/dist/index.css';
 import '@utrecht/form-label-css/dist/index.css';
 import '@utrecht/form-field-css/dist/index.css';

--- a/packages/website/src/styles/missing-tokens.css
+++ b/packages/website/src/styles/missing-tokens.css
@@ -35,7 +35,7 @@
  */
 .nl-data-badge {
   --nl-data-badge-padding-inline: var(--basis-space-inline-sm);
-  --nl-data-badge-padding-block: var(--basis-space-none);
+  --nl-data-badge-padding-block: var(--basis-space-block-sm);
   --nl-data-badge-min-inline-size: var(--basis-size-sm);
   --nl-data-badge-min-block-size: var(--basis-size-xs);
   --nl-data-badge-line-height: var(--basis-text-line-height-md);
@@ -47,6 +47,10 @@
   --nl-data-badge-border-radius: var(--basis-border-radius-sm);
   --nl-data-badge-border-color: var(--basis-color-transparent);
   --nl-data-badge-background-color: var(--basis-color-default-bg-default);
+
+  align-items: center;
+  display: inline-flex !important;
+  gap: var(--basis-space-text-sm);
 }
 
 /**

--- a/packages/website/src/styles/missing-tokens.css
+++ b/packages/website/src/styles/missing-tokens.css
@@ -123,7 +123,7 @@
 }
 
 /* The alignment of icons is off without the option to fix is via tokens */
-.utrecht-link-list__item .utrecht-link-list__link {
+.utrecht-page-footer .utrecht-link-list__item .utrecht-link-list__link {
   align-items: unset;
 }
 


### PR DESCRIPTION
closes: #4587

[Preview](https://documentatie-next-git-fix-icon-alignment-nl-design-system.vercel.app/handboek/huisstijl/basis-tokens/alle-basis-tokens/)