### PR TITLE
fix: styling community implementation card

### DIFF
--- a/packages/website/src/styles/missing-tokens.css
+++ b/packages/website/src/styles/missing-tokens.css
@@ -123,7 +123,7 @@
 }
 
 /* The alignment of icons is off without the option to fix is via tokens */
-.utrecht-page-footer .utrecht-link-list__item .utrecht-link-list__link {
+.utrecht-link-list__item .utrecht-link-list__link {
   align-items: unset;
 }
 

--- a/src/components/ComponentPage.css
+++ b/src/components/ComponentPage.css
@@ -56,6 +56,8 @@
   --utrecht-link-list-link-column-gap: 0.25em;
   --utrecht-link-list-icon-inset-block-start: 0.25em;
   --nl-heading-level-4-margin-block-start: 1.25rem;
+  --utrecht-heading-4-margin-block-start: 1.25rem;
+  --utrecht-heading-5-margin-block-start: 1.25rem;
 }
 
 .ma-implementation-card .nl-heading--level-4:first-of-type {

--- a/src/components/ComponentPage.tsx
+++ b/src/components/ComponentPage.tsx
@@ -1,7 +1,10 @@
 import { Heading, Link, LinkList, Paragraph, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import { Heading as NLHeading } from '@components/heading/heading';
+import { Paragraph as NLParagraph } from '@components/paragraph/paragraph';
 import clsx from 'clsx';
 import { BrandIcon } from './BrandIcon';
 import { Card, CardContent, CardGroup } from './CardGroup';
+import { Card as RhcCard } from '@components/card/card';
 import { ComponentProgress } from './ComponentProgress';
 import { EstafetteBadge } from './EstafetteBadge';
 import { InlineHeadingGroup } from './InlineHeadingGroup';
@@ -89,7 +92,61 @@ export const Implementations = ({ component, headingLevel }: ComponentPageSectio
             ({ name, value }) => urlMap.has(name) && URL.canParse(value) && new URL(value).protocol === 'https:',
           );
 
-          return (
+          return globalThis.isAstro ? (
+            <RhcCard
+              key={project.title}
+              heading={project.title.replace(/^Community/i, '')}
+              headingLevel={headingLevel as 1 | 2 | 3 | 4 | 5 | 6}
+              description={
+                <div className="ma-flow">
+                  <NLParagraph>
+                    <ComponentProgress
+                      checked={project.progress.value}
+                      unchecked={project.progress.max - project.progress.value}
+                    />
+                    {project.progress.value} van {project.progress.max} stappen gedocumenteerd op het{' '}
+                    <Link href={project.url}>{project.title} projectbord</Link>
+                  </NLParagraph>
+                  <div>
+                    {(links.length > 0 || frameworks.length > 0) && (
+                      <NLHeading level={Math.min(headingLevel + 1, 6) as 1 | 2 | 3 | 4 | 5 | 6}>
+                        Snel aan de slag
+                      </NLHeading>
+                    )}
+                    {links.length > 0 && (
+                      <LinkList
+                        links={links
+                          .filter((item) => !!urlMap.get(item.name))
+                          .map((item) => {
+                            const url = urlMap.get(item.name);
+                            return {
+                              children: url.desciption,
+                              icon: <BrandIcon brand={url.brand} />,
+                              href: item.value,
+                            };
+                          })}
+                      />
+                    )}
+                  </div>
+                  {frameworks.length > 0 &&
+                    frameworks.map(({ frameworkName, tasks }) => (
+                      <section key={frameworkName}>
+                        <NLHeading level={Math.min(headingLevel + 2, 6) as 1 | 2 | 3 | 4 | 5 | 6}>
+                          {alias} in {frameworkName}
+                        </NLHeading>
+                        <LinkList
+                          links={tasks.map((frameworkTask) => ({
+                            children: frameworkTask.description,
+                            icon: <BrandIcon brand={frameworkTask.brand} />,
+                            href: frameworkTask.value,
+                          }))}
+                        />
+                      </section>
+                    ))}
+                </div>
+              }
+            />
+          ) : (
             <Card key={project.title} className="ma-implementation-card">
               <CardContent>
                 <Heading level={headingLevel}>{project.title.replace(/^Community/i, '')}</Heading>


### PR DESCRIPTION
Ik heb toch maar een inline versie voor Astro van de Card gemaakt omdat het erg lastig was om alle data te dupliceren en naar een Astro component te krijgen. Als we over zijn naar Astro moet de file ComponentPage even goed opgeschoond worden, want zo veel componenten in één file is erg onhandig.

closes: #4473

perview: https://documentatie-next-git-fix-styling-commu-ebac6a-nl-design-system.vercel.app/accordion/
