### PR TITLE
feat: add dark color scheme

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -157,6 +157,9 @@ jobs:
       - name: "Continuous Integration: a11y:next"
         run: pnpm run test-a11y:next
 
+      - name: "Continuous Integration: a11y:next-dark"
+        run: pnpm run test-a11y:next-dark
+
       - name: "Continuous Integration: a11y"
         if: ${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci/a11y')) }}
         run: pnpm run --if-present test-a11y
@@ -169,6 +172,7 @@ jobs:
           path: |
             tmp/axe.json
             tmp/axe.next.json
+            tmp/axe.next.dark.json
 
       - name: "Continuous Integration: make screenshots"
         if: ${{ github.ref_name == 'main' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'visual regression test')) }}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "install-test-browsers": "playwright install",
     "test-a11y": "playwright test test/a11y/axe.test.ts --workers=8",
     "test-a11y:next": "playwright test test/a11y/axe.next.test.ts --workers=8",
+    "test-a11y:next-dark": "playwright test test/a11y/axe.next.dark.test.ts --workers=8",
     "test-e2e": "playwright test test/e2e/ --workers=8",
     "test-seo": "playwright test test/e2e/seo.spec.ts --workers=8",
     "test-seo-full": "E2E_SEO_ALL_PAGES=1 playwright test test/e2e/seo.spec.ts --workers=8",

--- a/packages/website/postcss.config.ts
+++ b/packages/website/postcss.config.ts
@@ -1,5 +1,3 @@
-import * as designTokens from '@nl-design-system-community/ma-design-tokens/dist/variables.mjs';
-import removeUnusedDesignTokens from '@nl-design-system-unstable/postcss-remove-unused-design-tokens';
 import postcssGlobalData from '@csstools/postcss-global-data';
 import customMedia from 'postcss-custom-media';
 
@@ -13,5 +11,5 @@ const globalData = !process.env['DOCUSAURUS_CURRENT_LOCALE']
   : null;
 
 export default {
-  plugins: [globalData, removeUnusedDesignTokens({ designTokens }), customMedia()],
+  plugins: [globalData, customMedia()],
 };

--- a/packages/website/src/layouts/document.astro
+++ b/packages/website/src/layouts/document.astro
@@ -51,6 +51,8 @@ import '@nl-design-system-candidate/code-css/code.css';
 import '@nl-design-system-candidate/code-block-css/code-block.css';
 import '@utrecht/component-library-css/dist/html.css';
 
+import '@nl-design-system-community/ma-design-tokens/dist/variables.css';
+import '../styles/color-scheme.css';
 import '../../src/styles/prism-theme.css';
 import '../../src/styles/missing-tokens.css';
 import './document.css';

--- a/packages/website/src/pages/index.css
+++ b/packages/website/src/pages/index.css
@@ -41,15 +41,31 @@
 
   /* Tweak card styling */
   .rhc-card {
-    /* Give hover border to participant logo cards */
+    /*
+     * Give hover border to participant logo cards. Pinned to its light value (not
+     * var(--basis-color-action-1-border-hover)) to match the fixed-light card
+     * background below — the dark-mode value is a light lavender meant to stand
+     * out against a dark card, which is nearly invisible against a light one.
+     */
     &:has(.ma-homepage__participant-link:hover) {
-      --rhc-card-border-color: var(--basis-color-action-1-border-hover);
+      --rhc-card-border-color: #6c337e;
     }
 
     /* Give all cards a background color except the participant logos */
     &:not(:has(.ma-homepage__participant-link)) {
       --rhc-card-background-color: var(--basis-color-action-2-bg-default);
       --rhc-card-border-color: transparent;
+    }
+
+    /*
+     * Participant logos are provided by third parties and assume a light backdrop
+     * (some are raster images with a baked-in white background). Keep their card
+     * light regardless of the site's color scheme so the logos stay legible and
+     * don't show a jarring white box in dark mode.
+     */
+    &:has(.ma-homepage__participant-link) {
+      --rhc-card-background-color: #fcfcfc;
+      --rhc-card-border-color: #c2c4c6;
     }
 
     /* Tweak the spacing between the icons and heading when a card has an icon */

--- a/packages/website/src/seo.config.ts
+++ b/packages/website/src/seo.config.ts
@@ -7,6 +7,6 @@ export const siteDescription =
 export const siteKeywords = ['nl design system', 'design system'];
 
 export const siteThemeColor = '#ffffff';
-export const siteColorScheme = 'light';
+export const siteColorScheme = 'light dark';
 
 export const twitterCard = 'summary_large_image';

--- a/packages/website/src/styles/color-scheme.css
+++ b/packages/website/src/styles/color-scheme.css
@@ -1,0 +1,5 @@
+@import "@nl-design-system-community/ma-design-tokens/dist/color-scheme-dark/variables.css" (prefers-color-scheme: dark);
+
+:root {
+  color-scheme: light dark;
+}

--- a/src/components/Canvas/CanvasAstro.css
+++ b/src/components/Canvas/CanvasAstro.css
@@ -1,3 +1,176 @@
+/*
+ * Dark mode fix: the live preview must always render in the light color scheme,
+ * even when the site itself is in dark mode, because guideline text describes
+ * exact contrast ratios that only hold against a fixed light background.
+ *
+ * `color-scheme: light` alone doesn't achieve this — it only affects native UA
+ * rendering, not the `--basis-*`/`--utrecht-*` design tokens, which get resolved
+ * once in dark mode's `:root` override and inherit down unchanged from there. So
+ * every token used by .utrecht-html content is redeclared below, pinned back to
+ * its light value: first the `--basis-*` primitives, then the `--utrecht-*`
+ * tokens, derived from them using the same formula as ma-design-tokens' theme.css.
+ *
+ * This is a workaround. The real fix belongs upstream in ma-design-tokens: if its
+ * dark values were applied via `light-dark()` keyed off the inherited `color-scheme`
+ * property instead of an unconditional `@media (prefers-color-scheme: dark)` import
+ * at `:root`, `color-scheme: light` here would be enough on its own, and none of
+ * this token list would need to exist.
+ */
+/* stylelint-disable-next-line selector-class-pattern */
+.voorbeeld-theme {
+  --basis-color-action-1-inverse-color-active: #fff;
+  --basis-color-action-1-inverse-color-default: #fff;
+  --basis-color-action-1-inverse-color-hover: #fff;
+  --basis-color-action-2-color-active: #1a4061;
+  --basis-color-action-2-color-default: #255d8d;
+  --basis-color-action-2-color-hover: #1f4e77;
+  --basis-color-default-bg-active: #e5e5e6;
+  --basis-color-default-bg-default: #f0f1f1;
+  --basis-color-default-bg-hover: #eaebec;
+  --basis-color-default-border-active: #3c3e41;
+  --basis-color-default-border-default: #575a5e;
+  --basis-color-default-border-hover: #494b4f;
+  --basis-color-default-color-active: #3c3e41;
+  --basis-color-default-color-default: #575a5e;
+  --basis-color-default-color-document: #1b1c1d;
+  --basis-color-default-color-hover: #494b4f;
+  --basis-color-disabled-bg-default: #f0f1f1;
+  --basis-color-disabled-border-subtle: #c2c4c6;
+  --basis-color-disabled-color-subtle: #616368;
+  --basis-color-highlight-inverse-bg-default: #6a5723;
+  --basis-color-highlight-inverse-color-default: #fff;
+  --basis-focus-inverse-outline-color: #fff;
+  --basis-form-control-accent-color: #803d95;
+  --basis-form-control-active-accent-color: #592a67;
+  --basis-form-control-active-background-color: #e5e5e6;
+  --basis-form-control-active-border-color: #3c3e41;
+  --basis-form-control-background-color: #fcfcfc;
+  --basis-form-control-border-color: #575a5e;
+  --basis-form-control-color: #1b1c1d;
+  --basis-form-control-disabled-background-color: #f0f1f1;
+  --basis-form-control-disabled-border-color: #c2c4c6;
+  --basis-form-control-disabled-color: #616368;
+  --basis-form-control-focus-accent-color: #fcfcfc;
+  --basis-form-control-focus-background-color: #fcfcfc;
+  --basis-form-control-focus-border-color: #3c3e41;
+  --basis-form-control-focus-color: #1b1c1d;
+  --basis-form-control-hover-accent-color: #6c337e;
+  --basis-form-control-hover-background-color: #eaebec;
+  --basis-form-control-hover-border-color: #494b4f;
+  --basis-form-control-hover-color: #1b1c1d;
+  --basis-form-control-invalid-background-color: #faeeef;
+  --basis-form-control-invalid-border-color: #a1313c;
+  --basis-form-control-placeholder-color: #616368;
+  --basis-form-control-read-only-background-color: #f6f6f7;
+  --basis-form-control-read-only-color: #1b1c1d;
+  --basis-heading-color: #1b1c1d;
+  --utrecht-blockquote-content-color: var(--basis-color-default-color-document);
+  --utrecht-button-active-background-color: var(--basis-color-default-bg-active);
+  --utrecht-button-active-border-color: var(--basis-color-default-border-active);
+  --utrecht-button-active-color: var(--basis-color-default-color-active);
+  --utrecht-button-border-color: var(--basis-color-default-border-default);
+  --utrecht-button-color: var(--basis-color-default-color-default);
+  --utrecht-button-disabled-background-color: var(--basis-color-disabled-bg-default);
+  --utrecht-button-disabled-border-color: var(--basis-color-disabled-border-subtle);
+  --utrecht-button-disabled-color: var(--basis-color-disabled-color-subtle);
+  --utrecht-button-hover-background-color: var(--basis-color-default-bg-hover);
+  --utrecht-button-hover-border-color: var(--basis-color-default-border-hover);
+  --utrecht-button-hover-color: var(--basis-color-default-color-hover);
+  --utrecht-button-pressed-background-color: var(--basis-color-default-bg-active);
+  --utrecht-button-pressed-border-color: var(--basis-color-default-border-active);
+  --utrecht-button-pressed-color: var(--basis-color-default-color-active);
+  --utrecht-code-background-color: var(--basis-color-default-bg-default);
+  --utrecht-code-block-background-color: var(--basis-color-default-bg-default);
+  --utrecht-code-block-color: var(--basis-color-default-color-document);
+  --utrecht-code-color: var(--basis-color-default-color-document);
+  --utrecht-figure-caption-color: var(--basis-color-default-color-document);
+  --utrecht-focus-inverse-outline-color: var(--basis-focus-inverse-outline-color);
+  --utrecht-form-fieldset-legend-color: var(--basis-color-default-color-document);
+  --utrecht-form-fieldset-legend-disabled-color: var(--basis-color-disabled-color-subtle);
+  --utrecht-form-label-checkbox-color: var(--basis-color-default-color-document);
+  --utrecht-form-label-color: var(--basis-color-default-color-document);
+  --utrecht-heading-1-color: var(--basis-heading-color);
+  --utrecht-heading-2-color: var(--basis-heading-color);
+  --utrecht-heading-3-color: var(--basis-heading-color);
+  --utrecht-heading-4-color: var(--basis-heading-color);
+  --utrecht-heading-5-color: var(--basis-heading-color);
+  --utrecht-heading-6-color: var(--basis-heading-color);
+  --utrecht-link-active-color: var(--basis-color-action-2-color-active);
+  --utrecht-link-color: var(--basis-color-action-2-color-default);
+  --utrecht-link-hover-color: var(--basis-color-action-2-color-hover);
+  --utrecht-link-visited-color: var(--basis-color-action-2-color-default);
+  --utrecht-mark-background-color: var(--basis-color-highlight-inverse-bg-default);
+  --utrecht-mark-color: var(--basis-color-highlight-inverse-color-default);
+  --utrecht-paragraph-color: var(--basis-color-default-color-document);
+  --utrecht-radio-button-active-background-color: var(--basis-form-control-active-background-color);
+  --utrecht-radio-button-active-border-color: var(--basis-form-control-active-border-color);
+  --utrecht-radio-button-active-color: var(--utrecht-radio-button-active-border-color);
+  --utrecht-radio-button-background-color: var(--basis-form-control-background-color);
+  --utrecht-radio-button-border-color: var(--basis-form-control-border-color);
+  --utrecht-radio-button-checked-active-background-color: var(--basis-form-control-active-accent-color);
+  --utrecht-radio-button-checked-active-color: var(--basis-color-action-1-inverse-color-active);
+  --utrecht-radio-button-checked-background-color: var(--basis-form-control-accent-color);
+  --utrecht-radio-button-checked-color: var(--basis-color-action-1-inverse-color-default);
+  --utrecht-radio-button-checked-focus-background-color: var(--basis-form-control-focus-accent-color);
+  --utrecht-radio-button-checked-focus-border-color: var(--basis-form-control-focus-border-color);
+  --utrecht-radio-button-checked-focus-color: var(--basis-form-control-focus-color);
+  --utrecht-radio-button-checked-hover-background-color: var(--basis-form-control-hover-accent-color);
+  --utrecht-radio-button-checked-hover-color: var(--basis-color-action-1-inverse-color-hover);
+  --utrecht-radio-button-color: var(--utrecht-radio-button-border-color);
+  --utrecht-radio-button-disabled-background-color: var(--basis-form-control-disabled-background-color);
+  --utrecht-radio-button-disabled-border-color: var(--basis-form-control-disabled-border-color);
+  --utrecht-radio-button-disabled-color: var(--utrecht-radio-button-disabled-border-color);
+  --utrecht-radio-button-focus-background-color: var(--basis-form-control-focus-background-color);
+  --utrecht-radio-button-focus-border-color: var(--basis-form-control-focus-border-color);
+  --utrecht-radio-button-focus-color: var(--utrecht-radio-button-focus-border-color);
+  --utrecht-radio-button-hover-background-color: var(--basis-form-control-hover-background-color);
+  --utrecht-radio-button-hover-border-color: var(--basis-form-control-hover-border-color);
+  --utrecht-radio-button-hover-color: var(--utrecht-radio-button-hover-border-color);
+  --utrecht-radio-button-invalid-border-color: var(--basis-form-control-invalid-border-color);
+  --utrecht-radio-button-invalid-color: var(--utrecht-radio-button-invalid-border-color);
+  --utrecht-select-background-color: var(--basis-form-control-background-color);
+  --utrecht-select-color: var(--basis-form-control-color);
+  --utrecht-select-disabled-background-color: var(--basis-form-control-disabled-background-color);
+  --utrecht-select-disabled-color: var(--basis-form-control-disabled-color);
+  --utrecht-select-focus-background-color: var(--basis-form-control-focus-background-color);
+  --utrecht-select-focus-color: var(--basis-form-control-focus-color);
+  --utrecht-select-hover-background-color: var(--basis-form-control-hover-background-color);
+  --utrecht-select-hover-color: var(--basis-form-control-hover-color);
+  --utrecht-select-invalid-background-color: var(--basis-form-control-invalid-background-color);
+  --utrecht-table-caption-color: var(--basis-color-default-color-document);
+  --utrecht-table-header-cell-color: var(--basis-color-default-color-document);
+  --utrecht-table-header-color: var(--basis-color-default-color-document);
+  --utrecht-table-row-alternate-even-color: var(--basis-color-default-color-document);
+  --utrecht-table-row-alternate-odd-color: var(--basis-color-default-color-document);
+  --utrecht-textarea-background-color: var(--basis-form-control-background-color);
+  --utrecht-textarea-color: var(--basis-form-control-color);
+  --utrecht-textarea-disabled-background-color: var(--basis-form-control-disabled-background-color);
+  --utrecht-textarea-disabled-color: var(--basis-form-control-disabled-color);
+  --utrecht-textarea-focus-background-color: var(--basis-form-control-focus-background-color);
+  --utrecht-textarea-focus-color: var(--basis-form-control-focus-color);
+  --utrecht-textarea-invalid-background-color: var(--basis-form-control-invalid-background-color);
+  --utrecht-textarea-invalid-color: var(--basis-form-control-color);
+  --utrecht-textarea-placeholder-color: var(--basis-form-control-placeholder-color);
+  --utrecht-textarea-read-only-background-color: var(--basis-form-control-read-only-background-color);
+  --utrecht-textarea-read-only-color: var(--basis-form-control-read-only-color);
+  --utrecht-textbox-background-color: var(--basis-form-control-background-color);
+  --utrecht-textbox-color: var(--basis-form-control-color);
+  --utrecht-textbox-disabled-background-color: var(--basis-form-control-disabled-background-color);
+  --utrecht-textbox-disabled-color: var(--basis-form-control-disabled-color);
+  --utrecht-textbox-focus-background-color: var(--basis-form-control-focus-background-color);
+  --utrecht-textbox-focus-color: var(--basis-form-control-focus-color);
+  --utrecht-textbox-invalid-background-color: var(--basis-form-control-invalid-background-color);
+  --utrecht-textbox-invalid-color: var(--basis-form-control-color);
+  --utrecht-textbox-placeholder-color: var(--basis-form-control-placeholder-color);
+  --utrecht-textbox-read-only-background-color: var(--basis-form-control-read-only-background-color);
+  --utrecht-textbox-read-only-color: var(--basis-form-control-read-only-color);
+  --utrecht-unordered-list-marker-color: var(--basis-color-default-color-document);
+
+  background-color: #fff;
+  color: #1b1c1d;
+  color-scheme: light;
+}
+
 .ma-canvas-astro__example {
   padding-block-end: var(--basis-space-block-xl);
   padding-block-start: var(--basis-space-block-xl);

--- a/src/components/CardGroup.css
+++ b/src/components/CardGroup.css
@@ -33,13 +33,13 @@
 
 .ma-cardgroup__card {
   align-content: var(--ma-cardgroup-card-align-content, center);
-  background-color: var(--ma-cardgroup-card-background-color, var(--nlds-document-background-color, white));
+  background-color: var(--ma-cardgroup-card-background-color, var(--basis-color-default-bg-default, white));
   border-color: var(--ma-cardgroup-card-border-color, #cfd5dd);
   border-radius: var(--ma-cardgroup-card-border-radius, 8px);
   border-style: var(--ma-cardgroup-card-border-style, solid);
   border-width: var(--ma-cardgroup-card-border-width, 1px);
   box-sizing: border-box;
-  color: var(--ma-cardgroup-card-color, var(--nlds-document-color));
+  color: var(--ma-cardgroup-card-color, var(--basis-color-default-color-document));
   display: flex;
   flex-direction: var(--ma-cardgroup-card-flex-direction, column);
   justify-content: var(--ma-cardgroup-card-justify-content, space-between);

--- a/test/a11y/axe.next.dark.test.ts
+++ b/test/a11y/axe.next.dark.test.ts
@@ -7,15 +7,16 @@ const CONFIG = {
   baseUrl: 'http://localhost:4321',
   sitemapDir: './packages/website/dist',
   sitemap: '/sitemap-index.xml',
-  reportPath: './tmp/axe.next.json',
+  reportPath: './tmp/axe.next.dark.json',
   failOnImpact: ['critical', 'serious', 'moderate'],
 };
 
 const violations: AxeResults[] = [];
 
-test.describe('Accessibility features', () => {
+test.use({ colorScheme: 'dark' });
+
+test.describe('Accessibility features (dark mode)', () => {
   const pathnames = getPathnamesFromSitemap(CONFIG.sitemapDir, CONFIG.sitemap);
-  // .filter((pathname) => !shouldSkipRoute(pathname));
 
   pathnames.forEach((pathname) => {
     test(pathname, async ({ page }) => {

--- a/test/a11y/test-setup.ts
+++ b/test/a11y/test-setup.ts
@@ -1,6 +1,6 @@
 import { AxeBuilder } from '@axe-core/playwright';
 import { writeFile } from 'fs/promises';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import * as cheerio from 'cheerio';
 import { exclusions, exclusionGroups, skippedRoutes, type RouteExclusion } from './a11y-exclusions';
 import type { Page } from '@playwright/test';

--- a/test/a11y/test-setup.ts
+++ b/test/a11y/test-setup.ts
@@ -1,5 +1,7 @@
 import { AxeBuilder } from '@axe-core/playwright';
 import { writeFile } from 'fs/promises';
+import { readFileSync } from 'fs';
+import * as cheerio from 'cheerio';
 import { exclusions, exclusionGroups, skippedRoutes, type RouteExclusion } from './a11y-exclusions';
 import type { Page } from '@playwright/test';
 
@@ -78,6 +80,37 @@ export function getExcludedViolationIds(pathname: string): RegExp[] {
   }
 
   return excluded;
+}
+
+export function getPathnamesFromSitemap(sitemapDir: string, sitemapPath: string): string[] {
+  const paths: string[] = [];
+
+  try {
+    const sitemapIndex = readFileSync(`${sitemapDir}${sitemapPath}`, 'utf8');
+    const $ = cheerio.load(sitemapIndex, { xmlMode: true });
+
+    $('sitemap loc')
+      .map((_, element) => $(element).text())
+      .toArray()
+      .map((url) => new URL(url).pathname)
+      .forEach((path) => {
+        getPathnamesFromSitemap(sitemapDir, path).forEach((p) => paths.push(p));
+      });
+
+    $('url loc')
+      .map((_, element) => $(element).text())
+      .toArray()
+      .map((url) => new URL(url).pathname)
+      .forEach((path) => paths.push(path));
+
+    return Array.from(new Set(paths));
+  } catch (error) {
+    console.warn(
+      `Could not read sitemap at ${sitemapDir}${sitemapPath}, skipping accessibility tests generation.`,
+      error,
+    );
+    return [];
+  }
 }
 
 export function shouldSkipRoute(pathname: string): boolean {


### PR DESCRIPTION
Snelle check gedaan en alleen de cards op de componenten pagina hadden een witte achtergrond. Dit gefixt.

Het nadeel van deze implementatie is dat alle light en dark tokens geïnclude worden en de ongebruikte token worden niet meer uit de light theme verwijderd. Ik heb hier geen manier omheen gevonden.

<img width="333" height="1007" alt="image" src="https://github.com/user-attachments/assets/e9583914-0e5a-4c70-8826-af7e0294bdee" />
